### PR TITLE
Hide survey confirmation and allow repeatable surveys with $ignore

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideUpdates.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideUpdates.java
@@ -73,6 +73,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
             return null;
         }
         Survey s = mUnseenSurveys.remove(0);
+
+        // repeatable surveys don't show up unless specifically requested
+        if (s.isRepeatable()) {
+            Survey removedSurvey = s;
+            int newSurveyIndex = -1;
+
+            for (int i = 0; i < mUnseenSurveys.size(); i++) {
+                if (!mUnseenSurveys.get(i).isRepeatable()) {
+                    newSurveyIndex = i;
+                    break;
+                }
+            }
+
+            if (newSurveyIndex != -1) {
+                s = mUnseenSurveys.remove(newSurveyIndex);
+            } else {
+                s = null;
+            }
+
+            mUnseenSurveys.add(mUnseenSurveys.size(), removedSurvey);
+        }
+
         if (replace) {
             mUnseenSurveys.add(mUnseenSurveys.size(), s);
         }
@@ -87,7 +109,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         for (int i = 0; i < mUnseenSurveys.size(); i++) {
             if (mUnseenSurveys.get(i).getId() == id) {
                 survey = mUnseenSurveys.get(i);
-                if (!replace) {
+                if (!replace && !survey.isRepeatable()) {
                     mUnseenSurveys.remove(i);
                 }
                 break;

--- a/src/main/java/com/mixpanel/android/mpmetrics/Survey.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Survey.java
@@ -46,6 +46,7 @@ public class Survey implements Parcelable {
             final JSONArray collectionsJArray = description.getJSONArray("collections");
             final JSONObject collection0 = collectionsJArray.getJSONObject(0);
             mCollectionId = collection0.getInt("id");
+            mSurveyTitle = description.getString("name");
 
             final JSONArray questionsJArray = description.getJSONArray("questions");
             if (questionsJArray.length() == 0) {
@@ -76,6 +77,10 @@ public class Survey implements Parcelable {
 
     public List<Question> getQuestions() {
         return mQuestions;
+    }
+
+    public boolean isRepeatable() {
+        return mSurveyTitle.equals("$ignore");
     }
 
     @Override
@@ -160,6 +165,7 @@ public class Survey implements Parcelable {
         private final List<String> mChoices;
     }
 
+    private final String mSurveyTitle;
     private final JSONObject mDescription;
     private final int mId;
     private final int mCollectionId;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -7,5 +7,9 @@
     <string name="com_mixpanel_android_close">Close</string>
     <string name="com_mixpanel_android_done">Done</string>
     <string name="com_mixpanel_android_notification_image">Image not displayed</string>
+    <string name="com_mixpanel_android_survey_confirmation_title">We\'d love your feedback!</string>
+    <string name="com_mixpanel_android_survey_confirmation_message">Mind taking a quick survey?</string>
+    <string name="com_mixpanel_android_survey_confirmation_confirm">Sure</string>
+    <string name="com_mixpanel_android_survey_confirmation_deny">No, Thanks</string>
     <color name="com_mixpanel_android_selected">#66ffffff</color>
 </resources>


### PR DESCRIPTION
Add ability to disable showing a confirmation dialog ("would you like to take a survey?") before showing a survey. 

Also add a special survey name ($ignore) to allow a survey to be repeated multiple times. This replicates existing functionality in the mixpanel-ios repository.