### PR TITLE
use device defaults for notification features

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
@@ -263,7 +263,8 @@ public class GCMReceiver extends BroadcastReceiver {
                 setWhen(System.currentTimeMillis()).
                 setContentTitle(notificationData.title).
                 setContentText(notificationData.message).
-                setContentIntent(intent);
+                setContentIntent(intent).
+                setDefaults(MPConfig.getInstance(context).getNotificationDefaults());
         final Notification n = builder.getNotification();
         n.flags |= Notification.FLAG_AUTO_CANCEL;
         return n;
@@ -278,7 +279,8 @@ public class GCMReceiver extends BroadcastReceiver {
                 setWhen(System.currentTimeMillis()).
                 setContentTitle(notificationData.title).
                 setContentText(notificationData.message).
-                setContentIntent(intent);
+                setContentIntent(intent).
+                setDefaults(MPConfig.getInstance(context).getNotificationDefaults());
 
         final Notification n = builder.getNotification();
         n.flags |= Notification.FLAG_AUTO_CANCEL;
@@ -295,7 +297,8 @@ public class GCMReceiver extends BroadcastReceiver {
                 setContentTitle(notificationData.title).
                 setContentText(notificationData.message).
                 setContentIntent(intent).
-                setStyle(new Notification.BigTextStyle().bigText(notificationData.message));
+                setStyle(new Notification.BigTextStyle().bigText(notificationData.message)).
+                setDefaults(MPConfig.getInstance(context).getNotificationDefaults());
 
         final Notification n = builder.build();
         n.flags |= Notification.FLAG_AUTO_CANCEL;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -178,6 +178,7 @@ public class MPConfig {
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
         mDisableViewCrawler = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableViewCrawler", false);
         mDisableDecideChecker = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableDecideChecker", false);
+        mNotificationDefaults = metaData.getInt("com.mixpanel.android.MPConfig.NotificationDefaults", 0);
 
         // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
@@ -250,7 +251,8 @@ public class MPConfig {
                 "    PeopleFallbackEndpoint " + getPeopleFallbackEndpoint() + "\n" +
                 "    DecideFallbackEndpoint " + getDecideFallbackEndpoint() + "\n" +
                 "    EditorUrl " + getEditorUrl() + "\n" +
-                "    DisableDecideChecker " + getDisableDecideChecker() + "\n"
+                "    DisableDecideChecker " + getDisableDecideChecker() + "\n" +
+                "    NotificationDefaults " + getNotificationDefaults() + "\n"
             );
         }
     }
@@ -349,6 +351,10 @@ public class MPConfig {
         return mDisableDecideChecker;
     }
 
+    public int getNotificationDefaults() {
+        return mNotificationDefaults;
+    }
+
     // Pre-configured package name for resources, if they differ from the application package name
     //
     // mContext.getPackageName() actually returns the "application id", which
@@ -408,6 +414,7 @@ public class MPConfig {
     private final String mEditorUrl;
     private final String mResourcePackageName;
     private final boolean mDisableDecideChecker;
+    private final int mNotificationDefaults;
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;


### PR DESCRIPTION
This includes sound, lights, and vibration settings.

Without this, `Notification.defaults` defaults to 0 while `Notification.DEFAULT_ALL` == -1, which will result in no vibration or sound for any notification, even when the user has set these to happen.

More info [here](http://developer.android.com/reference/android/app/Notification.html#defaults).
