### PR TITLE
New layout test suite

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -27,17 +27,6 @@ import java.util.Map;
 
 
 public class EditProtocolTest extends AndroidTestCase {
-    private static class MockOnLayoutErrorListener implements ViewVisitor.OnLayoutErrorListener {
-        public MockOnLayoutErrorListener() {
-            errorList = new ArrayList<ViewVisitor.LayoutErrorMessage>();
-        }
-
-        public void onLayoutError(ViewVisitor.LayoutErrorMessage e) {
-            errorList.add(e);
-        }
-
-        public List<ViewVisitor.LayoutErrorMessage> errorList;
-    }
 
     @Override
     public void setUp() throws JSONException {
@@ -47,7 +36,7 @@ public class EditProtocolTest extends AndroidTestCase {
         idMap.put("relativelayout_button1", TestView.RELATIVE_LAYOUT_BUTTON1_ID);
         idMap.put("relativelayout_button2", TestView.RELATIVE_LAYOUT_BUTTON2_ID);
 
-        mLayoutErrorListener = new MockOnLayoutErrorListener();
+        mLayoutErrorListener = new TestView.MockOnLayoutErrorListener();
         mResourceIds = new TestUtils.TestResourceIds(idMap);
         mProtocol = new EditProtocol(mResourceIds, new ImageStore(getContext()) {
             @Override
@@ -428,7 +417,7 @@ public class EditProtocolTest extends AndroidTestCase {
     private JSONArray mIdAndNameDontMatch;
     private TestEventListener mListener;
     private TestView mRootView;
-    private MockOnLayoutErrorListener mLayoutErrorListener;
+    private TestView.MockOnLayoutErrorListener mLayoutErrorListener;
 
     private static final byte[] IMAGE_10x10_GREEN_BYTES = Base64.decode("R0lGODlhCgAKALMAAAAAAIAAAACAAICAAAAAgIAAgACAgMDAwICAgP8AAAD/AP//AAAA//8A/wD//////ywAAAAACgAKAAAEClDJSau9OOvNe44AOw==".getBytes(), 0);
     private static final Bitmap IMAGE_10x10_GREEN = BitmapFactory.decodeByteArray(IMAGE_10x10_GREEN_BYTES, 0, IMAGE_10x10_GREEN_BYTES.length);

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -58,10 +58,10 @@ public class EditProtocolTest extends AndroidTestCase {
                 String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditRemoveBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.BELOW, TestView.NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.BELOW, TestView.NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditAbsentAnchor = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test4\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mClickEvent = new JSONObject(
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"event_type\":\"click\",\"event_name\":\"Commencing Count-Down\"}"

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -63,16 +63,16 @@ public class EditProtocolTest extends AndroidTestCase {
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"property\":{\"classname\":\"android.widget.Button\",\"name\":\"text\",\"get\":{\"selector\":\"getText\",\"parameters\":[],\"result\":{\"type\":\"java.lang.CharSequence\"}},\"set\":{\"selector\":\"setText\",\"parameters\":[{\"type\":\"java.lang.CharSequence\"}]}},\"args\":[[\"Ground Control to Major Tom\",\"java.lang.CharSequence\"]],\"change_type\": \"property\"}"
         );
         mLayoutEditAlignParentRight = new JSONObject(
-            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", LAYOUT_ALIGNPARENTRIGHT, PARENT_OF_VIEW, TestView.RELATIVE_LAYOUT_ID)
+            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", TestView.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditRemoveBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.BELOW, TestView.NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditAbsentAnchor = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mClickEvent = new JSONObject(
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"event_type\":\"click\",\"event_name\":\"Commencing Count-Down\"}"
@@ -285,33 +285,33 @@ public class EditProtocolTest extends AndroidTestCase {
     }
 
     public void testLayoutEdit() throws EditProtocol.BadInstructionsException, EditProtocol.CantGetEditAssetsException {
-        // add LAYOUT_ALIGNPARENTRIGHT to mRelativeLayoutButton1, should success
+        // add ALIGN_PARENT_RIGHT to mRelativeLayoutButton1, should success
         final EditProtocol.Edit edit1 = mProtocol.readEdit(mLayoutEditAlignParentRight);
         edit1.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params1 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton1.getLayoutParams();
         int[] rules1 = params1.getRules();
-        assertEquals(rules1[LAYOUT_ALIGNPARENTRIGHT], PARENT_OF_VIEW);
+        assertEquals(rules1[TestView.ALIGN_PARENT_RIGHT], RelativeLayout.TRUE);
 
-        // add "LAYOUT_BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
+        // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
         final EditProtocol.Edit edit2 = mProtocol.readEdit(mLayoutEditBelow);
         edit2.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params2 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rules2 = params2.getRules();
-        assertEquals(rules2[LAYOUT_BELOW], TestView.RELATIVE_LAYOUT_BUTTON1_ID);
+        assertEquals(rules2[TestView.BELOW], TestView.RELATIVE_LAYOUT_BUTTON1_ID);
 
-        // remove "LAYOUT_BELOW mRelativeLayoutButton1" from mRelativeLayoutButton2, should success
+        // remove "BELOW mRelativeLayoutButton1" from mRelativeLayoutButton2, should success
         final EditProtocol.Edit edit3 = mProtocol.readEdit(mLayoutEditRemoveBelow);
         edit3.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params3 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rule3 = params3.getRules();
-        assertEquals(rule3[LAYOUT_BELOW], NO_ANCHOR);
+        assertEquals(rule3[TestView.BELOW], TestView.NO_ANCHOR);
 
-        // add "LAYOUT_BELOW relativelayout_button3 (absent)" to mRelativeLayoutButton2, should fail
+        // add "BELOW mRelativeLayoutButton3 (absent)" to mRelativeLayoutButton2, should fail
         final EditProtocol.Edit edit4 = mProtocol.readEdit(mLayoutEditAbsentAnchor);
         edit4.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params4 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rules4 = params4.getRules();
-        assertEquals(rules4[LAYOUT_BELOW], NO_ANCHOR);
+        assertEquals(rules4[TestView.BELOW], TestView.NO_ANCHOR);
     }
 
     public void testClickEvent() throws EditProtocol.BadInstructionsException {
@@ -432,9 +432,4 @@ public class EditProtocolTest extends AndroidTestCase {
 
     private static final byte[] IMAGE_10x10_GREEN_BYTES = Base64.decode("R0lGODlhCgAKALMAAAAAAIAAAACAAICAAAAAgIAAgACAgMDAwICAgP8AAAD/AP//AAAA//8A/wD//////ywAAAAACgAKAAAEClDJSau9OOvNe44AOw==".getBytes(), 0);
     private static final Bitmap IMAGE_10x10_GREEN = BitmapFactory.decodeByteArray(IMAGE_10x10_GREEN_BYTES, 0, IMAGE_10x10_GREEN_BYTES.length);
-
-    private static final int LAYOUT_ALIGNPARENTRIGHT = 11;
-    private static final int LAYOUT_BELOW = 3;
-    private static final int PARENT_OF_VIEW = -1;
-    private static final int NO_ANCHOR = 0;
 }

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -52,16 +52,16 @@ public class EditProtocolTest extends AndroidTestCase {
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"property\":{\"classname\":\"android.widget.Button\",\"name\":\"text\",\"get\":{\"selector\":\"getText\",\"parameters\":[],\"result\":{\"type\":\"java.lang.CharSequence\"}},\"set\":{\"selector\":\"setText\",\"parameters\":[{\"type\":\"java.lang.CharSequence\"}]}},\"args\":[[\"Ground Control to Major Tom\",\"java.lang.CharSequence\"]],\"change_type\": \"property\"}"
         );
         mLayoutEditAlignParentRight = new JSONObject(
-            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", TestView.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE, TestView.RELATIVE_LAYOUT_ID)
+            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", RelativeLayout.ALIGN_PARENT_RIGHT, RelativeLayout.TRUE, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditRemoveBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.BELOW, TestView.NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", RelativeLayout.BELOW, TestView.NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
         );
         mLayoutEditAbsentAnchor = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test4\"}", TestView.BELOW, TestView.RELATIVE_LAYOUT_ID)
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test4\"}", RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_ID)
         );
         mClickEvent = new JSONObject(
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"event_type\":\"click\",\"event_name\":\"Commencing Count-Down\"}"
@@ -279,28 +279,28 @@ public class EditProtocolTest extends AndroidTestCase {
         edit1.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params1 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton1.getLayoutParams();
         int[] rules1 = params1.getRules();
-        assertEquals(rules1[TestView.ALIGN_PARENT_RIGHT], RelativeLayout.TRUE);
+        assertEquals(RelativeLayout.TRUE, rules1[RelativeLayout.ALIGN_PARENT_RIGHT]);
 
         // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
         final EditProtocol.Edit edit2 = mProtocol.readEdit(mLayoutEditBelow);
         edit2.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params2 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rules2 = params2.getRules();
-        assertEquals(rules2[TestView.BELOW], TestView.RELATIVE_LAYOUT_BUTTON1_ID);
+        assertEquals(TestView.RELATIVE_LAYOUT_BUTTON1_ID, rules2[RelativeLayout.BELOW]);
 
         // remove "BELOW mRelativeLayoutButton1" from mRelativeLayoutButton2, should success
         final EditProtocol.Edit edit3 = mProtocol.readEdit(mLayoutEditRemoveBelow);
         edit3.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params3 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rule3 = params3.getRules();
-        assertEquals(rule3[TestView.BELOW], TestView.NO_ANCHOR);
+        assertEquals(TestView.NO_ANCHOR, rule3[RelativeLayout.BELOW]);
 
         // add "BELOW mRelativeLayoutButton3 (absent)" to mRelativeLayoutButton2, should fail
         final EditProtocol.Edit edit4 = mProtocol.readEdit(mLayoutEditAbsentAnchor);
         edit4.visitor.visit(mRootView);
         RelativeLayout.LayoutParams params4 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
         int[] rules4 = params4.getRules();
-        assertEquals(rules4[TestView.BELOW], TestView.NO_ANCHOR);
+        assertEquals( TestView.NO_ANCHOR, rules4[RelativeLayout.BELOW]);
     }
 
     public void testClickEvent() throws EditProtocol.BadInstructionsException {

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -66,6 +66,8 @@ public class EditProtocolTest extends AndroidTestCase {
                 String.format("{\"args\":[{\"verb\":3,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", TestView.RELATIVE_LAYOUT_ID));
         mLayoutEditAbove = new JSONObject(
                 String.format("{\"args\":[{\"verb\":2,\"anchor_id_name\":\"relativelayout_button2\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.RELATIVE_LAYOUT_ID));
+        mLayoutEditAbsentAnchor = new JSONObject(
+                String.format("{\"args\":[{\"verb\":3,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", TestView.RELATIVE_LAYOUT_ID));
         mClickEvent = new JSONObject(
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"event_type\":\"click\",\"event_name\":\"Commencing Count-Down\"}"
         );
@@ -303,6 +305,15 @@ public class EditProtocolTest extends AndroidTestCase {
         ViewVisitor.LayoutErrorMessage e = mLayoutErrorListener.errorList.get(0);
         assertEquals(e.getErrorType(), "circular_dependency");
         assertEquals(e.getName(), "test3");
+        mLayoutErrorListener.errorList.clear();
+
+        // add absent anchor view to mRelativeLayoutButton2, should fail
+        final EditProtocol.Edit edit5 = mProtocol.readEdit(mLayoutEditAbsentAnchor);
+        edit5.visitor.visit(mRootView);
+        RelativeLayout.LayoutParams params5 = (RelativeLayout.LayoutParams)mRootView.mRelativeLayoutButton2.getLayoutParams();
+        int[] rules5 = params5.getRules();
+        assertEquals(rules5[3], TestView.RELATIVE_LAYOUT_BUTTON1_ID);
+        assertEquals(mLayoutErrorListener.errorList.size(), 0);
     }
 
     public void testClickEvent() throws EditProtocol.BadInstructionsException {
@@ -402,6 +413,7 @@ public class EditProtocolTest extends AndroidTestCase {
     private JSONObject mLayoutEditAlignParentRight;
     private JSONObject mLayoutEditBelow;
     private JSONObject mLayoutEditAbove;
+    private JSONObject mLayoutEditAbsentAnchor;
     private JSONObject mClickEvent;
     private JSONObject mAppearsEvent;
     private JSONObject mTextEdit;

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/EditProtocolTest.java
@@ -63,13 +63,17 @@ public class EditProtocolTest extends AndroidTestCase {
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"property\":{\"classname\":\"android.widget.Button\",\"name\":\"text\",\"get\":{\"selector\":\"getText\",\"parameters\":[],\"result\":{\"type\":\"java.lang.CharSequence\"}},\"set\":{\"selector\":\"setText\",\"parameters\":[{\"type\":\"java.lang.CharSequence\"}]}},\"args\":[[\"Ground Control to Major Tom\",\"java.lang.CharSequence\"]],\"change_type\": \"property\"}"
         );
         mLayoutEditAlignParentRight = new JSONObject(
-            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", LAYOUT_ALIGNPARENTRIGHT, PARENT_OF_VIEW, TestView.RELATIVE_LAYOUT_ID));
+            String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button1\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test1\"}", LAYOUT_ALIGNPARENTRIGHT, PARENT_OF_VIEW, TestView.RELATIVE_LAYOUT_ID)
+        );
         mLayoutEditBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID));
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button1\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID)
+        );
         mLayoutEditRemoveBelow = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID));
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"%d\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test2\"}", LAYOUT_BELOW, NO_ANCHOR, TestView.RELATIVE_LAYOUT_ID)
+        );
         mLayoutEditAbsentAnchor = new JSONObject(
-                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID));
+                String.format("{\"args\":[{\"verb\":%d,\"anchor_id_name\":\"relativelayout_button3\",\"view_id_name\":\"relativelayout_button2\"}],\"path\": [{\"prefix\": \"shortest\", \"index\": 0, \"id\": %d }],\"change_type\": \"layout\", \"name\": \"test3\"}", LAYOUT_BELOW, TestView.RELATIVE_LAYOUT_ID)
+        );
         mClickEvent = new JSONObject(
             "{\"path\":[{\"view_class\":\"com.mixpanel.android.viewcrawler.TestView\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.LinearLayout\",\"index\":0},{\"view_class\":\"android.widget.Button\",\"index\":1}],\"event_type\":\"click\",\"event_name\":\"Commencing Count-Down\"}"
         );

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
@@ -242,28 +242,5 @@ public class TestView extends FrameLayout {
     public static final String BUTTON_1_CONTENT_DESCRIPTION = "Ad Hoc Button Number 1";
     public static final String BUTTON_3_CONTENT_DESCRIPTION = "Ad Hoc Button Number 3";
 
-    public static final int LEFT_OF = 0;
-    public static final int RIGHT_OF = 1;
-    public static final int ABOVE = 2;
-    public static final int BELOW = 3;
-    public static final int ALIGN_BASELINE = 4;
-    public static final int ALIGN_LEFT = 5;
-    public static final int ALIGN_TOP = 6;
-    public static final int ALIGN_RIGHT = 7;
-    public static final int ALIGN_BOTTOM = 8;
-    public static final int ALIGN_PARENT_LEFT = 9;
-    public static final int ALIGN_PARENT_TOP = 10;
-    public static final int ALIGN_PARENT_RIGHT = 11;
-    public static final int ALIGN_PARENT_BOTTOM = 12;
-    public static final int CENTER_IN_PARENT = 13;
-    public static final int CENTER_HORIZONTAL = 14;
-    public static final int CENTER_VERTICAL = 15;
-    public static final int START_OF = 16;
-    public static final int END_OF = 17;
-    public static final int ALIGN_START = 18;
-    public static final int ALIGN_END = 19;
-    public static final int ALIGN_PARENT_START = 20;
-    public static final int ALIGN_PARENT_END = 21;
-
     public static final int NO_ANCHOR = 0;
 }

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
@@ -227,4 +227,29 @@ public class TestView extends FrameLayout {
     public static final String TEXT_2_CONTENT_DESCRIPTION = "The Second Test Text View";
     public static final String BUTTON_1_CONTENT_DESCRIPTION = "Ad Hoc Button Number 1";
     public static final String BUTTON_3_CONTENT_DESCRIPTION = "Ad Hoc Button Number 3";
+
+    public static final int LEFT_OF = 0;
+    public static final int RIGHT_OF = 1;
+    public static final int ABOVE = 2;
+    public static final int BELOW = 3;
+    public static final int ALIGN_BASELINE = 4;
+    public static final int ALIGN_LEFT = 5;
+    public static final int ALIGN_TOP = 6;
+    public static final int ALIGN_RIGHT = 7;
+    public static final int ALIGN_BOTTOM = 8;
+    public static final int ALIGN_PARENT_LEFT = 9;
+    public static final int ALIGN_PARENT_TOP = 10;
+    public static final int ALIGN_PARENT_RIGHT = 11;
+    public static final int ALIGN_PARENT_BOTTOM = 12;
+    public static final int CENTER_IN_PARENT = 13;
+    public static final int CENTER_HORIZONTAL = 14;
+    public static final int CENTER_VERTICAL = 15;
+    public static final int START_OF = 16;
+    public static final int END_OF = 17;
+    public static final int ALIGN_START = 18;
+    public static final int ALIGN_END = 19;
+    public static final int ALIGN_PARENT_START = 20;
+    public static final int ALIGN_PARENT_END = 21;
+
+    public static final int NO_ANCHOR = 0;
 }

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/TestView.java
@@ -10,8 +10,10 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -193,6 +195,18 @@ public class TestView extends FrameLayout {
         public boolean includeForAccessibility() {
             return true;
         }
+    }
+
+    public static class MockOnLayoutErrorListener implements ViewVisitor.OnLayoutErrorListener {
+        public MockOnLayoutErrorListener() {
+            errorList = new ArrayList<ViewVisitor.LayoutErrorMessage>();
+        }
+
+        public void onLayoutError(ViewVisitor.LayoutErrorMessage e) {
+            errorList.add(e);
+        }
+
+        public List<ViewVisitor.LayoutErrorMessage> errorList;
     }
 
     public final Set<View> mAllViews;

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Set;
 
 public class ViewVisitorTest extends AndroidTestCase {
-
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
@@ -454,13 +454,13 @@ public class ViewVisitorTest extends AndroidTestCase {
     public void testLayoutBasicInteraction() {
         ArrayList<ViewVisitor.LayoutRule> params = new ArrayList<ViewVisitor.LayoutRule>();
         // add LAYOUT_ALIGNPARENTTOP
-        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
+        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
         // add "LAYOUT_BELOW mRelativeLayoutButton2" to mRelativeLayoutButton1
-        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.BELOW, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
+        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
         // add LAYOUT_ALIGNPARENTBOTTOM to mRelativeLayoutButton1
-        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
+        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
         // remove LAYOUT_ALIGNPARENTBOTTOM from mRelativeLayoutButton1
-        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_BOTTOM, TestView.NO_ANCHOR));
+        params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_BOTTOM, TestView.NO_ANCHOR));
 
         final ViewVisitor layoutVisitor =
                 new ViewVisitor.LayoutUpdateVisitor(mRelativeLayoutPath, params, "test", mLayoutErrorListener);
@@ -469,9 +469,9 @@ public class ViewVisitorTest extends AndroidTestCase {
         RelativeLayout.LayoutParams layoutParams =
                 (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton1.getLayoutParams();
         int[] rules = layoutParams.getRules();
-        assertEquals(RelativeLayout.TRUE, rules[TestView.ALIGN_PARENT_TOP]);
-        assertEquals(TestView.RELATIVE_LAYOUT_BUTTON2_ID, rules[TestView.BELOW]);
-        assertEquals(TestView.NO_ANCHOR, rules[TestView.ALIGN_PARENT_BOTTOM]);
+        assertEquals(RelativeLayout.TRUE, rules[RelativeLayout.ALIGN_PARENT_TOP]);
+        assertEquals(TestView.RELATIVE_LAYOUT_BUTTON2_ID, rules[RelativeLayout.BELOW]);
+        assertEquals(TestView.NO_ANCHOR, rules[RelativeLayout.ALIGN_PARENT_BOTTOM]);
 
         assertEquals(true, mLayoutErrorListener.errorList.isEmpty());
     }
@@ -480,13 +480,13 @@ public class ViewVisitorTest extends AndroidTestCase {
         {   // vertical layout circle
             ArrayList<ViewVisitor.LayoutRule> params = new ArrayList<ViewVisitor.LayoutRule>();
             // add ALIGN_PARENT_TOP
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
             // add "BELOW mRelativeLayoutButton2" to mRelativeLayoutButton1, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.BELOW, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
             // add "ALIGN_LEFT mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.ALIGN_LEFT, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ALIGN_LEFT, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
             // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should fail
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.ABOVE, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ABOVE, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
 
             final ViewVisitor layoutVisitor =
                     new ViewVisitor.LayoutUpdateVisitor(mRelativeLayoutPath, params, "test1", mLayoutErrorListener);
@@ -495,14 +495,14 @@ public class ViewVisitorTest extends AndroidTestCase {
             RelativeLayout.LayoutParams layoutParamsButton1 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton1.getLayoutParams();
             int[] rulesButton1 = layoutParamsButton1.getRules();
-            assertEquals(TestView.NO_ANCHOR, rulesButton1[TestView.ALIGN_PARENT_TOP]);
-            assertEquals(TestView.NO_ANCHOR, rulesButton1[TestView.BELOW]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton1[RelativeLayout.ALIGN_PARENT_TOP]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton1[RelativeLayout.BELOW]);
 
             RelativeLayout.LayoutParams layoutParamsButton2 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton2.getLayoutParams();
             int[] rulesButton2 = layoutParamsButton2.getRules();
-            assertEquals(TestView.NO_ANCHOR, rulesButton2[TestView.ALIGN_LEFT]);
-            assertEquals(TestView.NO_ANCHOR, rulesButton2[TestView.ABOVE]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton2[RelativeLayout.ALIGN_LEFT]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton2[RelativeLayout.ABOVE]);
 
             ViewVisitor.LayoutErrorMessage e = mLayoutErrorListener.errorList.get(0);
             assertEquals("circular_dependency", e.getErrorType());
@@ -513,13 +513,13 @@ public class ViewVisitorTest extends AndroidTestCase {
         {   // horizontal layout circle
             ArrayList<ViewVisitor.LayoutRule> params = new ArrayList<ViewVisitor.LayoutRule>();
             // add ALIGN_PARENT_BOTTOM to mRelativeLayoutButton1, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
             // add "LEFT_OF mRelativeLayoutButton2" to mRelativeLayoutButton1, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.LEFT_OF, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.LEFT_OF, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
             // add "ALIGN_BOTTOM mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.ALIGN_BOTTOM, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ALIGN_BOTTOM, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
             // add "ALIGN_RIGHT mRelativeLayoutButton1" to mRelativeLayoutButton2, should fail
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.ALIGN_RIGHT, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ALIGN_RIGHT, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
 
             final ViewVisitor layoutVisitor =
                     new ViewVisitor.LayoutUpdateVisitor(mRelativeLayoutPath, params, "test2", mLayoutErrorListener);
@@ -528,14 +528,14 @@ public class ViewVisitorTest extends AndroidTestCase {
             RelativeLayout.LayoutParams layoutParamsButton1 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton1.getLayoutParams();
             int[] rulesButton1 = layoutParamsButton1.getRules();
-            assertEquals(TestView.NO_ANCHOR, rulesButton1[TestView.ALIGN_PARENT_BOTTOM]);
-            assertEquals(TestView.NO_ANCHOR, rulesButton1[TestView.LEFT_OF]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton1[RelativeLayout.ALIGN_PARENT_BOTTOM]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton1[RelativeLayout.LEFT_OF]);
 
             RelativeLayout.LayoutParams layoutParamsButton2 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton2.getLayoutParams();
             int[] rulesButton2 = layoutParamsButton2.getRules();
-            assertEquals(TestView.NO_ANCHOR, rulesButton2[TestView.ALIGN_BOTTOM]);
-            assertEquals(TestView.NO_ANCHOR, rulesButton2[TestView.ALIGN_RIGHT]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton2[RelativeLayout.ALIGN_BOTTOM]);
+            assertEquals(TestView.NO_ANCHOR, rulesButton2[RelativeLayout.ALIGN_RIGHT]);
 
             ViewVisitor.LayoutErrorMessage e = mLayoutErrorListener.errorList.get(0);
             assertEquals("circular_dependency", e.getErrorType());
@@ -546,13 +546,13 @@ public class ViewVisitorTest extends AndroidTestCase {
         {   // mix of vertical and horizontal layouts, no circle
             ArrayList<ViewVisitor.LayoutRule> params = new ArrayList<ViewVisitor.LayoutRule>();
             // add ALIGN_PARENT_BOTTOM to mRelativeLayoutButton1, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE));
             // add "LEFT_OF mRelativeLayoutButton2" to mRelativeLayoutButton1, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, TestView.LEFT_OF, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.LEFT_OF, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
             // add "ALIGN_LEFT mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
             // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should fail
-            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, TestView.BELOW, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
+            params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
 
             final ViewVisitor layoutVisitor =
                     new ViewVisitor.LayoutUpdateVisitor(mRelativeLayoutPath, params, "test3", mLayoutErrorListener);
@@ -561,14 +561,14 @@ public class ViewVisitorTest extends AndroidTestCase {
             RelativeLayout.LayoutParams layoutParamsButton1 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton1.getLayoutParams();
             int[] rulesButton1 = layoutParamsButton1.getRules();
-            assertEquals(RelativeLayout.TRUE, rulesButton1[TestView.ALIGN_PARENT_BOTTOM]);
-            assertEquals(TestView.RELATIVE_LAYOUT_BUTTON2_ID, rulesButton1[TestView.LEFT_OF]);
+            assertEquals(RelativeLayout.TRUE, rulesButton1[RelativeLayout.ALIGN_PARENT_BOTTOM]);
+            assertEquals(TestView.RELATIVE_LAYOUT_BUTTON2_ID, rulesButton1[RelativeLayout.LEFT_OF]);
 
             RelativeLayout.LayoutParams layoutParamsButton2 =
                     (RelativeLayout.LayoutParams) mRootView.mRelativeLayoutButton2.getLayoutParams();
             int[] rulesButton2 = layoutParamsButton2.getRules();
-            assertEquals(RelativeLayout.TRUE, rulesButton2[TestView.ALIGN_PARENT_TOP]);
-            assertEquals(TestView.RELATIVE_LAYOUT_BUTTON1_ID, rulesButton2[TestView.BELOW]);
+            assertEquals(RelativeLayout.TRUE, rulesButton2[RelativeLayout.ALIGN_PARENT_TOP]);
+            assertEquals(TestView.RELATIVE_LAYOUT_BUTTON1_ID, rulesButton2[RelativeLayout.BELOW]);
 
             assertEquals(true, mLayoutErrorListener.errorList.isEmpty());
         }

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
@@ -18,17 +18,6 @@ import java.util.List;
 import java.util.Set;
 
 public class ViewVisitorTest extends AndroidTestCase {
-    private static class MockOnLayoutErrorListener implements ViewVisitor.OnLayoutErrorListener {
-        public MockOnLayoutErrorListener() {
-            errorList = new ArrayList<ViewVisitor.LayoutErrorMessage>();
-        }
-
-        public void onLayoutError(ViewVisitor.LayoutErrorMessage e) {
-            errorList.add(e);
-        }
-
-        public List<ViewVisitor.LayoutErrorMessage> errorList;
-    }
 
     public void setUp() throws Exception {
         super.setUp();
@@ -134,7 +123,7 @@ public class ViewVisitorTest extends AndroidTestCase {
 
         mTrackListener = new CollectingEventListener();
 
-        mLayoutErrorListener = new MockOnLayoutErrorListener();
+        mLayoutErrorListener = new TestView.MockOnLayoutErrorListener();
     }
 
     public void testPath() {
@@ -647,6 +636,6 @@ public class ViewVisitorTest extends AndroidTestCase {
     private List<Pathfinder.PathElement> mThirdLayerViewTag;
     private List<Pathfinder.PathElement> mThirdLayerWildcard;
     private CollectingEventListener mTrackListener;
-    private MockOnLayoutErrorListener mLayoutErrorListener;
+    private TestView.MockOnLayoutErrorListener mLayoutErrorListener;
     private TestView mRootView;
 }

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
@@ -585,12 +585,6 @@ public class ViewVisitorTest extends AndroidTestCase {
         }
     }
 
-    public void testAddAnchorLayout() {
-        // add LAYOUT_BELOW to mRelativeLayoutButton1, should success
-        ArrayList<ViewVisitor.LayoutRule> params = new ArrayList<ViewVisitor.LayoutRule>();
-
-    }
-
     private static class CollectorEditor extends ViewVisitor {
         public CollectorEditor(List<Pathfinder.PathElement> path) {
             super(path);

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ViewVisitorTest.java
@@ -550,7 +550,7 @@ public class ViewVisitorTest extends AndroidTestCase {
             params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON1_ID, RelativeLayout.LEFT_OF, TestView.RELATIVE_LAYOUT_BUTTON2_ID));
             // add "ALIGN_LEFT mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
             params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.ALIGN_PARENT_TOP, RelativeLayout.TRUE));
-            // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should fail
+            // add "BELOW mRelativeLayoutButton1" to mRelativeLayoutButton2, should success
             params.add(new ViewVisitor.LayoutRule(TestView.RELATIVE_LAYOUT_BUTTON2_ID, RelativeLayout.BELOW, TestView.RELATIVE_LAYOUT_BUTTON1_ID));
 
             final ViewVisitor layoutVisitor =


### PR DESCRIPTION
OMG.. Finally get a chance to take a step back and re-do the layout test. Feel much better with it now!!

1. `testLayoutEdit` in `EditProtocolTest` now only takes care of layout protocol - `"-1"` for adding parent layout, `"0"` for removing a layout, other id name for adding anchor layout, ignoring non-existing view
2. `TestView` has 2 tests now - one for testing the basic operations, the other for testing circular dependency detection