### PR TITLE
Guard against NPE when using certain Contexts.

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/ConfigurationChecker.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ConfigurationChecker.java
@@ -70,7 +70,14 @@ import android.util.Log;
 
         final PackageManager packageManager = context.getPackageManager();
         final String packageName = context.getPackageName();
+
+        if (packageManager == null || packageName == null) {
+            Log.w(LOGTAG, "Can't check configuration when using a Context with null packageManager or packageName");
+            return false;
+        }
+
         final String permissionName = packageName + ".permission.C2D_MESSAGE";
+
         // check special permission
         try {
             packageManager.getPermissionInfo(permissionName, PackageManager.GET_PERMISSIONS);

--- a/src/main/java/com/mixpanel/android/mpmetrics/ConfigurationChecker.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ConfigurationChecker.java
@@ -46,6 +46,10 @@ import android.util.Log;
         final PackageManager packageManager = context.getPackageManager();
         final String packageName = context.getPackageName();
 
+        if (packageManager == null || packageName == null) {
+            Log.w(LOGTAG, "Can't check configuration when using a Context with null packageManager or packageName");
+            return false;
+        }
         if (PackageManager.PERMISSION_GRANTED != packageManager.checkPermission("android.permission.INTERNET", packageName)) {
             Log.w(LOGTAG, "Package does not have permission android.permission.INTERNET - Mixpanel will not work at all!");
             Log.i(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +


### PR DESCRIPTION
Using special Context objects, such as the BridgeContext provided by
Android Studio's previewer, would result in an NPE when calling
Mixpanel.getInstance() previously, because
ConfigurationChecker.checkBasicConfiguration() assumes that the context's
packageManager and packageName can't be null. This is now guarded
against, and Mixpanel.getInstance() will return null for contexts such as
this.