### PR TITLE
Add remove people operator + Ability to remove single push device token

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1728,15 +1728,8 @@ public class MixpanelAPI {
 
         @Override
         public void clearSinglePushRegistrationId(String registrationId) {
-            // Must be thread safe, will be called from a lot of different threads.
-            synchronized (mPersistentIdentity) {
-                if (mPersistentIdentity.getPeopleDistinctId() == null) {
-                    return;
-                }
-
-                mPersistentIdentity.clearPushId();
-                remove("$android_devices", registrationId);
-            }
+            remove("$android_devices", registrationId);
+            mPersistentIdentity.clearPushId();
         }
 
         @Override

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1039,8 +1039,8 @@ public class MixpanelAPI {
          * <p>{@link People#clearPushRegistrationId} should only be called after {@link #identify(String)} has been called.
          *
          * <p>In general, all applications that call {@link #setPushRegistrationId(String)} should include a call to
-         * clearPushRegistrationId or clearPushRegistrationId, and no applications that call
-         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearPushRegistrationId
+         * clearPushRegistrationId, and no applications that call
+         * {@link #initPushHandling(String)} should call clearPushRegistrationId
          */
         public void clearPushRegistrationId();
 
@@ -1054,8 +1054,8 @@ public class MixpanelAPI {
          * <p>{@link People#clearPushRegistrationId} should only be called after {@link #identify(String)} has been called.
          *
          * <p>In general, all applications that call {@link #setPushRegistrationId(String)} should include a call to
-         * clearPushRegistrationId or clearPushRegistrationId, and no applications that call
-         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearPushRegistrationId
+         * clearPushRegistrationId, and no applications that call
+         * {@link #initPushHandling(String)} should call clearPushRegistrationId
          */
         public void clearPushRegistrationId(String registrationId);
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1039,8 +1039,8 @@ public class MixpanelAPI {
          * <p>{@link People#clearPushRegistrationId} should only be called after {@link #identify(String)} has been called.
          *
          * <p>In general, all applications that call {@link #setPushRegistrationId(String)} should include a call to
-         * clearPushRegistrationId or clearSinglePushRegistrationId, and no applications that call
-         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearSinglePushRegistrationId
+         * clearPushRegistrationId or clearPushRegistrationId, and no applications that call
+         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearPushRegistrationId
          */
         public void clearPushRegistrationId();
 
@@ -1051,13 +1051,13 @@ public class MixpanelAPI {
          * call this method when your application receives a com.google.android.c2dm.intent.REGISTRATION
          * with getStringExtra("unregistered") != null
          *
-         * <p>{@link People#clearSinglePushRegistrationId} should only be called after {@link #identify(String)} has been called.
+         * <p>{@link People#clearPushRegistrationId} should only be called after {@link #identify(String)} has been called.
          *
          * <p>In general, all applications that call {@link #setPushRegistrationId(String)} should include a call to
-         * clearPushRegistrationId or clearSinglePushRegistrationId, and no applications that call
-         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearSinglePushRegistrationId
+         * clearPushRegistrationId or clearPushRegistrationId, and no applications that call
+         * {@link #initPushHandling(String)} should call clearPushRegistrationId or clearPushRegistrationId
          */
-        public void clearSinglePushRegistrationId(String registrationId);
+        public void clearPushRegistrationId(String registrationId);
 
         /**
          * Returns the string id currently being used to uniquely identify the user associated
@@ -1727,7 +1727,7 @@ public class MixpanelAPI {
         }
 
         @Override
-        public void clearSinglePushRegistrationId(String registrationId) {
+        public void clearPushRegistrationId(String registrationId) {
             if(mPersistentIdentity.getPushId() == registrationId) {
                 mPersistentIdentity.clearPushId();
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1030,7 +1030,7 @@ public class MixpanelAPI {
         public void setPushRegistrationId(String registrationId);
 
         /**
-         * Manually clear a current Google Cloud Messaging registration id from Mixpanel.
+         * Manually clear all current Google Cloud Messaging registration ids from Mixpanel.
          *
          * <p>If you are handling Google Cloud Messages in your own application, you should
          * call this method when your application receives a com.google.android.c2dm.intent.REGISTRATION

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1728,7 +1728,7 @@ public class MixpanelAPI {
 
         @Override
         public void clearPushRegistrationId(String registrationId) {
-            if(mPersistentIdentity.getPushId() == registrationId) {
+            if (registrationId.equalsToString(mPersistentIdentity.getPushId())) {
                 mPersistentIdentity.clearPushId();
             }
             remove("$android_devices", registrationId);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1728,8 +1728,10 @@ public class MixpanelAPI {
 
         @Override
         public void clearSinglePushRegistrationId(String registrationId) {
+            if(mPersistentIdentity.getPushId() == registrationId) {
+                mPersistentIdentity.clearPushId();
+            }
             remove("$android_devices", registrationId);
-            mPersistentIdentity.clearPushId();
         }
 
         @Override


### PR DESCRIPTION
Add support for the ```$remove``` operator which is detailed [here](https://mixpanel.com/help/reference/http#people-analytics-updates). Using this ```$remove``` operator, an additional method ```clearSinglePushRegistrationId``` has been added to allow for a single push notification device token to be removed from a user's profile.