### PR TITLE
added callback for tweak initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ android {
 // pom! If you need a transitive dependency in the library, you'll
 // have to change the bit in uploadArchives that marks all dependencies as optional.
 dependencies {
-    compile "com.google.android.gms:play-services:[3.1,)"
+
+    //compile "com.google.android.gms:play-services:[3.1,)" //bad kitty
+    compile 'com.google.android.gms:play-services-gcm:7.5.0'
 }
 
 android.libraryVariants.all { variant ->

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -18,11 +18,11 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.mixpanel.android.R;
-import com.mixpanel.android.viewcrawler.UpdatesFromMixpanel;
-import com.mixpanel.android.viewcrawler.TrackingDebug;
-import com.mixpanel.android.viewcrawler.ViewCrawler;
 import com.mixpanel.android.surveys.SurveyActivity;
 import com.mixpanel.android.util.ActivityImageUtils;
+import com.mixpanel.android.viewcrawler.TrackingDebug;
+import com.mixpanel.android.viewcrawler.UpdatesFromMixpanel;
+import com.mixpanel.android.viewcrawler.ViewCrawler;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -188,10 +188,13 @@ public class MixpanelAPI {
         return sSharedTweaks.byteTweak(tweakName, defaultValue);
     }
 
-    /**
-     * You shouldn't instantiate MixpanelAPI objects directly.
-     * Use MixpanelAPI.getInstance to get an instance.
-     */
+    public static void bindChangeCallback(String tweakName, Tweaks.TweakChangeCallback callback) {
+        sSharedTweaks.bindChangeCallback(tweakName, callback);
+    }
+        /**
+         * You shouldn't instantiate MixpanelAPI objects directly.
+         * Use MixpanelAPI.getInstance to get an instance.
+         */
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token) {
         mContext = context;
         mToken = token;

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -99,6 +99,37 @@ public class Tweaks {
      */
     public static final @TweakType int STRING_TYPE = 4;
 
+
+    /**
+     * This interface is used to notify anyone who cares that a tweak has been changed.
+     * E.g. when the values have been loaded from the server.
+     *
+     * Please note that such a change might not necessarily be caused by data synchronization and after a change
+     */
+    public interface TweakChangeCallback {
+        /**
+         *
+         * @param value The updated value T of a Tweak<T>
+         */
+        void onChange(Object value);
+    }
+
+
+    /**
+     *
+     * @param tweakName name of the Tweak that should react to this callback, needs to be defined via MixpanelAPI.intTweak(tweakName, defaultValue) first - if it's not int use your thinking mush to find the correct method..
+     * @param callback the callback that should be called when the value of a named tweak changes.
+     */
+    public void bindChangeCallback(String tweakName, TweakChangeCallback callback) {
+        if (!mTweakValues.containsKey(tweakName)) {
+            Log.w(LOGTAG, "Attempt to bind to a tweak \"" + tweakName + "\" which doesn't exist");
+            return;
+        }
+
+        final TweakValue value = mTweakValues.get(tweakName);
+        value.setTweakChangeCallback(callback);
+    }
+
     /**
      * Represents the value and definition of a tweak known to the system. This class
      * is used internally to expose tweaks to the Mixpanel UI,
@@ -114,7 +145,13 @@ public class Tweaks {
         }
 
         public TweakValue updateValue(Object newValue) {
+            if(changeCallback != null)
+                changeCallback.onChange(newValue);
             return new TweakValue(type, defaultValue, minimum, maximum, newValue);
+        }
+
+        public void setTweakChangeCallback(TweakChangeCallback callback){
+            changeCallback = callback;
         }
 
         public String getStringValue() {
@@ -185,6 +222,8 @@ public class Tweaks {
         private final Object defaultValue;
         private final Number minimum;
         private final Number maximum;
+
+        private TweakChangeCallback changeCallback = null;
     }
 
     /**


### PR DESCRIPTION
I ran into the problem that I didn't know when tweaks have finished initializing - I believe this is already implemented for iOS. By implementing this I discovered that they only initialize after I call joinExperimentsIfAvailable() about 2 seconds after initializing mixpanel and my experiment, so for me this already was a huge help correctly implementing AB testing.
The implementation is similar to the one in 4.5.4 beta, even though that feature didn't make it into 4.6.+.

I also changed play-services to a specific version, which is kind of unrelated since it lead to issues on my end. Imho this should be done anyway since an update to play-services in the repo can break compilation and force changes onto the app just because someone decided to refactor that library. Feel free to ignore build.grade from the merge if you're against this decision. I should have put that in another commit, sorry.