### PR TITLE
Allow SDK users to disable the "ViewCrawler" with a Manifest Metadata

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -1,0 +1,68 @@
+package com.mixpanel.android.mpmetrics;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.test.AndroidTestCase;
+import com.mixpanel.android.viewcrawler.ViewCrawler;
+
+public class MPConfigTest extends AndroidTestCase {
+
+    public static final String TOKEN                             = "TOKEN";
+    public static final String DISABLE_VIEW_CRAWLER_METADATA_KEY = "com.mixpanel.android.MPConfig.DisableViewCrawler";
+
+    public void testDisableViewCrawlerDefaultsToFalse() throws Exception {
+        final Bundle metaData = new Bundle();
+
+        // DON'T set "com.mixpanel.android.MPConfig.DisableViewCrawler" in the bundle
+
+        final MixpanelAPI mixpanelAPI = mixpanelApi(mpConfig(metaData));
+
+        if (Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API) {
+            assertTrue("By default, we should use ViewCrawler as our Impl of UpdatesFromMixpanel",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof ViewCrawler);
+        } else {
+            assertTrue("When API is older than MPConfig.UI_FEATURES_MIN_API, we should use NoOp",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof MixpanelAPI.NoOpUpdatesFromMixpanel);
+        }
+    }
+
+    public void testDisableViewCrawlerTrueGetsNoOpImpl() throws Exception {
+        final Bundle metaData = new Bundle();
+
+        metaData.putBoolean(DISABLE_VIEW_CRAWLER_METADATA_KEY, true);
+
+        final MixpanelAPI mixpanelAPI = mixpanelApi(mpConfig(metaData));
+
+        if (Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API) {
+            assertTrue("When DisableViewCrawler is true, we should use a NoOp Impl of UpdatesFromMixpanel",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof MixpanelAPI.NoOpUpdatesFromMixpanel);
+        } else {
+            assertTrue("When API is older than MPConfig.UI_FEATURES_MIN_API, we should use NoOp",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof MixpanelAPI.NoOpUpdatesFromMixpanel);
+        }
+    }
+
+    public void testDisableViewCrawlerFalseGetsViewCrawler() throws Exception {
+        final Bundle metaData = new Bundle();
+
+        metaData.putBoolean(DISABLE_VIEW_CRAWLER_METADATA_KEY, false);
+
+        final MixpanelAPI mixpanelAPI = mixpanelApi(mpConfig(metaData));
+
+        if (Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API) {
+            assertTrue("When DisableViewCrawler is false, we should use ViewCrawler as our Impl of UpdatesFromMixpanel",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof ViewCrawler);
+        } else {
+            assertTrue("When API is older than MPConfig.UI_FEATURES_MIN_API, we should use NoOp",
+                       mixpanelAPI.constructUpdatesFromMixpanel(getContext(), TOKEN) instanceof MixpanelAPI.NoOpUpdatesFromMixpanel);
+        }
+    }
+
+    private MPConfig mpConfig(final Bundle metaData) {
+        return new MPConfig(metaData, getContext());
+    }
+
+    private MixpanelAPI mixpanelApi(final MPConfig config) {
+        return new MixpanelAPI(getContext(), new TestUtils.EmptyPreferences(getContext()), TOKEN, config);
+    }
+}

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -169,15 +169,16 @@ public class MPConfig {
         mBulkUploadLimit = metaData.getInt("com.mixpanel.android.MPConfig.BulkUploadLimit", 40); // 40 records default
         mFlushInterval = metaData.getInt("com.mixpanel.android.MPConfig.FlushInterval", 60 * 1000); // one minute default
         mDebugFlushInterval = metaData.getInt("com.mixpanel.android.MPConfig.DebugFlushInterval", 1 * 1000); // one second default
-        mDataExpiration = metaData.getInt("com.mixpanel.android.MPConfig.DataExpiration",  1000 * 60 * 60 * 24 * 5); // 5 days default
-        mMinimumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MinimumDatabaseLimit",  20 * 1024 * 1024); // 20 Mb
+        mDataExpiration = metaData.getInt("com.mixpanel.android.MPConfig.DataExpiration", 1000 * 60 * 60 * 24 * 5); // 5 days default
+        mMinimumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MinimumDatabaseLimit", 20 * 1024 * 1024); // 20 Mb
         mDisableFallback = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableFallback", true);
         mResourcePackageName = metaData.getString("com.mixpanel.android.MPConfig.ResourcePackageName"); // default is null
         mDisableGestureBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableGestureBindingUI", false);
         mDisableEmulatorBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableEmulatorBindingUI", false);
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
+        mDisableViewCrawler = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableViewCrawler", false);
 
-         // Disable if EITHER of these is present and false, otherwise enable
+        // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
         final boolean mixpanelUpdatesAutoShow = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoShowMixpanelUpdates", true);
         mAutoShowMixpanelUpdates = surveysAutoCheck && mixpanelUpdatesAutoShow;
@@ -236,6 +237,7 @@ public class MPConfig {
                 "    MinimumDatabaseLimit " + getMinimumDatabaseLimit() + "\n" +
                 "    DisableFallback " + getDisableFallback() + "\n" +
                 "    DisableAppOpenEvent " + getDisableAppOpenEvent() + "\n" +
+                "    DisableViewCrawler " + getDisableViewCrawler() + "\n" +
                 "    DisableDeviceUIBinding " + getDisableGestureBindingUI() + "\n" +
                 "    DisableEmulatorUIBinding " + getDisableEmulatorBindingUI() + "\n" +
                 "    EnableDebugLogging " + DEBUG + "\n" +
@@ -291,6 +293,10 @@ public class MPConfig {
 
     public boolean getDisableAppOpenEvent() {
         return mDisableAppOpenEvent;
+    }
+
+    public boolean getDisableViewCrawler() {
+        return mDisableViewCrawler;
     }
 
     public boolean getTestMode() {
@@ -385,6 +391,7 @@ public class MPConfig {
     private final boolean mDisableGestureBindingUI;
     private final boolean mDisableEmulatorBindingUI;
     private final boolean mDisableAppOpenEvent;
+    private final boolean mDisableViewCrawler;
     private final String mEventsEndpoint;
     private final String mEventsFallbackEndpoint;
     private final String mPeopleEndpoint;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -193,11 +193,19 @@ public class MixpanelAPI {
      * Use MixpanelAPI.getInstance to get an instance.
      */
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token) {
+        this(context, referrerPreferences, token, MPConfig.getInstance(context));
+    }
+
+    /**
+     * You shouldn't instantiate MixpanelAPI objects directly.
+     * Use MixpanelAPI.getInstance to get an instance.
+     */
+    MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token, final MPConfig config) {
         mContext = context;
         mToken = token;
         mEventTimings = new HashMap<String, Long>();
         mPeople = new PeopleImpl();
-        mConfig = getConfig();
+        mConfig = config;
 
         final Map<String, String> deviceInfo = new HashMap<String, String>();
         deviceInfo.put("$android_lib_version", MPConfig.VERSION);
@@ -1290,10 +1298,6 @@ public class MixpanelAPI {
         return AnalyticsMessages.getInstance(mContext);
     }
 
-    /* package */ MPConfig getConfig() {
-        return MPConfig.getInstance(mContext);
-    }
-
     /* package */ PersistentIdentity getPersistentIdentity(final Context context, Future<SharedPreferences> referrerPreferences, final String token) {
         final SharedPreferencesLoader.OnPrefsLoadedListener listener = new SharedPreferencesLoader.OnPrefsLoadedListener() {
             @Override
@@ -1326,7 +1330,9 @@ public class MixpanelAPI {
     /* package */ UpdatesFromMixpanel constructUpdatesFromMixpanel(final Context context, final String token) {
         if (Build.VERSION.SDK_INT < MPConfig.UI_FEATURES_MIN_API) {
             Log.i(LOGTAG, "Web Configuration, A/B Testing, and Dynamic Tweaks are not supported on this Android OS Version");
-            return new UnsupportedUpdatesFromMixpanel(sSharedTweaks);
+            return new NoOpUpdatesFromMixpanel(sSharedTweaks);
+        } else if (mConfig.getDisableViewCrawler()) {
+            return new NoOpUpdatesFromMixpanel(sSharedTweaks);
         } else {
             return new ViewCrawler(mContext, mToken, this, sSharedTweaks);
         }
@@ -1976,8 +1982,8 @@ public class MixpanelAPI {
         private final Executor mExecutor = Executors.newSingleThreadExecutor();
     }
 
-    private class UnsupportedUpdatesFromMixpanel implements UpdatesFromMixpanel {
-        public UnsupportedUpdatesFromMixpanel(Tweaks tweaks) {
+    /* package */ class NoOpUpdatesFromMixpanel implements UpdatesFromMixpanel {
+        public NoOpUpdatesFromMixpanel(Tweaks tweaks) {
             mTweaks = tweaks;
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1328,10 +1328,9 @@ public class MixpanelAPI {
     }
 
     /* package */ UpdatesFromMixpanel constructUpdatesFromMixpanel(final Context context, final String token) {
-        if (Build.VERSION.SDK_INT < MPConfig.UI_FEATURES_MIN_API) {
-            Log.i(LOGTAG, "Web Configuration, A/B Testing, and Dynamic Tweaks are not supported on this Android OS Version");
-            return new NoOpUpdatesFromMixpanel(sSharedTweaks);
-        } else if (mConfig.getDisableViewCrawler()) {
+        if (Build.VERSION.SDK_INT < MPConfig.UI_FEATURES_MIN_API
+            || mConfig.getDisableViewCrawler()) {
+            Log.i(LOGTAG, "Web Configuration, A/B Testing, and Dynamic Tweaks are disabled.");
             return new NoOpUpdatesFromMixpanel(sSharedTweaks);
         } else {
             return new ViewCrawler(mContext, mToken, this, sSharedTweaks);


### PR DESCRIPTION
Implements #276 

ViewCrawler will be on by default but can be turned off with: 

```
        <meta-data
            android:name="com.mixpanel.android.MPConfig.DisableViewCrawler"
            android:value="true"/>
```

