### PR TITLE
Add app release prop

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -506,6 +506,10 @@ import javax.net.ssl.SSLSocketFactory;
                 if (null != applicationVersionName)
                     ret.put("$app_version", applicationVersionName);
 
+                final Integer applicationVersionCode = mSystemInformation.getAppVersionCode();
+                if (null != applicationVersionCode)
+                    ret.put("$app_release", applicationVersionCode);
+
                 final Boolean hasNFC = mSystemInformation.hasNFC();
                 if (null != hasNFC)
                     ret.put("$has_nfc", hasNFC.booleanValue());


### PR DESCRIPTION
This property is currently tracked in iOS and missed on Android.

This should be added for parity and allow for cross-platform comparisons between builds.