### PR TITLE
New variants listener bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ We'd also love for you to come and work with us! Check out http://boards.greenho
 Changelog
 ---------
 
+#### v4.6.3
+
+ * Fix a bug where the user defined listener (by calling
+   mMixpanel.getPeople().addOnMixpanelUpdatesReceivedListener())
+   is not called on new variants receiving
+
+
 #### v4.6.1
 
  * The Mixpanel library no longer uses the default SSLSocketFactory

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ group = com.mixpanel.android
 # As long as we support building from source in Eclipse, we can't
 # just use BuildConfig.MIXPANEL_VERSION in our source, so if you
 # update the value of version you'll also need to update MPConfig.VERSION
-version = 4.6.2
+version = 4.6.3

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -75,7 +75,7 @@ import java.util.Set;
         for (int i = 0; i < newVariantsLength; i++) {
             try {
                 JSONObject variant = variants.getJSONObject(i);
-                if (mVariants == null || !mLoadedVariants.contains(variant.getInt("id"))) {
+                if (!mLoadedVariants.contains(variant.getInt("id"))) {
                     mVariants = variants;
                     newContent = true;
                     break;

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -70,7 +70,10 @@ import java.util.Set;
             }
         }
 
+        // the following logic checks if the variants have been applied by looking up their id's in the HashSet
+        // this is needed to make sure the user defined `mListener` will get called on new variants receiving
         int newVariantsLength = variants.length();
+        boolean hasNewVariants = false;
 
         for (int i = 0; i < newVariantsLength; i++) {
             try {
@@ -78,6 +81,7 @@ import java.util.Set;
                 if (!mLoadedVariants.contains(variant.getInt("id"))) {
                     mVariants = variants;
                     newContent = true;
+                    hasNewVariants = true;
                     break;
                 }
             } catch(JSONException e) {
@@ -85,7 +89,7 @@ import java.util.Set;
             }
         }
 
-        if (mVariants == variants) {
+        if (hasNewVariants) {
             mLoadedVariants.clear();
 
             for (int i = 0; i < newVariantsLength; i++) {
@@ -100,7 +104,7 @@ import java.util.Set;
 
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +
-                    newSurveys.size() + " surveys and " +
+                    newSurveys.size() + " surveys, " +
                     newNotifications.size() + " notifications and " +
                     variants.length() + " experiments have been added.");
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -8,11 +8,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 // Will be called from both customer threads and the Mixpanel worker thread.

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -88,7 +88,7 @@ public class MPConfig {
     // Unfortunately, as long as we support building from source in Eclipse,
     // we can't rely on BuildConfig.MIXPANEL_VERSION existing, so this must
     // be hard-coded both in our gradle files and here in code.
-    public static final String VERSION = "4.6.2";
+    public static final String VERSION = "4.6.3";
 
     public static boolean DEBUG = false;
 


### PR DESCRIPTION
Fix the bug where the user defined listener doesn't get called on new variants receive.

NOTE:
1. bump up the version
2. ~~make sure the decide change goes live before this one~~ - this is not needed as we are not going to merge in the updated_time change