### PR TITLE
Added Client Offline Mode

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
+++ b/src/androidTest/java/com/mixpanel/android/viewcrawler/ImageStoreTest.java
@@ -7,6 +7,7 @@ import android.test.AndroidTestCase;
 import android.util.Base64;
 
 import com.mixpanel.android.util.ImageStore;
+import com.mixpanel.android.util.OfflineMode;
 import com.mixpanel.android.util.RemoteService;
 
 import java.io.IOException;
@@ -71,7 +72,7 @@ public class ImageStoreTest extends AndroidTestCase {
         }
 
         @Override
-        public boolean isOnline(final Context context) {
+        public boolean isOnline(final Context context, OfflineMode offlineMode) {
             return online;
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -378,7 +378,7 @@ import javax.net.ssl.SSLSocketFactory;
 
             private void sendAllData(MPDbAdapter dbAdapter) {
                 final RemoteService poster = getPoster();
-                if (!poster.isOnline(mContext)) {
+                if (!poster.isOnline(mContext, mConfig.getOfflineMode())) {
                     logAboutMessageToMixpanel("Not flushing data to Mixpanel because the device is not connected to the internet.");
                     return;
                 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
@@ -3,7 +3,6 @@ package com.mixpanel.android.mpmetrics;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Point;
 import android.os.Build;
 import android.util.Log;
@@ -23,7 +22,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -278,14 +276,15 @@ import javax.net.ssl.SSLSocketFactory;
 
     private static byte[] getUrls(RemoteService poster, Context context, String[] urls)
         throws RemoteService.ServiceUnavailableException {
-        if (!poster.isOnline(context)) {
+        final MPConfig config = MPConfig.getInstance(context);
+
+        if (!poster.isOnline(context, config.getOfflineMode())) {
             return null;
         }
 
         byte[] response = null;
         for (String url : urls) {
             try {
-                final MPConfig config = MPConfig.getInstance(context);
                 final SSLSocketFactory socketFactory = config.getSSLSocketFactory();
                 response = poster.performRequest(url, null, socketFactory);
                 break;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -7,6 +7,8 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.mixpanel.android.util.OfflineMode;
+
 import java.security.GeneralSecurityException;
 
 import javax.net.ssl.SSLContext;
@@ -142,6 +144,31 @@ public class MPConfig {
      */
     public synchronized void setSSLSocketFactory(SSLSocketFactory factory) {
         mSSLSocketFactory = factory;
+    }
+
+    /**
+     * {@link OfflineMode} allows Mixpanel to be in-sync with client offline internal logic.
+     * If you want to integrate your own logic with Mixpanel you'll need to call
+     * {@link #setOfflineMode(OfflineMode)} early in your code, like this
+     *
+     * {@code
+     * <pre>
+     *     MPConfig.getInstance(context).setOfflineMode(OfflineModeImplementation);
+     * </pre>
+     * }
+     *
+     * Your settings will be globally available to all Mixpanel instances, and will be used across
+     * all the library. The call is thread safe, but should be done before
+     * your first call to MixpanelAPI.getInstance to insure that the library never uses it's
+     * default.
+     *
+     * The given {@link OfflineMode} may be used from multiple threads, you should ensure that
+     * your implementation is thread-safe before passing it to Mixpanel.
+     *
+     * @param offlineMode client offline implementation to use on Mixpanel
+     */
+    public synchronized void setOfflineMode(OfflineMode offlineMode) {
+        mOfflineMode = offlineMode;
     }
 
     /* package */ MPConfig(Bundle metaData, Context context) {
@@ -363,6 +390,11 @@ public class MPConfig {
         return mSSLSocketFactory;
     }
 
+    // This method is thread safe, and assumes that OfflineMode is also thread safe
+    public synchronized OfflineMode getOfflineMode() {
+        return mOfflineMode;
+    }
+
     ///////////////////////////////////////////////
 
     // Package access for testing only- do not call directly in library code
@@ -403,6 +435,7 @@ public class MPConfig {
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;
+    private OfflineMode mOfflineMode;
 
     private static MPConfig sInstance;
     private static final Object sInstanceLock = new Object();

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -55,8 +55,9 @@ public class HttpService implements RemoteService {
     }
 
     @Override
-    public boolean isOnline(Context context) {
+    public boolean isOnline(Context context, OfflineMode offlineMode) {
         if (sIsMixpanelBlocked) return false;
+        if (onOfflineMode(offlineMode)) return false;
 
         boolean isOnline;
         try {
@@ -74,6 +75,21 @@ public class HttpService implements RemoteService {
             }
         }
         return isOnline;
+    }
+
+    private boolean onOfflineMode(OfflineMode offlineMode) {
+        boolean onOfflineMode;
+
+        try {
+            onOfflineMode = offlineMode != null && offlineMode.isOffline();
+        } catch (Exception e) {
+            onOfflineMode = false;
+            if (MPConfig.DEBUG) {
+                Log.v(LOGTAG, "Client State should not throw exception, will assume is not on offline mode", e);
+            }
+        }
+
+        return onOfflineMode;
     }
 
     @Override

--- a/src/main/java/com/mixpanel/android/util/OfflineMode.java
+++ b/src/main/java/com/mixpanel/android/util/OfflineMode.java
@@ -1,0 +1,16 @@
+package com.mixpanel.android.util;
+
+/**
+ * Implement this to allow Mixpanel behave in-sync with your current custom offline logic
+ */
+public interface OfflineMode {
+
+    /**
+     * Returns true if offline-mode is active on the client. When true Mixpanel will not start
+     * new connections, but current active connections will not be interrupted.
+     *
+     * @return true if offline mode is active, false otherwise
+     */
+    boolean isOffline();
+
+}

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -10,7 +10,7 @@ import javax.net.ssl.SSLSocketFactory;
 
 
 public interface RemoteService {
-    boolean isOnline(Context context);
+    boolean isOnline(Context context, OfflineMode offlineMode);
 
     void checkIsMixpanelBlocked();
 


### PR DESCRIPTION
Added OfflineMode configuration parameter on MPConfig to work in-sync
with client built-in offline mode. When set all the calls to
HttpService.isOnline will check the current Offline mode status of the
client and honor it.