### PR TITLE
Exit A/B test experiments when they are turned off

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -30,9 +30,7 @@ import java.util.Set;
         mUnseenNotifications = new LinkedList<InAppNotification>();
         mSurveyIds = new HashSet<Integer>();
         mNotificationIds = new HashSet<Integer>();
-        if(mVariants == null) {
-            mVariants = new JSONArray();
-        }
+        mVariants = new JSONArray();
     }
 
     public String getToken() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -30,6 +30,9 @@ import java.util.Set;
         mUnseenNotifications = new LinkedList<InAppNotification>();
         mSurveyIds = new HashSet<Integer>();
         mNotificationIds = new HashSet<Integer>();
+        if(mVariants == null) {
+            mVariants = new JSONArray();
+        }
     }
 
     public String getToken() {
@@ -105,9 +108,9 @@ import java.util.Set;
         }
 
         // in the case we do not receive a new variant, this means the A/B test should be turned off
-        if(!hasNewVariants && newVariantsLength == 0) {
+        if(newVariantsLength == 0) {
             mLoadedVariants.clear();
-            mVariants = null;
+            mVariants = new JSONArray();
             newContent = true;
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -77,6 +77,8 @@ import java.util.Set;
         int newVariantsLength = variants.length();
         boolean hasNewVariants = false;
 
+        Log.d("Variants", "New variants length: " + newVariantsLength);
+
         for (int i = 0; i < newVariantsLength; i++) {
             try {
                 JSONObject variant = variants.getJSONObject(i);
@@ -91,6 +93,10 @@ import java.util.Set;
             }
         }
 
+        Log.d("Variants", "New variants? " + hasNewVariants);
+        Log.d("Variants", "Currently loaded variants: " + mLoadedVariants);
+        Log.d("Variants", "Current variants: " + mVariants);
+
         if (hasNewVariants) {
             mLoadedVariants.clear();
 
@@ -104,12 +110,25 @@ import java.util.Set;
             }
         }
 
+        // in case we do not receive a new variant, this means the A/B test should be turned off
+        if(!hasNewVariants && newVariantsLength == 0) {
+            Log.e("Variants", "Attempting to clear due to disabled experiment");
+            mLoadedVariants.clear();
+            mVariants = null;
+            newContent = true;
+        }
+
+        Log.d("Variants", "Currently loaded variants: " + mLoadedVariants);
+        Log.d("Variants", "Current variants: " + mVariants);
+
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +
                     newSurveys.size() + " surveys, " +
                     newNotifications.size() + " notifications and " +
                     variants.length() + " experiments have been added.");
         }
+
+        Log.d("Variants", "Are we returning an update? " + hasUpdatesAvailable());
 
         if (newContent && hasUpdatesAvailable() && null != mListener) {
             mListener.onNewResults();

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -77,8 +77,6 @@ import java.util.Set;
         int newVariantsLength = variants.length();
         boolean hasNewVariants = false;
 
-        Log.d("Variants", "New variants length: " + newVariantsLength);
-
         for (int i = 0; i < newVariantsLength; i++) {
             try {
                 JSONObject variant = variants.getJSONObject(i);
@@ -93,10 +91,6 @@ import java.util.Set;
             }
         }
 
-        Log.d("Variants", "New variants? " + hasNewVariants);
-        Log.d("Variants", "Currently loaded variants: " + mLoadedVariants);
-        Log.d("Variants", "Current variants: " + mVariants);
-
         if (hasNewVariants) {
             mLoadedVariants.clear();
 
@@ -110,16 +104,12 @@ import java.util.Set;
             }
         }
 
-        // in case we do not receive a new variant, this means the A/B test should be turned off
+        // in the case we do not receive a new variant, this means the A/B test should be turned off
         if(!hasNewVariants && newVariantsLength == 0) {
-            Log.e("Variants", "Attempting to clear due to disabled experiment");
             mLoadedVariants.clear();
             mVariants = null;
             newContent = true;
         }
-
-        Log.d("Variants", "Currently loaded variants: " + mLoadedVariants);
-        Log.d("Variants", "Current variants: " + mVariants);
 
         if (MPConfig.DEBUG) {
             Log.v(LOGTAG, "New Decide content has become available. " +
@@ -127,8 +117,6 @@ import java.util.Set;
                     newNotifications.size() + " notifications and " +
                     variants.length() + " experiments have been added.");
         }
-
-        Log.d("Variants", "Are we returning an update? " + hasUpdatesAvailable());
 
         if (newContent && hasUpdatesAvailable() && null != mListener) {
             mListener.onNewResults();

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1605,11 +1605,7 @@ public class MixpanelAPI {
         @Override
         public void joinExperimentIfAvailable() {
             final JSONArray variants = mDecideMessages.getVariants();
-            Log.d("Variants", "What is decide returning? " + variants);
-            //if (null != variants) {
-                Log.d("Variants", "It's still running");
-                mUpdatesFromMixpanel.setVariants(variants);
-            //}
+            mUpdatesFromMixpanel.setVariants(variants);
         }
 
         @Override
@@ -1968,8 +1964,6 @@ public class MixpanelAPI {
     private class SupportedUpdatesListener implements UpdatesListener, Runnable {
         @Override
         public void onNewResults() {
-            Log.d("Variants", "onNewResults executing");
-            Log.d("Variants", "what is this?" + this);
             mExecutor.execute(this);
         }
 
@@ -1992,7 +1986,6 @@ public class MixpanelAPI {
             // It's possible that by the time this has run the updates we detected are no longer
             // present, which is ok.
             for (final OnMixpanelUpdatesReceivedListener listener : mListeners) {
-                Log.d("Variants", "Running for each listener");
                 listener.onMixpanelUpdatesReceived();
             }
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1605,9 +1605,11 @@ public class MixpanelAPI {
         @Override
         public void joinExperimentIfAvailable() {
             final JSONArray variants = mDecideMessages.getVariants();
-            if (null != variants) {
+            Log.d("Variants", "What is decide returning? " + variants);
+            //if (null != variants) {
+                Log.d("Variants", "It's still running");
                 mUpdatesFromMixpanel.setVariants(variants);
-            }
+            //}
         }
 
         @Override
@@ -1966,6 +1968,8 @@ public class MixpanelAPI {
     private class SupportedUpdatesListener implements UpdatesListener, Runnable {
         @Override
         public void onNewResults() {
+            Log.d("Variants", "onNewResults executing");
+            Log.d("Variants", "what is this?" + this);
             mExecutor.execute(this);
         }
 
@@ -1988,6 +1992,7 @@ public class MixpanelAPI {
             // It's possible that by the time this has run the updates we detected are no longer
             // present, which is ok.
             for (final OnMixpanelUpdatesReceivedListener listener : mListeners) {
+                Log.d("Variants", "Running for each listener");
                 listener.onMixpanelUpdatesReceived();
             }
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -57,6 +57,10 @@ public class Tweaks {
         return new HashMap<String, TweakValue>(mTweakValues);
     }
 
+    public synchronized Map<String, TweakValue> getDefaultValues() {
+        return new HashMap<String, TweakValue>(mTweakDefaultValues);
+    }
+
     @IntDef({
             BOOLEAN_TYPE,
             DOUBLE_TYPE,
@@ -197,6 +201,7 @@ public class Tweaks {
 
     /* package */ Tweaks() {
         mTweakValues = new HashMap<String, TweakValue>();
+        mTweakDefaultValues = new HashMap<String, TweakValue>();
         mTweakDeclaredListeners = new ArrayList<OnTweakDeclaredListener>();
     }
 
@@ -307,6 +312,7 @@ public class Tweaks {
 
         final TweakValue value = new TweakValue(tweakType, defaultValue, null, null, defaultValue);
         mTweakValues.put(tweakName, value);
+        mTweakDefaultValues.put(tweakName, value);
         final int listenerSize = mTweakDeclaredListeners.size();
         for (int i = 0; i < listenerSize; i++) {
             mTweakDeclaredListeners.get(i).onTweakDeclared();
@@ -315,6 +321,7 @@ public class Tweaks {
 
     // All access to mTweakValues must be synchronized
     private final Map<String, TweakValue> mTweakValues;
+    private final Map<String, TweakValue> mTweakDefaultValues;
     private final List<OnTweakDeclaredListener> mTweakDeclaredListeners;
 
     private static final String LOGTAG = "MixpanelAPI.Tweaks";

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -754,7 +754,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
         private void handleVariantsReceived(JSONArray variants) {
             final SharedPreferences preferences = getSharedPreferences();
             final SharedPreferences.Editor editor = preferences.edit();
-            if(variants != null) {
+            if(variants.length() > 0) {
                 editor.putString(SHARED_PREF_CHANGES_KEY, variants.toString());
             } else {
                 editor.remove(SHARED_PREF_CHANGES_KEY);

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -108,6 +108,8 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
     public void setVariants(JSONArray variants) {
         final Message msg = mMessageThreadHandler.obtainMessage(ViewCrawler.MESSAGE_VARIANTS_RECEIVED);
         msg.obj = variants;
+        Log.d("Variants", "Setting variants");
+        Log.d("Variants", "variants are" + variants);
         mMessageThreadHandler.sendMessage(msg);
     }
 
@@ -311,6 +313,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                         break;
                     case MESSAGE_VARIANTS_RECEIVED:
                         handleVariantsReceived((JSONArray) msg.obj);
+                        Log.d("Variants", "Running in handler");
                         break;
                     case MESSAGE_HANDLE_EDITOR_CHANGES_RECEIVED:
                         handleEditorChangeReceived((JSONObject) msg.obj);
@@ -374,6 +377,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
             final String storedChanges = preferences.getString(SHARED_PREF_CHANGES_KEY, null);
             final String storedBindings = preferences.getString(SHARED_PREF_BINDINGS_KEY, null);
             List<Pair<Integer, Integer>> emptyVariantIds = new ArrayList<>();
+            Log.d("Variants", "Stored changes " + storedChanges);
 
             try {
                 if (null != storedChanges) {
@@ -382,6 +386,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
 
                     final JSONArray variants = new JSONArray(storedChanges);
                     final int variantsLength = variants.length();
+                    Log.d("Variants", "Variant length " + variantsLength);
                     for (int variantIx = 0; variantIx < variantsLength; variantIx++) {
                         final JSONObject nextVariant = variants.getJSONObject(variantIx);
                         final int variantIdPart = nextVariant.getInt("id");
@@ -409,6 +414,20 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                             final Pair<Integer, Integer> emptyVariantId = new Pair<Integer, Integer>(experimentIdPart, variantIdPart);
                             emptyVariantIds.add(emptyVariantId);
                         }
+                    }
+                } else {
+                    Log.d("Variants2", "Persistent tweaks: " + mPersistentTweaks);
+                    mPersistentChanges.clear();
+                    mPersistentTweaks.clear();
+
+                    final Map<String, Tweaks.TweakValue> tweakDefaults = mTweaks.getDefaultValues();
+                    Log.d("Variants2", "Map is " + tweakDefaults);
+                    for (Map.Entry<String, Tweaks.TweakValue> tweak:tweakDefaults.entrySet()) {
+                        final Tweaks.TweakValue value = tweak.getValue();
+                        final String tweakName = tweak.getKey();
+                        Log.d("Variants2", "tweak name " + tweakName);
+                        Log.d("Variants2", "tweak value" + value);
+                        mTweaks.set(tweakName, value);
                     }
                 }
 
@@ -754,7 +773,12 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
         private void handleVariantsReceived(JSONArray variants) {
             final SharedPreferences preferences = getSharedPreferences();
             final SharedPreferences.Editor editor = preferences.edit();
-            editor.putString(SHARED_PREF_CHANGES_KEY, variants.toString());
+            Log.d("Variants", "Changes being applied");
+            if(variants != null) {
+                editor.putString(SHARED_PREF_CHANGES_KEY, variants.toString());
+            } else {
+                editor.remove(SHARED_PREF_CHANGES_KEY);
+            }
             editor.apply();
 
             initializeChanges();
@@ -836,7 +860,9 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
 
             {
                 final int size = mPersistentChanges.size();
+                Log.d("Variants2", "Persistent changes " + mPersistentChanges);
                 for (int i = 0; i < size; i++) {
+                    Log.d("Variants2", "Editing persistent changes");
                     final VariantChange changeInfo = mPersistentChanges.get(i);
                     try {
                         final EditProtocol.Edit edit = mProtocol.readEdit(changeInfo.change);
@@ -856,10 +882,15 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
 
             {
                 final int size = mPersistentTweaks.size();
+                Log.d("Variants2", "Persistent tweaks " + mPersistentTweaks);
                 for (int i = 0; i < size; i++) {
+                    Log.d("Variants2", "Editing persistent tweaks");
                     final VariantTweak tweakInfo = mPersistentTweaks.get(i);
                     try {
                         final Pair<String, Object> tweakValue = mProtocol.readTweak(tweakInfo.tweak);
+                        Log.d("Variants2", "The tweaks info is: " + tweakInfo + tweakInfo.tweak);
+                        Log.d("Variants2", "The tweaks are: " + tweakValue.first + tweakValue.second);
+                        Log.d("Variants2", "mTweaks is: " + mTweaks);
                         mTweaks.set(tweakValue.first, tweakValue.second);
                         if (!mSeenExperiments.contains(tweakInfo.variantId)) {
                             toTrack.add(tweakInfo.variantId);

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -410,13 +410,6 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                             emptyVariantIds.add(emptyVariantId);
                         }
                     }
-                } else {
-                    final Map<String, Tweaks.TweakValue> tweakDefaults = mTweaks.getDefaultValues();
-                    for (Map.Entry<String, Tweaks.TweakValue> tweak:tweakDefaults.entrySet()) {
-                        final Tweaks.TweakValue tweakValue = tweak.getValue();
-                        final String tweakName = tweak.getKey();
-                        mTweaks.set(tweakName, tweakValue);
-                    }
                 }
 
                 if (null != storedBindings) {
@@ -877,6 +870,14 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                         }
                     } catch (EditProtocol.BadInstructionsException e) {
                         Log.e(LOGTAG, "Bad editor tweak cannot be applied.", e);
+                    }
+                }
+                if(size == 0) { // there are no new tweaks, so reset to default values
+                    final Map<String, Tweaks.TweakValue> tweakDefaults = mTweaks.getDefaultValues();
+                    for (Map.Entry<String, Tweaks.TweakValue> tweak:tweakDefaults.entrySet()) {
+                        final Tweaks.TweakValue tweakValue = tweak.getValue();
+                        final String tweakName = tweak.getKey();
+                        mTweaks.set(tweakName, tweakValue);
                     }
                 }
             }

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -380,11 +380,8 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                 mPersistentTweaks.clear();
 
                 if (null != storedChanges) {
-                    
-
                     final JSONArray variants = new JSONArray(storedChanges);
                     final int variantsLength = variants.length();
-                    Log.d("Variants", "Variant length " + variantsLength);
                     for (int variantIx = 0; variantIx < variantsLength; variantIx++) {
                         final JSONObject nextVariant = variants.getJSONObject(variantIx);
                         final int variantIdPart = nextVariant.getInt("id");


### PR DESCRIPTION
Currently a device will have many difficulties exiting an A/B test -- there are a multitude of conditional statements within the library which never trigger an update when a test is turned off from the Mixpanel UI. Instead, the device will continue to use the most recently cached A/B test experiment.

This PR adds support for leaving an A/B test once it is turned off. It will trigger an update to A/B test info when no new variants are received, and then process this case specially to reset all tweaks to their default values and remove all UI changes.