### PR TITLE
Bump up the API level to 23 -

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ android {
 // have to change the bit in uploadArchives that marks all dependencies as optional.
 dependencies {
     compile 'com.google.android.gms:play-services:[3.1,)'
-    compile 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2'
+    compile group: 'cz.msebera.android' , name: 'httpclient', version: '4.4.1.1'
 }
 
 android.libraryVariants.all { variant ->

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,12 @@ android {
 // pom! If you need a transitive dependency in the library, you'll
 // have to change the bit in uploadArchives that marks all dependencies as optional.
 dependencies {
-    compile 'com.google.android.gms:play-services:[3.1,)'
-    compile group: 'cz.msebera.android' , name: 'httpclient', version: '4.4.1.1'
+    compile ('com.google.android.gms:play-services:[3.1,)') {
+        ext.optional = true
+    }
+    compile (group: 'cz.msebera.android' , name: 'httpclient', version: '4.4.1.1') {
+        transitive = true
+    }
 }
 
 android.libraryVariants.all { variant ->
@@ -134,7 +138,11 @@ uploadArchives {
         }
 
         pom.whenConfigured { pom ->
-            pom.dependencies*.optional = true
+            pom.dependencies.findAll {
+                def dependencyMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
+                def dep = dependencyMap[it.artifactId]
+                return dep?.hasProperty('optional') && dep.optional
+            }*.optional = true
         }
 
         if (isReleaseVersion() && project.hasProperty("sonatypeUsername")) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,19 +7,23 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 android {
-    compileSdkVersion 21
+    compileSdkVersion 23
     buildToolsVersion "22.0.1"
 
     defaultConfig {
         // If you change minSdkVersion or targetSdkVersion below, you must also change
         // the relevant attributes of the <uses-sdk> tag in AndroidManifest.xml
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 23
         testApplicationId "com.mixpanel.android.mpmetrics"
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
 
@@ -35,7 +39,8 @@ android {
 // pom! If you need a transitive dependency in the library, you'll
 // have to change the bit in uploadArchives that marks all dependencies as optional.
 dependencies {
-    compile "com.google.android.gms:play-services:[3.1,)"
+    compile 'com.google.android.gms:play-services:[3.1,)'
+    compile 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2'
 }
 
 android.libraryVariants.all { variant ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ group = com.mixpanel.android
 # As long as we support building from source in Eclipse, we can't
 # just use BuildConfig.MIXPANEL_VERSION in our source, so if you
 # update the value of version you'll also need to update MPConfig.VERSION
-version = 4.6.4
+version = 4.6.5

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
@@ -8,7 +8,7 @@ import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 import com.mixpanel.android.viewcrawler.UpdatesFromMixpanel;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 import org.json.JSONArray;
 
 import java.io.IOException;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -14,7 +14,7 @@ import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 import com.mixpanel.android.viewcrawler.UpdatesFromMixpanel;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 import org.json.JSONArray;
 
 import java.io.ByteArrayOutputStream;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -9,7 +9,7 @@ import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -16,7 +16,7 @@ import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
@@ -9,7 +9,7 @@ import android.util.Base64;
 import com.mixpanel.android.util.ImageStore;
 import com.mixpanel.android.util.RemoteService;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -17,8 +17,8 @@ import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
+import cz.msebera.android.httpclient.message.BasicNameValuePair;
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
@@ -3,6 +3,7 @@ package com.mixpanel.android.mpmetrics;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.support.v4.app.NotificationCompat;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -256,9 +257,16 @@ public class GCMReceiver extends BroadcastReceiver {
     @SuppressWarnings("deprecation")
     @TargetApi(9)
     private Notification makeNotificationSDKLessThan11(Context context, PendingIntent intent, NotificationData notificationData) {
-        final Notification n = new Notification(notificationData.icon, notificationData.message, System.currentTimeMillis());
+        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context).
+                setSmallIcon(notificationData.icon).
+                setTicker(notificationData.message).
+                setWhen(System.currentTimeMillis()).
+                setContentTitle(notificationData.title).
+                setContentText(notificationData.message).
+                setContentIntent(intent);
+
+        final Notification n = builder.getNotification();
         n.flags |= Notification.FLAG_AUTO_CANCEL;
-        n.setLatestEventInfo(context, notificationData.title, notificationData.message, intent);
         return n;
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
@@ -48,6 +48,7 @@ public class InAppFragment extends Fragment {
         mDisplayState = displayState;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -88,7 +88,7 @@ public class MPConfig {
     // Unfortunately, as long as we support building from source in Eclipse,
     // we can't rely on BuildConfig.MIXPANEL_VERSION existing, so this must
     // be hard-coded both in our gradle files and here in code.
-    public static final String VERSION = "4.6.4";
+    public static final String VERSION = "4.6.5";
 
     public static boolean DEBUG = false;
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -123,6 +123,7 @@ import android.view.WindowManager;
     }
 
 
+    @SuppressWarnings("deprecation")
     public Boolean isWifiConnected() {
         Boolean ret = null;
 

--- a/src/main/java/com/mixpanel/android/surveys/MiniCircleImageView.java
+++ b/src/main/java/com/mixpanel/android/surveys/MiniCircleImageView.java
@@ -29,6 +29,7 @@ public class MiniCircleImageView extends ImageView { // TODO move to surveys pac
         init();
     }
     
+    @SuppressWarnings("deprecation")
     private void init() {
         mWhitePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mWhitePaint.setColor(getResources().getColor(android.R.color.white));

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -7,8 +7,8 @@ import android.util.Log;
 
 import com.mixpanel.android.mpmetrics.MPConfig;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
+import cz.msebera.android.httpclient.NameValuePair;
+import cz.msebera.android.httpclient.client.entity.UrlEncodedFormEntity;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -2,7 +2,7 @@ package com.mixpanel.android.util;
 
 import android.content.Context;
 
-import org.apache.http.NameValuePair;
+import cz.msebera.android.httpclient.NameValuePair;
 
 import java.io.IOException;
 import java.util.List;


### PR DESCRIPTION
1. add a HttpClient library as it gets removed in Android M
2. replace NotificationCompat with the old Notification in API 9
3. add SuppressWarnings to eliminate the deprecation warnings

(tested on a phone with API 10)