### PR TITLE
Fix to retain A/B testing variant after app crashes

### DIFF
--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -351,7 +351,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                     for (int i = 0; i < variantsLength; i++) {
                         final JSONObject variant = variants.getJSONObject(i);
                         final int variantId = variant.getInt("id");
-                        final int experimentId = variant.getInt("experiment");
+                        final int experimentId = variant.getInt("experiment_id");
                         final Pair<Integer,Integer> sight = new Pair<Integer,Integer>(experimentId, variantId);
                         mSeenExperiments.add(sight);
                     }


### PR DESCRIPTION
Picking "experiment" instead of "experiment_id" here causes the app to encounter a key error and thus run the except block which invalidates all A/B testing variants in the shared preferences. So, for A/B tests after the app crashes when you resume using the app the test will not be applied by default and users will appear in a test they are not getting.