### PR TITLE
Fix addOnMixpanelUpdatesReceived listener for A/B tests

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -68,12 +68,17 @@ import java.util.Set;
             }
         }
 
+        if (variants.length() > 0) {
+            newContent = true;
+        }
+
         mVariants = variants;
 
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +
                     newSurveys.size() + " surveys and " +
-                    newNotifications.size() + " notifications have been added.");
+                    newNotifications.size() + " notifications and " +
+                    variants.length() + " experiments have been added.");
         }
 
         if (newContent && hasUpdatesAvailable() && null != mListener) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -69,10 +69,9 @@ import java.util.Set;
         }
 
         if (variants.length() > 0) {
+            mVariants = variants;
             newContent = true;
-        }
-
-        mVariants = variants;
+        } 
 
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +


### PR DESCRIPTION
Currently the ```addOnMixpanelUpdatesReceivedListener``` is broken for A/B tests. This listener is intended to run whenever an update is received from /decide and then allow the user to execute code.

Unfortunately, the current behavior does nothing for A/B tests and causes the code within the listener to never run. This fix updates the code to flip a boolean ```newContent``` when variants exist to force the listener code to run as well as adds the receipt of new experiments from /decide to the SDK debug logging.

I have tested this locally and was able to effectively use ```addOnMixpanelUpdatesReceivedListener``` to join an experiment as it comes in from /decide.

I do want to make it clear this is when A/B testing is the ONLY thing you are using. If you also receive surveys or notifications when you receive A/B tests then the code will run as expected.