### PR TITLE
Time event accross sessions

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -227,7 +227,6 @@ public class MixpanelAPI {
         mTrackingDebug = constructTrackingDebug();
         mPersistentIdentity = getPersistentIdentity(context, referrerPreferences, token);
         mEventTimings = mPersistentIdentity.getTimeEvents();
-
         mUpdatesListener = constructUpdatesListener();
         mDecideMessages = constructDecideUpdates(token, mUpdatesListener, mUpdatesFromMixpanel);
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -203,7 +203,6 @@ public class MixpanelAPI {
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token, MPConfig config) {
         mContext = context;
         mToken = token;
-        mEventTimings = new HashMap<String, Long>();
         mPeople = new PeopleImpl();
         mConfig = config;
 
@@ -227,6 +226,8 @@ public class MixpanelAPI {
         mUpdatesFromMixpanel = constructUpdatesFromMixpanel(context, token);
         mTrackingDebug = constructTrackingDebug();
         mPersistentIdentity = getPersistentIdentity(context, referrerPreferences, token);
+        mEventTimings = mPersistentIdentity.getTimeEvents();
+
         mUpdatesListener = constructUpdatesListener();
         mDecideMessages = constructDecideUpdates(token, mUpdatesListener, mUpdatesFromMixpanel);
 
@@ -435,6 +436,7 @@ public class MixpanelAPI {
         final long writeTime = System.currentTimeMillis();
         synchronized (mEventTimings) {
             mEventTimings.put(eventName, writeTime);
+            mPersistentIdentity.addTimeEvent(eventName, writeTime);
         }
     }
 
@@ -485,6 +487,7 @@ public class MixpanelAPI {
         synchronized (mEventTimings) {
             eventBegin = mEventTimings.get(eventName);
             mEventTimings.remove(eventName);
+            mPersistentIdentity.removeTimeEvent(eventName);
         }
 
         try {
@@ -1345,7 +1348,11 @@ public class MixpanelAPI {
 
         final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + token;
         final Future<SharedPreferences> storedPreferences = sPrefsLoader.loadPreferences(context, prefsName, listener);
-        return new PersistentIdentity(referrerPreferences, storedPreferences);
+
+        final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimedEvents_" + token;
+        final Future<SharedPreferences> timedEventsPrefs = sPrefsLoader.loadPreferences(context, timeEventsPrefsName, null);
+
+        return new PersistentIdentity(referrerPreferences, storedPreferences, timedEventsPrefs);
     }
 
     /* package */ DecideMessages constructDecideUpdates(final String token, final DecideMessages.OnNewResultsListener listener, UpdatesFromMixpanel updatesFromMixpanel) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1348,10 +1348,10 @@ public class MixpanelAPI {
         final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + token;
         final Future<SharedPreferences> storedPreferences = sPrefsLoader.loadPreferences(context, prefsName, listener);
 
-        final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimedEvents_" + token;
-        final Future<SharedPreferences> timedEventsPrefs = sPrefsLoader.loadPreferences(context, timeEventsPrefsName, null);
+        final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimeEvents_" + token;
+        final Future<SharedPreferences> timeEventsPrefs = sPrefsLoader.loadPreferences(context, timeEventsPrefsName, null);
 
-        return new PersistentIdentity(referrerPreferences, storedPreferences, timedEventsPrefs);
+        return new PersistentIdentity(referrerPreferences, storedPreferences, timeEventsPrefs);
     }
 
     /* package */ DecideMessages constructDecideUpdates(final String token, final DecideMessages.OnNewResultsListener listener, UpdatesFromMixpanel updatesFromMixpanel) {


### PR DESCRIPTION
Time events are not currently persisted. This PR saves time events in disk and restore the state on future user sessions.