### PR TITLE
fix for NPE in case if File.listFiles returns null

### DIFF
--- a/src/main/java/com/mixpanel/android/util/ImageStore.java
+++ b/src/main/java/com/mixpanel/android/util/ImageStore.java
@@ -105,12 +105,12 @@ public class ImageStore {
 
     public void clearStorage() {
         File[] files = mDirectory.listFiles();
-        int length = files.length;
-        for (int i = 0; i < length; i++) {
-            final File file = files[i];
-            final String filename = file.getName();
-            if (filename.startsWith(FILE_PREFIX)) {
-                final boolean ignored = file.delete();
+        if (null != files) {
+            for (final File file : files) {
+                final String filename = file.getName();
+                if (filename.startsWith(FILE_PREFIX)) {
+                    final boolean ignored = file.delete();
+                }
             }
         }
     }


### PR DESCRIPTION
fix for NPE found via ACRA, according http://developer.android.com/reference/java/io/File.html#listFiles(), `File.listFiles` can return `null`