### PR TITLE
Add flag to ignore invisible views on mixpanel visual editors

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -82,6 +82,9 @@ import javax.net.ssl.SSLSocketFactory;
  *
  *     <dt>com.mixpanel.android.MPConfig.EditorUrl</dt>
  *     <dd>A string URL. If present, the library will attempt to connect to this endpoint when in interactive editing mode, rather than to the default Mixpanel editor url.</dd>
+ *
+ *     <dt>com.mixpanel.android.MPConfig.IgnoreInvisibleViewsVisualEditor</dt>
+ *     <dd>A boolean value. If true, invisible views won't be shown on Mixpanel Visual Editor (AB Test and codeless events) . Defaults to false.</dd>
  * </dl>
  *
  */
@@ -208,6 +211,7 @@ public class MPConfig {
         mDisableViewCrawler = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableViewCrawler", false);
         mDisableDecideChecker = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableDecideChecker", false);
         mImageCacheMaxMemoryFactor = metaData.getInt("com.mixpanel.android.MPConfig.ImageCacheMaxMemoryFactor", 10);
+        mIgnoreInvisibleViewsEditor = metaData.getBoolean("com.mixpanel.android.MPConfig.IgnoreInvisibleViewsVisualEditor", false);
 
         // Disable if EITHER of these is present and false, otherwise enable
         final boolean surveysAutoCheck = metaData.getBoolean("com.mixpanel.android.MPConfig.AutoCheckForSurveys", true);
@@ -287,7 +291,8 @@ public class MPConfig {
                 "    PeopleFallbackEndpoint " + getPeopleFallbackEndpoint() + "\n" +
                 "    DecideFallbackEndpoint " + getDecideFallbackEndpoint() + "\n" +
                 "    EditorUrl " + getEditorUrl() + "\n" +
-                "    DisableDecideChecker " + getDisableDecideChecker() + "\n"
+                "    DisableDecideChecker " + getDisableDecideChecker() + "\n" +
+                "    IgnoreInvisibleViewsEditor " + getIgnoreInvisibleViewsEditor() + "\n"
             );
         }
     }
@@ -379,6 +384,10 @@ public class MPConfig {
         return mDisableDecideChecker;
     }
 
+    public boolean getIgnoreInvisibleViewsEditor() {
+        return mIgnoreInvisibleViewsEditor;
+    }
+
     // Pre-configured package name for resources, if they differ from the application package name
     //
     // mContext.getPackageName() actually returns the "application id", which
@@ -449,6 +458,7 @@ public class MPConfig {
     private final String mResourcePackageName;
     private final boolean mDisableDecideChecker;
     private final int mImageCacheMaxMemoryFactor;
+    private final boolean mIgnoreInvisibleViewsEditor;
 
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;

--- a/src/main/java/com/mixpanel/android/viewcrawler/EditProtocol.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/EditProtocol.java
@@ -1,5 +1,6 @@
 package com.mixpanel.android.viewcrawler;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
@@ -63,7 +64,8 @@ import java.util.List;
         public final List<String> imageUrls;
     }
 
-    public EditProtocol(ResourceIds resourceIds, ImageStore imageStore, ViewVisitor.OnLayoutErrorListener layoutErrorListener) {
+    public EditProtocol(Context context, ResourceIds resourceIds, ImageStore imageStore, ViewVisitor.OnLayoutErrorListener layoutErrorListener) {
+        mContext = context;
         mResourceIds = resourceIds;
         mImageStore = imageStore;
         mLayoutErrorListener = layoutErrorListener;
@@ -209,7 +211,7 @@ import java.util.List;
                 }
             }
 
-            return new ViewSnapshot(properties, mResourceIds);
+            return new ViewSnapshot(mContext, properties, mResourceIds);
         } catch (JSONException e) {
             throw new BadInstructionsException("Can't read snapshot configuration", e);
         } catch (final ClassNotFoundException e) {
@@ -420,6 +422,7 @@ import java.util.List;
         }
     }
 
+    private final Context mContext;
     private final ResourceIds mResourceIds;
     private final ImageStore mImageStore;
     private final ViewVisitor.OnLayoutErrorListener mLayoutErrorListener;

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -280,7 +280,7 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
             final ResourceIds resourceIds = new ResourceReader.Ids(resourcePackage, context);
 
             mImageStore = new ImageStore(context, "ViewCrawler");
-            mProtocol = new EditProtocol(resourceIds, mImageStore, layoutErrorListener);
+            mProtocol = new EditProtocol(context, resourceIds, mImageStore, layoutErrorListener);
             mEditorChanges = new HashMap<String, Pair<String, JSONObject>>();
             mEditorTweaks = new ArrayList<JSONObject>();
             mEditorAssetUrls = new ArrayList<String>();

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewSnapshot.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewSnapshot.java
@@ -3,6 +3,7 @@ package com.mixpanel.android.viewcrawler;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -48,7 +49,8 @@ import java.util.concurrent.TimeoutException;
 @TargetApi(MPConfig.UI_FEATURES_MIN_API)
 /* package */ class ViewSnapshot {
 
-    public ViewSnapshot(List<PropertyDescription> properties, ResourceIds resourceIds) {
+    public ViewSnapshot(Context context, List<PropertyDescription> properties, ResourceIds resourceIds) {
+        mConfig = MPConfig.getInstance(context);
         mProperties = properties;
         mResourceIds = resourceIds;
         mMainThreadHandler = new Handler(Looper.getMainLooper());
@@ -134,6 +136,10 @@ import java.util.concurrent.TimeoutException;
 
     private void snapshotView(JsonWriter j, View view)
             throws IOException {
+        if (view.getVisibility() == View.INVISIBLE && mConfig.getIgnoreInvisibleViewsEditor()) {
+            return;
+        }
+
         final int viewId = view.getId();
         final String viewIdName;
         if (-1 == viewId) {
@@ -448,6 +454,7 @@ import java.util.concurrent.TimeoutException;
         public float scale;
     }
 
+    private final MPConfig mConfig;
     private final RootViewFinder mRootViewFinder;
     private final List<PropertyDescription> mProperties;
     private final ClassNameCache mClassnameCache;


### PR DESCRIPTION
With `com.mixpanel.android.MPConfig.IgnoreInvisibleViewsVisualEditor` set to true on your `AndroidManifest.xml` the `ViewCrawler` will filter out invisible views.