### PR TITLE
don't track survey responses if survey was not shown

### DIFF
--- a/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
+++ b/src/main/java/com/mixpanel/android/surveys/SurveyActivity.java
@@ -292,7 +292,7 @@ public class SurveyActivity extends Activity {
     @SuppressLint("SimpleDateFormat")
     private void onDestroySurvey() {
         if (null != mMixpanel) {
-            if (null != mUpdateDisplayState) {
+            if (mUpdateDisplayState != null && mUpdateDisplayState.getDistinctId() != null) {
                 final UpdateDisplayState.DisplayState.SurveyState surveyState = getSurveyState();
                 final Survey survey = surveyState.getSurvey();
                 final List<Survey.Question> questionList = survey.getQuestions();


### PR DESCRIPTION
This fixes https://github.com/mixpanel/mixpanel-android/issues/404 and https://github.com/mixpanel/mixpanel-android/issues/399