### PR TITLE
Hide navigation bar when mini app notification appears

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
@@ -61,6 +61,11 @@ public class InAppFragment extends Fragment {
             return;
         }
 
+        View decorView = mParent.getWindow().getDecorView();
+        if (decorView != null) {
+            int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
+            decorView.setSystemUiVisibility(uiOptions);
+        }
         // We have to manually clear these Runnables in onStop in case they exist, since they
         // do illegal operations when onSaveInstanceState has been called already.
 
@@ -240,6 +245,13 @@ public class InAppFragment extends Fragment {
             transaction.setCustomAnimations(0, R.anim.com_mixpanel_android_slide_down).remove(this).commit();
             UpdateDisplayState.releaseDisplayState(mDisplayStateId);
             mCleanedUp = true;
+            
+            // reset ui
+            View decorView = mParent.getWindow().getDecorView();
+            if (decorView != null) {
+                int uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
+                decorView.setSystemUiVisibility(uiOptions);
+            }
         }
     }
 


### PR DESCRIPTION
When navigation bar is translucent mini app notification shows bellow the navigation bar.
With this fix before the notification shows we hide the navigation bar until the notification disappears
