### PR TITLE
Adding flags to disable notifications & surveys to avoid unneeded decide requests

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -170,14 +170,13 @@ public class MPConfig {
         mFlushInterval = metaData.getInt("com.mixpanel.android.MPConfig.FlushInterval", 60 * 1000); // one minute default
         mDebugFlushInterval = metaData.getInt("com.mixpanel.android.MPConfig.DebugFlushInterval", 1 * 1000); // one second default
         mDataExpiration = metaData.getInt("com.mixpanel.android.MPConfig.DataExpiration",  1000 * 60 * 60 * 24 * 5); // 5 days default
-        mMinimumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MinimumDatabaseLimit",  20 * 1024 * 1024); // 20 Mb
+        mMinimumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MinimumDatabaseLimit", 20 * 1024 * 1024); // 20 Mb
         mDisableFallback = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableFallback", true);
         mResourcePackageName = metaData.getString("com.mixpanel.android.MPConfig.ResourcePackageName"); // default is null
         mDisableGestureBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableGestureBindingUI", false);
         mDisableEmulatorBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableEmulatorBindingUI", false);
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
-        mDisableNotifications = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableNotifications", false);
-        mDisableSurveys = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableSurveys", false);
+        mDisableDecideChecker = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableDecideChecker", false);
 
          // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
@@ -249,8 +248,7 @@ public class MPConfig {
                 "    PeopleFallbackEndpoint " + getPeopleFallbackEndpoint() + "\n" +
                 "    DecideFallbackEndpoint " + getDecideFallbackEndpoint() + "\n" +
                 "    EditorUrl " + getEditorUrl() + "\n" +
-                "    DisableNotifications " + getDisableNotifications() + "\n" +
-                "    DisableSurveys " + getDisableSurveys() + "\n"
+                "    DisableDecideChecker " + getDisableDecideChecker() + "\n"
             );
         }
     }
@@ -341,12 +339,8 @@ public class MPConfig {
         return mEditorUrl;
     }
 
-    public boolean getDisableSurveys() {
-        return mDisableSurveys;
-    }
-
-    public boolean getDisableNotifications() {
-        return mDisableNotifications;
+    public boolean getDisableDecideChecker() {
+        return mDisableDecideChecker;
     }
 
     // Pre-configured package name for resources, if they differ from the application package name
@@ -406,8 +400,7 @@ public class MPConfig {
     private final boolean mAutoShowMixpanelUpdates;
     private final String mEditorUrl;
     private final String mResourcePackageName;
-    private final boolean mDisableNotifications;
-    private final boolean mDisableSurveys;
+    private final boolean mDisableDecideChecker;
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -176,6 +176,8 @@ public class MPConfig {
         mDisableGestureBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableGestureBindingUI", false);
         mDisableEmulatorBindingUI = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableEmulatorBindingUI", false);
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
+        mDisableNotifications = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableNotifications", false);
+        mDisableSurveys = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableSurveys", false);
 
          // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
@@ -246,7 +248,9 @@ public class MPConfig {
                 "    EventsFallbackEndpoint " + getEventsFallbackEndpoint() + "\n" +
                 "    PeopleFallbackEndpoint " + getPeopleFallbackEndpoint() + "\n" +
                 "    DecideFallbackEndpoint " + getDecideFallbackEndpoint() + "\n" +
-                "    EditorUrl " + getEditorUrl() + "\n"
+                "    EditorUrl " + getEditorUrl() + "\n" +
+                "    DisableNotifications " + getDisableNotifications() + "\n" +
+                "    DisableSurveys " + getDisableSurveys() + "\n"
             );
         }
     }
@@ -337,6 +341,14 @@ public class MPConfig {
         return mEditorUrl;
     }
 
+    public boolean getDisableSurveys() {
+        return mDisableSurveys;
+    }
+
+    public boolean getDisableNotifications() {
+        return mDisableNotifications;
+    }
+
     // Pre-configured package name for resources, if they differ from the application package name
     //
     // mContext.getPackageName() actually returns the "application id", which
@@ -394,6 +406,8 @@ public class MPConfig {
     private final boolean mAutoShowMixpanelUpdates;
     private final String mEditorUrl;
     private final String mResourcePackageName;
+    private final boolean mDisableNotifications;
+    private final boolean mDisableSurveys;
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -231,9 +231,9 @@ public class MixpanelAPI {
         mDecideMessages.setDistinctId(decideId);
         mMessages = getAnalyticsMessages();
 
-		if (!mConfig.getDisableSurveys() || !mConfig.getDisableNotifications()) {
-			mMessages.installDecideCheck(mDecideMessages);
-		}
+        if (!mConfig.getDisableDecideChecker()) {
+            mMessages.installDecideCheck(mDecideMessages);
+        }
 
         registerMixpanelActivityLifecycleCallbacks();
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -230,7 +230,10 @@ public class MixpanelAPI {
         }
         mDecideMessages.setDistinctId(decideId);
         mMessages = getAnalyticsMessages();
-        mMessages.installDecideCheck(mDecideMessages);
+
+		if (!mConfig.getDisableSurveys() || !mConfig.getDisableNotifications()) {
+			mMessages.installDecideCheck(mDecideMessages);
+		}
 
         registerMixpanelActivityLifecycleCallbacks();
 


### PR DESCRIPTION
Hello,

in our application we use the Mixpanel track to send usage statistics, but we don't use the notification/surveys features. We've seen that we're sending so many unnecessary requests to _decide_, just to get always the same empty response. We thought that it would be interesting to be able to configure the _decide_ behaviour to just not perform those requests when we are sure that we will not use them.

Thanks in advance.