### PR TITLE
Reset A/B tests on reset() call

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -714,10 +714,11 @@ public class MixpanelAPI {
      * Will not clear referrer information.
      */
     public void reset() {
-        // Will clear distinct_ids, superProperties,
+        // Will clear distinct_ids, superProperties, experiments,
         // and waiting People Analytics properties. Will have no effect
         // on messages already queued to send with AnalyticsMessages.
         mPersistentIdentity.clearPreferences();
+        identify(getDistinctId());
     }
 
     /**

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -714,11 +714,12 @@ public class MixpanelAPI {
      * Will not clear referrer information.
      */
     public void reset() {
-        // Will clear distinct_ids, superProperties, experiments,
+        // Will clear distinct_ids, superProperties, notifications, surveys, experiments,
         // and waiting People Analytics properties. Will have no effect
         // on messages already queued to send with AnalyticsMessages.
         mPersistentIdentity.clearPreferences();
         identify(getDistinctId());
+        flush();
     }
 
     /**


### PR DESCRIPTION
Currently A/B test data is not refreshed on a ```reset()``` call from ```MixpanelAPI```. Since reset is supposed to be a fresh instance of MixpanelAPI, the A/B test data from the old user should also be removed.

Let me know if I should be calling to ```mDecideMessages``` directly as opposed to using the ```identify()``` method. The line that needs to trigger to reset the experiment data is [here](https://github.com/mixpanel/mixpanel-android/blob/master/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java#L406).