### PR TITLE
clear distinctId by setting a random number

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -1002,6 +1002,18 @@ public class MixpanelBasicTest extends AndroidTestCase {
         metrics.alias("new id", "old id");
     }
 
+    public void testClearDistinctId() {
+        MixpanelAPI metrics = new TestUtils.CleanMixpanelAPI(getContext(), mMockPreferences, "Logout Test Token");
+
+        metrics.identify("USER_ID");
+        String setId = metrics.getDistinctId();
+        assertEquals("USER_ID", setId);
+
+        metrics.clearDistincId();
+        setId = metrics.getDistinctId();
+        assertNotSame("USER_ID", setId);
+    }
+
     private Future<SharedPreferences> mMockPreferences;
 
     private static final int POLL_WAIT_SECONDS = 5;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -42,6 +42,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -413,6 +414,10 @@ public class MixpanelAPI {
     public String getDistinctId() {
         return mPersistentIdentity.getEventsDistinctId();
      }
+
+    public void clearDistincId() {
+        identify(UUID.randomUUID().toString());
+    }
 
     /**
      * Register properties that will be sent with every subsequent call to {@link #track(String, JSONObject)}.


### PR DESCRIPTION
Encapsulate workaround to clear distinct_id when logging out an user.
