### PR TITLE
Point to next development version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.mixpanel.android
-version = 4.2.1
+version = 4.2.2-SNAPSHOT


### PR DESCRIPTION
It looks like you guys do all your development on `master`. As such, the version there should always be a `SNAPSHOT`. This has the added benefit of making a `./gradlew assemble` command work out-of-the-box since it no longer configures the build for signing.
