### PR TITLE
fix inapp notif rendering

### DIFF
--- a/acceptance/test-application/build.gradle
+++ b/acceptance/test-application/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ group = com.mixpanel.android
 # As long as we support building from source in Eclipse, we can't
 # just use BuildConfig.MIXPANEL_VERSION in our source, so if you
 # update the value of version you'll also need to update MPConfig.VERSION
-version = 4.6.4
+version = 4.7.0-RC1

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -88,7 +88,7 @@ public class MPConfig {
     // Unfortunately, as long as we support building from source in Eclipse,
     // we can't rely on BuildConfig.MIXPANEL_VERSION existing, so this must
     // be hard-coded both in our gradle files and here in code.
-    public static final String VERSION = "4.6.4";
+    public static final String VERSION = "4.7.0-RC1";
 
     public static boolean DEBUG = false;
 

--- a/src/main/java/com/mixpanel/android/surveys/FadingImageView.java
+++ b/src/main/java/com/mixpanel/android/surveys/FadingImageView.java
@@ -15,6 +15,7 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 
 import com.mixpanel.android.R;
 
@@ -42,6 +43,7 @@ public class FadingImageView extends ImageView {
         mHeight = getHeight();
         mWidth = getWidth();
         int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
+        LinearLayout container = (LinearLayout) getParent();
 
         if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
             // For Portrait takeover notifications, we have to fade out into the notification text
@@ -61,7 +63,7 @@ public class FadingImageView extends ImageView {
             // give it a few extra dp's of room.
             Resources r = getResources();
             float extraPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 15, r.getDisplayMetrics());
-            mGradientMatrix.setScale(1, parentHeight - bottomWrapperHeight + extraPx);
+            mGradientMatrix.setScale(1, parentHeight + container.getPaddingBottom() - bottomWrapperHeight + extraPx);
         } else {
             mGradientMatrix.setScale(1, parentHeight);
         }
@@ -79,13 +81,9 @@ public class FadingImageView extends ImageView {
 
         super.draw(canvas);
 
+        // Only apply the gradient when we're in portrait view
         if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
             canvas.drawRect(0, 0, mWidth, mHeight, mAlphaGradientPaint);
-        } else {
-            canvas.drawRect(getPaddingLeft(), getPaddingTop(),
-                            mWidth - getPaddingRight(),
-                            mHeight - getPaddingBottom(),
-                            mDarkenGradientPaint);
         }
         canvas.restoreToCount(restoreTo);
     }

--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -131,12 +131,21 @@ public class SurveyActivity extends Activity {
         if (inAppImage.getWidth() < SHADOW_SIZE_THRESHOLD_PX || inAppImage.getHeight() < SHADOW_SIZE_THRESHOLD_PX) {
             inAppImageView.setBackgroundResource(R.drawable.com_mixpanel_android_square_nodropshadow);
         } else {
-            final Bitmap scaledImage = Bitmap.createScaledBitmap(inAppImage, 1, 1, false);
-            final int averageColor = scaledImage.getPixel(0, 0);
-            final int averageAlpha = Color.alpha(averageColor);
-
-            if (averageAlpha < 0xFF) {
-                inAppImageView.setBackgroundResource(R.drawable.com_mixpanel_android_square_nodropshadow);
+            int h = inAppImage.getHeight() / 100;
+            int w = inAppImage.getWidth() / 100;
+            final Bitmap scaledImage = Bitmap.createScaledBitmap(inAppImage, w, h, false);
+            int averageColor;
+            int averageAlpha;
+            outerloop:
+            for (int x = 0; x < w; x++) {
+                for (int y = 0; y < h; y++) {
+                    averageColor = scaledImage.getPixel(x, y);
+                    averageAlpha = Color.alpha(averageColor);
+                    if (averageAlpha < 0xFF) {
+                        inAppImageView.setBackgroundResource(R.drawable.com_mixpanel_android_square_nodropshadow);
+                        break outerloop;
+                    }
+                }
             }
         }
         inAppImageView.setImageBitmap(inAppImage);

--- a/src/main/res/layout/com_mixpanel_android_activity_notification_full.xml
+++ b/src/main/res/layout/com_mixpanel_android_activity_notification_full.xml
@@ -76,8 +76,9 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/com_mixpanel_android_button_exit_wrapper"
-        android:gravity="top|center_horizontal"
+        android:layout_marginTop="50dp"
+        android:paddingBottom="100dp"
+        android:gravity="center"
         android:orientation="horizontal">
         <com.mixpanel.android.surveys.FadingImageView
             android:id="@+id/com_mixpanel_android_notification_image"


### PR DESCRIPTION
- more accurate alpha detection in inapp images, which means we'll more
  accurately guess if the image has alpha and thus should use
transparent background instead of the drop shadow
- better positioning of the inapp image; it's now higher
- remove gradient when in landscape mode