### PR TITLE
Update OnMixpanelUpdatesReceivedListener when A/B test is exited

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -119,7 +119,7 @@ import java.util.Set;
                     variants.length() + " experiments have been added.");
         }
 
-        if (newContent && hasUpdatesAvailable() && null != mListener) {
+        if (newContent && null != mListener) {
             mListener.onNewResults();
         }
     }
@@ -194,7 +194,7 @@ import java.util.Set;
     }
 
     public synchronized boolean hasUpdatesAvailable() {
-        return (! mUnseenNotifications.isEmpty()) || (! mUnseenSurveys.isEmpty()) || mVariants != null;
+        return (! mUnseenNotifications.isEmpty()) || (! mUnseenSurveys.isEmpty()) || mVariants.length() > 0;
     }
 
     // Mutable, must be synchronized


### PR DESCRIPTION
This change sends an update to OnMixpanelUpdatesReceivedListener when an A/B test is exited. This improves the functionality included in https://github.com/mixpanel/mixpanel-android/pull/330