### PR TITLE
Keep prior decide response on identify calls when distinct ID does not change

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -39,7 +39,7 @@ import java.util.Set;
     // Called from other synchronized code. Do not call into other synchronized code or you'll
     // risk deadlock
     public synchronized void setDistinctId(String distinctId) {
-        if (mDistinctId == null || (mDistinctId != null && !mDistictId.equals(distinctId))){
+        if (mDistinctId == null || !mDistictId.equals(distinctId)){
             mUnseenSurveys.clear();
             mUnseenNotifications.clear();
             mVariants = null;

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -39,7 +39,7 @@ import java.util.Set;
     // Called from other synchronized code. Do not call into other synchronized code or you'll
     // risk deadlock
     public synchronized void setDistinctId(String distinctId) {
-        if (mDistinctId.equals(distinctId)) {
+        if (mDistinctId != null && mDistinctId.equals(distinctId)) {
             return; // the user is the same, so no new response is needed
         } else {
             mUnseenSurveys.clear();

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -42,7 +42,6 @@ import java.util.Set;
         if (mDistinctId == null || !mDistictId.equals(distinctId)){
             mUnseenSurveys.clear();
             mUnseenNotifications.clear();
-            mVariants = null;
         }
         mDistinctId = distinctId;
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -39,7 +39,7 @@ import java.util.Set;
     // Called from other synchronized code. Do not call into other synchronized code or you'll
     // risk deadlock
     public synchronized void setDistinctId(String distinctId) {
-        if (mDistinctId == distinctId) {
+        if (mDistinctId.equals(distinctId)) {
             return; // the user is the same, so no new response is needed
         } else {
             mUnseenSurveys.clear();

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -39,14 +39,12 @@ import java.util.Set;
     // Called from other synchronized code. Do not call into other synchronized code or you'll
     // risk deadlock
     public synchronized void setDistinctId(String distinctId) {
-        if (mDistinctId != null && mDistinctId.equals(distinctId)) {
-            return; // the user is the same, so no new response is needed
-        } else {
+        if (mDistinctId == null || (mDistinctId != null && !mDistictId.equals(distinctId))){
             mUnseenSurveys.clear();
             mUnseenNotifications.clear();
-            mVariants = new JSONArray();
-            mDistinctId = distinctId;
+            mVariants = null;
         }
+        mDistinctId = distinctId;
     }
 
     public synchronized String getDistinctId() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -39,9 +39,14 @@ import java.util.Set;
     // Called from other synchronized code. Do not call into other synchronized code or you'll
     // risk deadlock
     public synchronized void setDistinctId(String distinctId) {
-        mUnseenSurveys.clear();
-        mUnseenNotifications.clear();
-        mDistinctId = distinctId;
+        if (mDistinctId == distinctId) {
+            return; // the user is the same, so no new response is needed
+        } else {
+            mUnseenSurveys.clear();
+            mUnseenNotifications.clear();
+            mVariants = new JSONArray();
+            mDistinctId = distinctId;
+        }
     }
 
     public synchronized String getDistinctId() {


### PR DESCRIPTION
Currently each time you call ```identify()``` or ```getPeople().identify()```, the library clears the decide response of all surveys and in-apps as indicated [here](https://github.com/mixpanel/mixpanel-android/blob/master/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java#L41-L45). While this makes sense when the ID for a user changes, this causes problems when the ID stays the same.

Instead of resetting each time, we should do a check on the distinct ID to see if it is the same or not -- if it is the same, we should hold the response. If the distinct ID is different, we should clear the response and make a new request to decide. One additional improvement on this clearing of the response is that we should clear variants in addition to surveys and notifications.

As it stands, the current SDK behavior causes issues for many users of the library. Since each one calls identify with different behavior each user has a different level of issues with this; however, they seem to be traced to this same root problem -- the SDK says a notification exists, the user calls identify, the decide response is cleared, and then they attempt to render a notification or survey which no longer exists.