### PR TITLE
Add app release prop & additional props for parity with iOS

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -507,8 +507,16 @@ import javax.net.ssl.SSLSocketFactory;
                 ret.put("$screen_width", displayMetrics.widthPixels);
 
                 final String applicationVersionName = mSystemInformation.getAppVersionName();
-                if (null != applicationVersionName)
+                if (null != applicationVersionName) {
                     ret.put("$app_version", applicationVersionName);
+                    ret.put("$app_version_string", applicationVersionName);
+                }
+
+                 final Integer applicationVersionCode = mSystemInformation.getAppVersionCode();
+                 if (null != applicationVersionCode) {
+                 	ret.put("$app_release", applicationVersionCode);
+                 	ret.put("$app_build_number", applicationVersionCode);
+                 }
 
                 final Boolean hasNFC = mSystemInformation.hasNFC();
                 if (null != hasNFC)

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -514,9 +514,9 @@ import javax.net.ssl.SSLSocketFactory;
 
                  final Integer applicationVersionCode = mSystemInformation.getAppVersionCode();
                  if (null != applicationVersionCode) {
-                 	ret.put("$app_release", applicationVersionCode);
-                 	ret.put("$app_build_number", applicationVersionCode);
-                 }
+                    ret.put("$app_release", applicationVersionCode);
+                    ret.put("$app_build_number", applicationVersionCode);
+                }
 
                 final Boolean hasNFC = mSystemInformation.hasNFC();
                 if (null != hasNFC)


### PR DESCRIPTION
For App Release, this property is currently tracked in iOS and missed on Android. This should be added for parity and allow for cross-platform comparisons between builds.

The additional properties are to correct for an error in prior iOS builds where the version and release have been flip-flopped (see PR [here](https://github.com/mixpanel/mixpanel-iphone/pull/304)). We need to add these new props in order to track Android data against iOS going forward without removing old functionality.