### PR TITLE
Use a clean SSL context by default, allow users to override if needed

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
@@ -16,6 +16,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.net.ssl.SSLSocketFactory;
+
 public class DecideCheckerTest extends AndroidTestCase {
 
     @Override
@@ -335,7 +337,7 @@ public class DecideCheckerTest extends AndroidTestCase {
 
     private static class MockPoster extends HttpService {
         @Override
-        public byte[] performRequest(String url, List<NameValuePair> pairs) throws IOException {
+        public byte[] performRequest(String url, List<NameValuePair> pairs, SSLSocketFactory socketFactory) throws IOException {
             assertNull(pairs);
             requestedUrls.add(url);
 

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.SSLSocketFactory;
+
 public class DecideFunctionalTest extends AndroidTestCase {
 
     public void setUp() throws InterruptedException {
@@ -59,7 +61,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
         mExpectations = new Expectations();
         mMockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
+            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs, SSLSocketFactory socketFactory) {
                 return mExpectations.setExpectationsRequest(endpointUrl, nameValuePairs);
             }
         };

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLSocketFactory;
+
 public class HttpTest extends AndroidTestCase {
 
     public void setUp() {
@@ -37,7 +39,7 @@ public class HttpTest extends AndroidTestCase {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs)
+            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs, SSLSocketFactory socketFactory)
                 throws ServiceUnavailableException, IOException {
                 try {
                     if (null == nameValuePairs) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLSocketFactory;
+
 public class MixpanelBasicTest extends AndroidTestCase {
 
     @Override
@@ -408,7 +410,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
+            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs, SSLSocketFactory socketFactory) {
                 final boolean isIdentified = isIdentifiedRef.get();
                 if (null == nameValuePairs) {
                     if (isIdentified) {
@@ -914,7 +916,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
     public void testAlias() {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
+            public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs, SSLSocketFactory socketFactory) {
                 try {
                     assertEquals(nameValuePairs.get(0).getName(), "data");
                     final String jsonData = Base64Coder.decodeString(nameValuePairs.get(0).getValue());

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
@@ -18,12 +18,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import javax.net.ssl.SSLSocketFactory;
+
 public class ImageStoreTest extends AndroidTestCase {
     public void setUp() {
         mService = new PretendService();
         mService.online = true;
-        final File testDirectory = getContext().getDir("TEST_DIRECTORY", Context.MODE_PRIVATE);
-        mImageStore = new ImageStore(testDirectory, mService);
+        mImageStore = new ImageStore(getContext(), "TEST_DIRECTORY", mService);
         mImageStore.clearStorage();
 
     }
@@ -82,7 +83,7 @@ public class ImageStoreTest extends AndroidTestCase {
         }
 
         @Override
-        public byte[] performRequest(final String endpointUrl, final List<NameValuePair> params)
+        public byte[] performRequest(final String endpointUrl, final List<NameValuePair> params, SSLSocketFactory socketFactory)
                 throws ServiceUnavailableException, IOException {
             queries++;
             return response;

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -31,6 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SSLSocketFactory;
+
 /**
  * Manage communication of events with the internal database and the Mixpanel servers.
  *
@@ -409,7 +411,8 @@ import java.util.Map;
                     byte[] response;
                     for (String url : urls) {
                         try {
-                            response = poster.performRequest(url, params);
+                            final SSLSocketFactory socketFactory = mConfig.getSSLSocketFactory();
+                            response = poster.performRequest(url, params, socketFactory);
                             deleteEvents = true; // Delete events on any successful post, regardless of 1 or 0 response
                             if (null == response) {
                                 logAboutMessageToMixpanel("Response was null, unexpected failure posting to " + url + ".");

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
@@ -27,6 +27,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.net.ssl.SSLSocketFactory;
+
 /* package */ class DecideChecker {
 
     /* package */ static class Result {
@@ -277,7 +279,9 @@ import java.util.List;
         byte[] response = null;
         for (String url : urls) {
             try {
-                response = poster.performRequest(url, null);
+                final MPConfig config = MPConfig.getInstance(context);
+                final SSLSocketFactory socketFactory = config.getSSLSocketFactory();
+                response = poster.performRequest(url, null, socketFactory);
                 break;
             } catch (final MalformedURLException e) {
                 Log.e(LOGTAG, "Cannot interpret " + url + " as a URL.", e);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -46,6 +46,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.net.ssl.SSLSocketFactory;
+
 /**
  * Core class for interacting with Mixpanel Analytics.
  *
@@ -185,6 +187,12 @@ public class MixpanelAPI {
      */
     public static Tweak<Byte> byteTweak(String tweakName, byte defaultValue) {
         return sSharedTweaks.byteTweak(tweakName, defaultValue);
+    }
+
+    public static void setSSLSocketFactory(SSLSocketFactory factory) {
+        synchronized (MixpanelAPI.class) {
+            sSSLSocketFactory = factory;
+        }
     }
 
     /**
@@ -2110,6 +2118,7 @@ public class MixpanelAPI {
     private static final SharedPreferencesLoader sPrefsLoader = new SharedPreferencesLoader();
     private static final Tweaks sSharedTweaks = new Tweaks();
     private static Future<SharedPreferences> sReferrerPrefs;
+    private static SSLSocketFactory sSSLSocketFactory;
 
     private static final String LOGTAG = "MixpanelAPI.API";
     private static final String APP_LINKS_LOGTAG = "MixpanelAPI.AL";

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -20,11 +20,13 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
 /**
- * An HTTP utility class for internal use in the Mixpanel library.
+ * An HTTP utility class for internal use in the Mixpanel library. Not thread-safe.
  */
 public class HttpService implements RemoteService {
-
     @Override
     public boolean isOnline(Context context) {
         boolean isOnline;
@@ -46,7 +48,7 @@ public class HttpService implements RemoteService {
     }
 
     @Override
-    public byte[] performRequest(String endpointUrl, List<NameValuePair> params) throws ServiceUnavailableException, IOException {
+    public byte[] performRequest(String endpointUrl, List<NameValuePair> params, SSLSocketFactory socketFactory) throws ServiceUnavailableException, IOException {
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "Attempting request to " + endpointUrl);
         }
@@ -67,6 +69,10 @@ public class HttpService implements RemoteService {
             try {
                 final URL url = new URL(endpointUrl);
                 connection = (HttpURLConnection) url.openConnection();
+                if (null != socketFactory && connection instanceof HttpsURLConnection) {
+                    ((HttpsURLConnection) connection).setSSLSocketFactory(socketFactory);
+                }
+
                 connection.setConnectTimeout(2000);
                 connection.setReadTimeout(10000);
                 if (null != params) {

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -7,13 +7,16 @@ import org.apache.http.NameValuePair;
 import java.io.IOException;
 import java.util.List;
 
+import javax.net.ssl.SSLSocketFactory;
+
 
 public interface RemoteService {
     boolean isOnline(Context context);
 
-    byte[] performRequest(String endpointUrl, List<NameValuePair> params) throws ServiceUnavailableException, IOException;
+    byte[] performRequest(String endpointUrl, List<NameValuePair> params, SSLSocketFactory socketFactory)
+            throws ServiceUnavailableException, IOException;
 
-    public static class ServiceUnavailableException extends Exception {
+    class ServiceUnavailableException extends Exception {
         public ServiceUnavailableException(String message, String strRetryAfter) {
             super(message);
             int retry;

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewVisitor.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewVisitor.java
@@ -36,11 +36,11 @@ import java.util.WeakHashMap;
      * on click)
      */
     public interface OnEventListener {
-        public void OnEvent(View host, String eventName, boolean debounce);
+        void OnEvent(View host, String eventName, boolean debounce);
     }
 
     public interface OnLayoutErrorListener {
-        public void onLayoutError(LayoutErrorMessage e);
+        void onLayoutError(LayoutErrorMessage e);
     }
 
     public static class LayoutErrorMessage {


### PR DESCRIPTION
Relevant to #95 - by default, this change isolates the Mixpanel library from app changes to the default SSL context, but allows users to explicitly set their own context if it is needed.