### PR TITLE
NoClassDefFoundError when querying BluetoothAdapter on Samsung Galaxy Young 2

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -144,6 +144,8 @@ import android.view.WindowManager;
             }
         } catch (SecurityException e) {
             // do nothing since we don't have permissions
+        } catch (NoClassDefFoundError e) {
+            // Some phones doesn't have this class. Just ignore it
         }
         return isBluetoothEnabled;
     }


### PR DESCRIPTION
Hello,

We're having several crashes from Samsung Galaxy Young 2 (SM-G130HN)

`java.lang.NoClassDefFoundError: android.bluetooth.BluetoothAdapter$1
	at android.bluetooth.BluetoothAdapter.<init>(BluetoothAdapter.java:1465)
	at android.bluetooth.BluetoothAdapter.getDefaultAdapter(BluetoothAdapter.java:439)
	at com.mixpanel.android.mpmetrics.SystemInformation.isBluetoothEnabled(SourceFile:140)
	at com.mixpanel.android.mpmetrics.AnalyticsMessages$Worker$AnalyticsMessageHandler.getDefaultEventProperties(SourceFile:550)
	at com.mixpanel.android.mpmetrics.AnalyticsMessages$Worker$AnalyticsMessageHandler.prepareEventObject(SourceFile:564)
	at com.mixpanel.android.mpmetrics.AnalyticsMessages$Worker$AnalyticsMessageHandler.handleMessage(SourceFile:252)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:146)
	at android.os.HandlerThread.run(HandlerThread.java:61)`

I think it should be fixed by Samsung, because it's a bug on their SDK, but for us is crucial to prevent from crashing the app to the owners of this model.

If you want me to do anything else, please dont hesitate to tell me.
Best regards.