### PR TITLE
Push notification enhacements

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
@@ -18,12 +18,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
-import com.mixpanel.android.R;
 import com.mixpanel.android.mpmetrics.MixpanelAPI.InstanceProcessor;
 
-import java.util.HashMap;
-import java.util.IllegalFormatException;
-import java.util.Map;
 
 /**
 * BroadcastReceiver for handling Google Cloud Messaging intents.
@@ -154,7 +150,7 @@ public class GCMReceiver extends BroadcastReceiver {
                 color = Color.parseColor(colorName);
             } catch (IllegalArgumentException e) {}
         }
-        
+
         if (message == null) {
             return null;
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
@@ -290,7 +290,7 @@ public class GCMReceiver extends BroadcastReceiver {
 
     @SuppressWarnings("deprecation")
     @TargetApi(9)
-    private Notification makeNotificationSDKLessThan11(Context context, PendingIntent intent, NotificationData notificationData) {
+    protected Notification makeNotificationSDKLessThan11(Context context, PendingIntent intent, NotificationData notificationData) {
         final NotificationCompat.Builder builder = new NotificationCompat.Builder(context).
                 setSmallIcon(notificationData.icon).
                 setTicker(notificationData.message).
@@ -310,7 +310,7 @@ public class GCMReceiver extends BroadcastReceiver {
 
     @SuppressWarnings("deprecation")
     @TargetApi(11)
-    private Notification makeNotificationSDK11OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
+    protected Notification makeNotificationSDK11OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setSmallIcon(notificationData.icon).
                 setTicker(notificationData.message).
@@ -330,7 +330,7 @@ public class GCMReceiver extends BroadcastReceiver {
 
     @SuppressLint("NewApi")
     @TargetApi(16)
-    private Notification makeNotificationSDK16OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
+    protected Notification makeNotificationSDK16OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setSmallIcon(notificationData.icon).
                 setTicker(notificationData.message).
@@ -351,7 +351,7 @@ public class GCMReceiver extends BroadcastReceiver {
 
     @SuppressLint("NewApi")
     @TargetApi(21)
-    private Notification makeNotificationSDK21OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
+    protected Notification makeNotificationSDK21OrHigher(Context context, PendingIntent intent, NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setTicker(notificationData.message).
                 setWhen(System.currentTimeMillis()).


### PR DESCRIPTION
The following keys can now be used as part of a push notification payload:

- `mp_icnm_l` Large icon to be used on a push notification.
- `mp_icnm_w` White icon to be used on Lollipop and above.
- `mp_color` Color to be used on Lollipop and above (#argb).

Example of a payload:

`{"mp_icnm":"an_icon", "mp_icnm_l":"big_icon", "mp_icnm_w":"white_icon","mp_color":"#FFAA0000"}`

