### PR TITLE
Add event tracking when survey is received (parity with iOS)

### DIFF
--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -183,7 +183,7 @@ public class SurveyActivity extends Activity {
         });
         ctaButton.setOnTouchListener(new View.OnTouchListener() {
             @Override
-            public boolean onTouch(View v, MotionEvent event) {
+			public boolean onTouch(View v, MotionEvent event) {
                 if (event.getAction() == MotionEvent.ACTION_DOWN) {
                     v.setBackgroundResource(R.drawable.com_mixpanel_android_cta_button_highlight);
                 } else {

--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -183,7 +183,7 @@ public class SurveyActivity extends Activity {
         });
         ctaButton.setOnTouchListener(new View.OnTouchListener() {
             @Override
-			public boolean onTouch(View v, MotionEvent event) {
+            public boolean onTouch(View v, MotionEvent event) {
                 if (event.getAction() == MotionEvent.ACTION_DOWN) {
                     v.setBackgroundResource(R.drawable.com_mixpanel_android_cta_button_highlight);
                 } else {
@@ -324,6 +324,7 @@ public class SurveyActivity extends Activity {
                 final UpdateDisplayState.DisplayState.SurveyState surveyState = getSurveyState();
                 final Survey survey = surveyState.getSurvey();
                 final List<Survey.Question> questionList = survey.getQuestions();
+                int answerCount = 0;
 
                 final String answerDistinctId = mUpdateDisplayState.getDistinctId();
                 final MixpanelAPI.People people = mMixpanel.getPeople().withIdentity(answerDistinctId);
@@ -346,11 +347,27 @@ public class SurveyActivity extends Activity {
                             answerJson.put("$value", answerString);
 
                             people.append("$answers", answerJson);
+
+                            answerCount = answerCount + 1;
                         } catch (final JSONException e) {
                             Log.e(LOGTAG, "Couldn't record user's answer.", e);
                         }
                     } // if answer is present
                 } // For each question
+                try {
+                    final JSONObject surveyJson = new JSONObject();
+                    surveyJson.put("survey_id", survey.getId());
+                    surveyJson.put("collection_id", survey.getCollectionId());
+                    surveyJson.put("$answer_count", answerCount);
+                    if (answerCount > 0) {
+                        surveyJson.put("$survey_shown", true);
+                    } else {
+                        surveyJson.put("$survey_shown", false);
+                    }
+                    mMixpanel.track("$show_survey", surveyJson);
+                } catch (final JSONException e) {
+                    Log.e(LOGTAG, "Couldn't record survey shown.", e);
+                } // track the survey as received
             } // if we have a survey state
             mMixpanel.flush();
         } // if we initialized property and we have a mixpanel

--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -359,11 +359,7 @@ public class SurveyActivity extends Activity {
                     surveyJson.put("survey_id", survey.getId());
                     surveyJson.put("collection_id", survey.getCollectionId());
                     surveyJson.put("$answer_count", answerCount);
-                    if (answerCount > 0) {
-                        surveyJson.put("$survey_shown", true);
-                    } else {
-                        surveyJson.put("$survey_shown", false);
-                    }
+                    surveyJson.put("$survey_shown", mSurveyBegun);
                     mMixpanel.track("$show_survey", surveyJson);
                 } catch (final JSONException e) {
                     Log.e(LOGTAG, "Couldn't record survey shown.", e);


### PR DESCRIPTION
Currently iOS tracks that a survey is received [here](https://github.com/mixpanel/mixpanel-iphone/blob/2106d67e4197b3244f202793d54d6e580152773e/Mixpanel/Mixpanel.m#L1521-L1525) whereas Android does not track any event to indicate a survey has been received.

This PR adds support for the same event and properties as sent from iOS to be sent when a survey is received on Android for parity.