### PR TITLE
A feature that allows the user to disable view crawler for certain projects

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -258,6 +258,13 @@ public class MPConfig {
         }
         mEditorUrl = editorUrl;
 
+        int resourceId = metaData.getInt("com.mixpanel.android.MPConfig.DisableViewCrawlerForProjects", -1);
+        if (resourceId != -1) {
+            mDisableViewCrawlerForProjects = context.getResources().getStringArray(resourceId);
+        } else {
+            mDisableViewCrawlerForProjects = new String[0];
+        }
+
         if (DEBUG) {
             Log.v(LOGTAG,
                 "Mixpanel (" + VERSION + ") configured with:\n" +
@@ -321,6 +328,8 @@ public class MPConfig {
     public boolean getDisableViewCrawler() {
         return mDisableViewCrawler;
     }
+
+    public String[] getDisableViewCrawlerForProjects() { return mDisableViewCrawlerForProjects; }
 
     public boolean getTestMode() {
         return mTestMode;
@@ -428,6 +437,7 @@ public class MPConfig {
     private final boolean mDisableEmulatorBindingUI;
     private final boolean mDisableAppOpenEvent;
     private final boolean mDisableViewCrawler;
+    private final String[] mDisableViewCrawlerForProjects;
     private final String mEventsEndpoint;
     private final String mEventsFallbackEndpoint;
     private final String mPeopleEndpoint;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1389,7 +1390,7 @@ public class MixpanelAPI {
         if (Build.VERSION.SDK_INT < MPConfig.UI_FEATURES_MIN_API) {
             Log.i(LOGTAG, "SDK version is lower than " + MPConfig.UI_FEATURES_MIN_API + ". Web Configuration, A/B Testing, and Dynamic Tweaks are disabled.");
             return new NoOpUpdatesFromMixpanel(sSharedTweaks);
-        } else if (mConfig.getDisableViewCrawler()) {
+        } else if (mConfig.getDisableViewCrawler() || Arrays.asList(mConfig.getDisableViewCrawlerForProjects()).contains(token)) {
             Log.i(LOGTAG, "DisableViewCrawler is set to true. Web Configuration, A/B Testing, and Dynamic Tweaks are disabled.");
             return new NoOpUpdatesFromMixpanel(sSharedTweaks);
         } else {
@@ -2213,4 +2214,6 @@ public class MixpanelAPI {
     private static final String LOGTAG = "MixpanelAPI.API";
     private static final String APP_LINKS_LOGTAG = "MixpanelAPI.AL";
     private static final String ENGAGE_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
+
+    private boolean mDisableDecideChecker;
 }


### PR DESCRIPTION
https://github.com/mixpanel/mixpanel-android/issues/357

When a user has multiple instances of MixpanelAPI, the A/B changes might get messed up as the lib always applies the change in the last decide response.

This feature is for disabling A/B and codeless for certain projects that are specified by the user.

To use this feature, the user will need to define
```
<resources>
    <string-array name="my_project_list">
        <item>project token 1</item>
        <item>project token 2</item>
    </string-array>
</resources>
```
in `array.xml`.

Then reference it in the AndroidManifest
```
        <meta-data android:name="com.mixpanel.android.MPConfig.DisableViewCrawlerForProjects"
            android:resource="@array/my_project_list" />
```