### PR TITLE
Fix crash from ClassCastException when displaying in-app images

### DIFF
--- a/src/main/java/com/mixpanel/android/surveys/FadingImageView.java
+++ b/src/main/java/com/mixpanel/android/surveys/FadingImageView.java
@@ -43,7 +43,7 @@ public class FadingImageView extends ImageView {
         mHeight = getHeight();
         mWidth = getWidth();
         int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
-        LinearLayout container = (LinearLayout) getParent();
+        ViewGroup container = (ViewGroup) getParent();
 
         if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
             // For Portrait takeover notifications, we have to fade out into the notification text


### PR DESCRIPTION
A customer has highlighted this issue and its fix as an issue [here](https://github.com/mixpanel/mixpanel-android/issues/286).

Currently what happens is the linear layout cannot be applied when rendering an image, causing a crash to show on the device. Instead, the proposal is to grab the ViewGroup itself instead of LinearLayout -- the customer has confirmed this resolves the issues in their testing.