### PR TITLE
fix identifier matching for clarity and to support genymotion's emulator

### DIFF
--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -221,27 +221,22 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
         }
 
         private boolean isInEmulator() {
-            if (!Build.HARDWARE.equals("goldfish")) {
-                return false;
+            if (Build.HARDWARE.equals("vbox86") &&
+                    Build.BRAND.startsWith("generic") &&
+                    Build.DEVICE.equals("vbox86p") &&
+                    Build.PRODUCT.equals("vbox86p")) {
+                return true;
             }
 
-            if (!Build.BRAND.startsWith("generic")) {
-                return false;
+            if (Build.HARDWARE.equals("goldfish") &&
+                    Build.BRAND.startsWith("generic") &&
+                    Build.DEVICE.startsWith("generic") &&
+                    Build.PRODUCT.contains("sdk") &&
+                    Build.MODEL.toLowerCase(Locale.US).contains("sdk")) {
+                return true;
             }
 
-            if (!Build.DEVICE.startsWith("generic")) {
-                return false;
-            }
-
-            if (!Build.PRODUCT.contains("sdk")) {
-                return false;
-            }
-
-            if (!Build.MODEL.toLowerCase(Locale.US).contains("sdk")) {
-                return false;
-            }
-
-            return true;
+            return false;
         }
 
         private final FlipGesture mFlipGesture;


### PR DESCRIPTION
Genymotion reports different identifier strings than vanilla AS:

Geny
HARDWARE 06-19 14:01:35.674    3825-3825/com.bulsy.greenwall D/emulator﹕ vbox86
BRAND 06-19 14:01:35.674    3825-3825/com.bulsy.greenwall D/emulator﹕ generic
DEVICE 06-19 14:01:35.674    3825-3825/com.bulsy.greenwall D/emulator﹕ vbox86p
PRODUCT 06-19 14:01:35.674    3825-3825/com.bulsy.greenwall D/emulator﹕ vbox86p
MODEL 06-19 14:01:35.674    3825-3825/com.bulsy.greenwall D/emulator﹕ Custom Phone - 5.1.0 - API 22 - 768x1280

Vanilla
HARDWARE 06-19 11:24:05.890    2129-2129/com.bulsy.greenwall D/emulator﹕ goldfish
BRAND 06-19 11:24:05.890    2129-2129/com.bulsy.greenwall D/emulator﹕ generic_x86_64
DEVICE 06-19 11:24:05.890    2129-2129/com.bulsy.greenwall D/emulator﹕ generic_x86_64
PRODUCT 06-19 11:24:05.890    2129-2129/com.bulsy.greenwall D/emulator﹕ sdk_google_phone_x86_64
MODEL 06-19 11:24:05.890    2129-2129/com.bulsy.greenwall D/emulator﹕ Android SDK built for x86_64

This fix cleans up the code and allows our A/B testing stack to recognize Genymotion as an emulator, bypassing the need for a gesture