### PR TITLE
Consider UX when applying Experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This method was deprecated in version 4.0, and now is a no-op. To change the flu
 interval for your application, use the com.mixpanel.android.MPConfig.FlushInterval
 meta-data tag in your manifest. To get available surveys, call getSurveyIfAvailable()
 
-* The minimum Android OS version necessary for surveys, in app notifications, and dynamic event binding
+* The minimum Android OS version necessary for surveys, in-app notifications, and dynamic event binding
   has been increased to JellyBean/API 16. The minimum OS version to use basic tracking features
   has been increased to Gingerbread/API 9.
 
@@ -174,10 +174,10 @@ meta-data tag in your manifest. To get available surveys, call getSurveyIfAvaila
 
 #### v4.1.0
 
-This version adds support for Android in app notifications.
+This version adds support for Android in-app notifications.
 
 * There is now an additional theme parameter on the SurveyActivity declaration in AndroidManifest.xml
-  that is used for full screen in app notifications.
+  that is used for full screen in-app notifications.
 
   ```
   <activity android:name="com.mixpanel.android.surveys.SurveyActivity"
@@ -185,33 +185,33 @@ This version adds support for Android in app notifications.
   ```
 
 * A new unified set of functions have been created to make it easier to fetch and display surveys
-  and in app notifications.
+  and in-app notifications.
 
   * `getSurveyIfAvailable()` and `getNotificationIfAvailable()` have been added to fetch Survey and
     InAppNotification objects when the library has successfully received them. You may use these objects
-    to display your own custom surveys or in app notifications.
+    to display your own custom surveys or in-app notifications.
 
   * `showSurveyIfAvailable()` and `showNotificationIfAvailable()` have been added to display surveys and
     notifications when the library has successfully received them.
 
   * `addOnMixpanelUpdatesReceivedListener()` and `removeOnMixpanelUpdatesReceivedListener()` have been added
-    so you may be notified when the library has successfully received a survey or in app notification in the
+    so you may be notified when the library has successfully received a survey or in-app notification in the
     background.
 
   * `showSurvey()` and `checkForSurvey()` functions have been deprecated.
 
 * `com.mixpanel.android.MPConfig.AutoCheckForSurveys` has been deprecated. The option has been renamed
-  to `com.mixpanel.android.MPConfig.AutoShowMixpanelUpdates`. It is also now used for both surveys and in app
+  to `com.mixpanel.android.MPConfig.AutoShowMixpanelUpdates`. It is also now used for both surveys and in-app
   notifications.
 
 * `com.mixpanel.android.MPConfig.TestMode` has been added. This option, when set to true, will render
-  your in app notifications and surveys but not track that they have been displayed. If you have multiple
+  your in-app notifications and surveys but not track that they have been displayed. If you have multiple
   notifications/surveys, calls the respective show/get methods will simply rotate through them.
 
 * `MixpanelAPI.logPosts()` has been deprecated. Set the `com.mixpanel.android.MPConfig.EnableDebugLogging`
   flag to true to now get extensive debugging output.
 
-* The minimum Android version necessary for surveys and in app notifications has been increased to 14,
+* The minimum Android version necessary for surveys and in-app notifications has been increased to 14,
   Ice Cream Sandwich to improve stability.
 
 * `MixpanelAPI.alias()` has been added.
@@ -224,7 +224,7 @@ This version adds support for Android in app notifications.
   ```
   <application>
           <!-- This activity allows your application to show Mixpanel
-               surveys and takeover in app notifications. -->
+               surveys and takeover in-app notifications. -->
           <activity android:name="com.mixpanel.android.surveys.SurveyActivity"
                     android:theme="@style/com_mixpanel_android_SurveyActivityTheme" />
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
             android:value="false" />
         -->
 
-        <!-- Set this option to true if you wish for in app notifications and surveys to be displayed without
+        <!-- Set this option to true if you wish for in-app notifications and surveys to be displayed without
              being tracked by Mixpanel. This is useful for testing the integration with your Android app.
              The default value is false. -->
         <!--
@@ -77,15 +77,15 @@
         -->
 
         <!-- Set the following option to true if you wish to see the debug output from the Mixpanel Android
-             library. This may be useful in determining when track calls go out or in app notifications or
+             library. This may be useful in determining when track calls go out or in-app notifications or
              surveys are fetched. The default value is false. -->
         <!--
         <meta-data android:name="com.mixpanel.android.MPConfig.EnableDebugLogging"
             android:value="true" />
         -->
 
-        <!-- This activity allows your application to show Mixpanel surveys and takeover in app notifications.
-             If you only wish to show mini in app notifications, you do not need to declare this Activity.
+        <!-- This activity allows your application to show Mixpanel surveys and takeover in-app notifications.
+             If you only wish to show mini in-app notifications, you do not need to declare this Activity.
              You may also specify a different theme to better fit the look and feel of your application. -->
         <!--
         <activity android:name="com.mixpanel.android.surveys.SurveyActivity"

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -263,7 +263,7 @@ import java.util.Map;
                         }
                     }
                     else if (msg.what == INSTALL_DECIDE_CHECK) {
-                        logAboutMessageToMixpanel("Installing a check for surveys and in app notifications");
+                        logAboutMessageToMixpanel("Installing a check for surveys and in-app notifications");
                         final DecideMessages check = (DecideMessages) msg.obj;
                         mDecideChecker.addDecideCheck(check);
                         if (SystemClock.elapsedRealtime() >= mRetryAfter) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -48,7 +48,6 @@ import java.util.Set;
     public synchronized void reportResults(List<Survey> newSurveys, List<InAppNotification> newNotifications, JSONArray eventBindings, JSONArray variants) {
         boolean newContent = false;
         mUpdatesFromMixpanel.setEventBindings(eventBindings);
-        mUpdatesFromMixpanel.setVariants(variants);
 
         for (final Survey s : newSurveys) {
             final int id = s.getId();
@@ -67,6 +66,8 @@ import java.util.Set;
                 newContent = true;
             }
         }
+
+        mVariants = variants;
 
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +
@@ -104,6 +105,10 @@ import java.util.Set;
         return survey;
     }
 
+    public synchronized JSONArray getVariants() {
+        return mVariants;
+    }
+
     public synchronized InAppNotification getNotification(boolean replace) {
         if (mUnseenNotifications.isEmpty()) {
             if (MPConfig.DEBUG) {
@@ -137,7 +142,7 @@ import java.util.Set;
     }
 
     public synchronized boolean hasUpdatesAvailable() {
-        return (! mUnseenNotifications.isEmpty()) || (! mUnseenSurveys.isEmpty());
+        return (! mUnseenNotifications.isEmpty()) || (! mUnseenSurveys.isEmpty()) || mVariants != null;
     }
 
     // Mutable, must be synchronized
@@ -150,6 +155,7 @@ import java.util.Set;
     private final List<InAppNotification> mUnseenNotifications;
     private final OnNewResultsListener mListener;
     private final UpdatesFromMixpanel mUpdatesFromMixpanel;
+    private JSONArray mVariants;
 
     @SuppressWarnings("unused")
     private static final String LOGTAG = "MixpanelAPI.DecideUpdts";

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -953,9 +953,9 @@ public class MixpanelAPI {
          * <p>The survey activity will use the root of the given view to take a screenshot
          * for its background.
          *
-         * <p>It is safe to call this method any time you want to potentially display an in app notification.
-         * This method will be a no-op if there is already a survey or in app notification being displayed.
-         * Thus, if you have both surveys and in app notification campaigns built in Mixpanel, you may call
+         * <p>It is safe to call this method any time you want to potentially display an in-app notification.
+         * This method will be a no-op if there is already a survey or in-app notification being displayed.
+         * Thus, if you have both surveys and in-app notification campaigns built in Mixpanel, you may call
          * both this and {@link People#showNotificationIfAvailable(Activity)} right after each other, and
          * only one of them will be displayed.
          *
@@ -968,16 +968,16 @@ public class MixpanelAPI {
         public void showSurveyIfAvailable(Activity parent);
 
         /**
-         * Shows an in app notification to the user if one is available. If the notification
+         * Shows an in-app notification to the user if one is available. If the notification
          * is a mini notification, this method will attach and remove a Fragment to parent.
          * The lifecycle of the Fragment will be handled entirely by the Mixpanel library.
          *
          * <p>If the notification is a takeover notification, a SurveyActivity will be launched to
          * display the Takeover notification.
          *
-         * <p>It is safe to call this method any time you want to potentially display an in app notification.
-         * This method will be a no-op if there is already a survey or in app notification being displayed.
-         * Thus, if you have both surveys and in app notification campaigns built in Mixpanel, you may call
+         * <p>It is safe to call this method any time you want to potentially display an in-app notification.
+         * This method will be a no-op if there is already a survey or in-app notification being displayed.
+         * Thus, if you have both surveys and in-app notification campaigns built in Mixpanel, you may call
          * both this and {@link People#showSurveyIfAvailable(Activity)} right after each other, and
          * only one of them will be displayed.
          *
@@ -1007,7 +1007,7 @@ public class MixpanelAPI {
         public void joinExperimentIfAvailable();
 
         /**
-         * Shows the given in app notification to the user. Display will occur just as if the
+         * Shows the given in-app notification to the user. Display will occur just as if the
          * notification was shown via showNotificationIfAvailable. In most cases, it is
          * easier and more efficient to use showNotificationIfAvailable.
          *
@@ -1044,7 +1044,7 @@ public class MixpanelAPI {
 
         /**
          * Returns an InAppNotification object if one is available and being held by the library, or null if
-         * no survey is currently available. Callers who want to display in app notifications should call this
+         * no survey is currently available. Callers who want to display in-app notifications should call this
          * method periodically. A given InAppNotification will be returned only once from this method, so callers
          * should be ready to consume any non-null return value.
          *
@@ -1082,7 +1082,7 @@ public class MixpanelAPI {
         public void showSurveyById(int id, final Activity parent);
 
         /**
-         * Shows an in app notification identified by id. The behavior of this is otherwise identical to
+         * Shows an in-app notification identified by id. The behavior of this is otherwise identical to
          * {@link People#showNotificationIfAvailable(Activity)}.
          *
          * @param id the id of the InAppNotification you wish to show.
@@ -1099,14 +1099,14 @@ public class MixpanelAPI {
 
         /**
          * Adds a new listener that will receive a callback when new updates from Mixpanel
-         * (like surveys, in app notifications, or A/B test experiments) are discovered. Most users of the library
+         * (like surveys, in-app notifications, or A/B test experiments) are discovered. Most users of the library
          * will not need this method, since surveys, in-app notifications, and experiments are
          * applied automatically to your application by default.
          *
          * <p>The given listener will be called when a new batch of updates is detected. Handlers
          * should be prepared to handle the callback on an arbitrary thread.
          *
-         * <p>The listener will be called when new surveys, in app notifications, or experiments
+         * <p>The listener will be called when new surveys, in-app notifications, or experiments
          * are detected as available. That means you wait to call {@link People#showSurveyIfAvailable(Activity)},
          * {@link People#showNotificationIfAvailable(Activity)}, and {@link People#joinExperimentIfAvailable()}
          * to show content and updates that have been delivered to your app. (You can also call these
@@ -1168,7 +1168,7 @@ public class MixpanelAPI {
 
     /**
      * Attempt to register MixpanelActivityLifecycleCallbacks to the application's event lifecycle.
-     * Once registered, we can automatically check for and show surveys and in app notifications
+     * Once registered, we can automatically check for and show surveys and in-app notifications
      * when any Activity is opened.
      *
      * This is only available if the android version is >= 16. You can disable livecycle callbacks by setting
@@ -1456,7 +1456,7 @@ public class MixpanelAPI {
             try {
                 notifProperties.put("$time", dateFormat.format(new Date()));
             } catch (final JSONException e) {
-                Log.e(LOGTAG, "Exception trying to track an in app notification seen", e);
+                Log.e(LOGTAG, "Exception trying to track an in-app notification seen", e);
             }
             people.append("$campaigns", notif.getId());
             people.append("$notifications", notifProperties);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -22,7 +22,6 @@ import android.os.Bundle;
         mMpInstance.getPeople().showSurveyIfAvailable(activity);
     }
 
-
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) { }
 
@@ -36,7 +35,9 @@ import android.os.Bundle;
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) { }
 
     @Override
-    public void onActivityResumed(Activity activity) { }
+    public void onActivityResumed(Activity activity) {
+        mMpInstance.getPeople().joinExperimentIfAvailable();
+    }
 
     @Override
     public void onActivityStopped(Activity activity) { }


### PR DESCRIPTION
Experiments will (by default) only be applied when an activity resumes.
Users of the library can also call joinExperimentIfAvailable to join
whenever they feel the UX is appropriate.