### PR TITLE
transaction.commit() might raise an IllegalStateException exception 

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -175,6 +175,12 @@ import java.util.Set;
         return notif;
     }
 
+    // if a notification was failed to show, add it back to the unseen list so that we
+    // won't lose it
+    public synchronized void handleNotificationDisplayFailure(InAppNotification notif) {
+        mUnseenNotifications.add(notif);
+    }
+
     public synchronized boolean hasUpdatesAvailable() {
         return (! mUnseenNotifications.isEmpty()) || (! mUnseenSurveys.isEmpty()) || mVariants != null;
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -120,7 +120,7 @@ import java.util.Set;
         }
         Survey s = mUnseenSurveys.remove(0);
         if (replace) {
-            mUnseenSurveys.add(mUnseenSurveys.size(), s);
+            mUnseenSurveys.add(s);
         }
         return s;
     }
@@ -152,7 +152,7 @@ import java.util.Set;
         }
         InAppNotification n = mUnseenNotifications.remove(0);
         if (replace) {
-            mUnseenNotifications.add(mUnseenNotifications.size(), n);
+            mUnseenNotifications.add(n);
         } else {
             if (MPConfig.DEBUG) {
                 Log.v(LOGTAG, "Recording notification " + n + " as seen.");

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -177,8 +177,8 @@ import java.util.Set;
 
     // if a notification was failed to show, add it back to the unseen list so that we
     // won't lose it
-    public synchronized void markNotificationAsUnseen(InAppNotification notif, boolean isDebugMode) {
-        if (!isDebugMode) {
+    public synchronized void markNotificationAsUnseen(InAppNotification notif) {
+        if (!MPConfig.DEBUG) {
             mUnseenNotifications.add(notif);
         }
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -177,8 +177,10 @@ import java.util.Set;
 
     // if a notification was failed to show, add it back to the unseen list so that we
     // won't lose it
-    public synchronized void handleNotificationDisplayFailure(InAppNotification notif) {
-        mUnseenNotifications.add(notif);
+    public synchronized void markNotificationAsUnseen(InAppNotification notif, boolean isDebugMode) {
+        if (!isDebugMode) {
+            mUnseenNotifications.add(notif);
+        }
     }
 
     public synchronized boolean hasUpdatesAvailable() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1891,7 +1891,15 @@ public class MixpanelAPI {
                                 final FragmentTransaction transaction = parent.getFragmentManager().beginTransaction();
                                 transaction.setCustomAnimations(0, R.anim.com_mixpanel_android_slide_down);
                                 transaction.add(android.R.id.content, inapp);
-                                transaction.commit();
+
+                                try {
+                                    transaction.commit();
+                                } catch (IllegalStateException e) {
+                                    // if the app is in the background or the current activity gets killed, rendering the
+                                    // notifiction will lead to a crash
+                                    Log.v(LOGTAG, "Unable to show notification.");
+                                    mDecideMessages.handleNotificationDisplayFailure(toShow);
+                                }
                             }
                             break;
                             case TAKEOVER: {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1900,7 +1900,7 @@ public class MixpanelAPI {
                                     if (MPConfig.DEBUG) {
                                         Log.v(LOGTAG, "Unable to show notification.");
                                     }
-                                    mDecideMessages.markNotificationAsUnseen(toShow, MPConfig.DEBUG);
+                                    mDecideMessages.markNotificationAsUnseen(toShow);
                                 }
                             }
                             break;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1897,8 +1897,10 @@ public class MixpanelAPI {
                                 } catch (IllegalStateException e) {
                                     // if the app is in the background or the current activity gets killed, rendering the
                                     // notifiction will lead to a crash
-                                    Log.v(LOGTAG, "Unable to show notification.");
-                                    mDecideMessages.handleNotificationDisplayFailure(toShow);
+                                    if (MPConfig.DEBUG) {
+                                        Log.v(LOGTAG, "Unable to show notification.");
+                                    }
+                                    mDecideMessages.markNotificationAsUnseen(toShow, MPConfig.DEBUG);
                                 }
                             }
                             break;


### PR DESCRIPTION
if the current activity is no long available. When that happens, we want to add the notification back to the list