### PR TITLE
Assign $experiments super property before $experiment_started event sends

### DIFF
--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -948,25 +948,28 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                         final JSONObject trackProps = new JSONObject();
                         trackProps.put("$experiment_id", experimentId);
                         trackProps.put("$variant_id", variantId);
-                        mMixpanel.track("$experiment_started", trackProps);
-
+                        
                         variantObject.put(Integer.toString(experimentId), variantId);
+
+                        mMixpanel.getPeople().merge("$experiments", variantObject);
+                        mMixpanel.updateSuperProperties(new SuperPropertyUpdate() {
+                            public JSONObject update(JSONObject in) {
+                                try {
+                                    in.put("$experiments", variantObject);
+                                } catch (JSONException e) {
+                                    Log.wtf(LOGTAG, "Can't write $experiments super property", e);
+                                }
+                                return in;
+                            }
+                        });
+
+                        mMixpanel.track("$experiment_started", trackProps);
                     }
                 } catch (JSONException e) {
                     Log.wtf(LOGTAG, "Could not build JSON for reporting experiment start", e);
                 }
 
-                mMixpanel.getPeople().merge("$experiments", variantObject);
-                mMixpanel.updateSuperProperties(new SuperPropertyUpdate() {
-                    public JSONObject update(JSONObject in) {
-                        try {
-                            in.put("$experiments", variantObject);
-                        } catch (JSONException e) {
-                            Log.wtf(LOGTAG, "Can't write $experiments super property", e);
-                        }
-                        return in;
-                    }
-                });
+                
             }
         }
 


### PR DESCRIPTION
Currently, the $experiments super property is not assigned until after the event sends marking the start of the experiment ($experiment_started). Instead, the super property should be assigned before the event, allowing for parity with iOS and for users to analyze this information correctly within the UI.

Tested on Jelly Bean (API level 16) and this change was successful in fixing the behavior.