### PR TITLE
make survey prompt optional via metadata flag

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -178,6 +178,7 @@ public class MPConfig {
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
         mDisableViewCrawler = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableViewCrawler", false);
         mDisableDecideChecker = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableDecideChecker", false);
+        mShouldPromptForSurvey = metaData.getBoolean("com.mixpanel.android.MPConfig.ShouldPromptForSurvey", true);
 
         // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
@@ -250,7 +251,8 @@ public class MPConfig {
                 "    PeopleFallbackEndpoint " + getPeopleFallbackEndpoint() + "\n" +
                 "    DecideFallbackEndpoint " + getDecideFallbackEndpoint() + "\n" +
                 "    EditorUrl " + getEditorUrl() + "\n" +
-                "    DisableDecideChecker " + getDisableDecideChecker() + "\n"
+                "    DisableDecideChecker " + getDisableDecideChecker() + "\n" +
+                "    ShouldPromptForSurvey " + getShouldPromptForSurvey() + "\n"
             );
         }
     }
@@ -349,6 +351,10 @@ public class MPConfig {
         return mDisableDecideChecker;
     }
 
+    public boolean getShouldPromptForSurvey() {
+        return mShouldPromptForSurvey;
+    }
+
     // Pre-configured package name for resources, if they differ from the application package name
     //
     // mContext.getPackageName() actually returns the "application id", which
@@ -408,6 +414,7 @@ public class MPConfig {
     private final String mEditorUrl;
     private final String mResourcePackageName;
     private final boolean mDisableDecideChecker;
+    private final boolean mShouldPromptForSurvey;
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;

--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -277,26 +277,34 @@ public class SurveyActivity extends Activity {
             trackSurveyAttempted();
         }
 
-        final AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
-        alertBuilder.setTitle(R.string.com_mixpanel_android_survey_prompt_dialog_title);
-        alertBuilder.setMessage(R.string.com_mixpanel_android_survey_prompt_dialog_message);
-        alertBuilder.setPositiveButton(R.string.com_mixpanel_android_sure, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                SurveyActivity.this.findViewById(R.id.com_mixpanel_android_activity_survey_id).setVisibility(View.VISIBLE);
-                mSurveyBegun = true;
-                showQuestion(mCurrentQuestion);
-            }
-        });
-        alertBuilder.setNegativeButton(R.string.com_mixpanel_android_no_thanks, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                SurveyActivity.this.finish();
-            }
-        });
-        alertBuilder.setCancelable(false);
-        mDialog = alertBuilder.create();
-        mDialog.show();
+        if (MPConfig.getInstance(this).getShouldPromptForSurvey()) {
+            final AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+            alertBuilder.setTitle(R.string.com_mixpanel_android_survey_prompt_dialog_title);
+            alertBuilder.setMessage(R.string.com_mixpanel_android_survey_prompt_dialog_message);
+            alertBuilder.setPositiveButton(R.string.com_mixpanel_android_sure, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    startSurvey();
+                }
+            });
+            alertBuilder.setNegativeButton(R.string.com_mixpanel_android_no_thanks, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    SurveyActivity.this.finish();
+                }
+            });
+            alertBuilder.setCancelable(false);
+            mDialog = alertBuilder.create();
+            mDialog.show();
+        } else {
+            startSurvey();
+        }
+    }
+
+    private void startSurvey() {
+        SurveyActivity.this.findViewById(R.id.com_mixpanel_android_activity_survey_id).setVisibility(View.VISIBLE);
+        mSurveyBegun = true;
+        showQuestion(mCurrentQuestion);
     }
 
     @Override


### PR DESCRIPTION
Currently in the Mixpanel SDK for iOS, there is no prompt before the user is shown a survey.  We would like to replicate this on Android.  The intention of this change is to allow this to be configurable via a metadata tag in the app manifest, falling back to current behavior if this tag is not present.

Example usage:

```
    <meta-data
        android:name="com.mixpanel.android.MPConfig.ShouldPromptForSurvey"
        android:value="false"/>
```

If there is a more appropriate place for this flag, please let me know.
