### PR TITLE
Track open push

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/GCMReceiver.java
@@ -139,6 +139,9 @@ public class GCMReceiver extends BroadcastReceiver {
         final String uriString = inboundIntent.getStringExtra("mp_cta");
         CharSequence notificationTitle = inboundIntent.getStringExtra("mp_title");
         final String colorName = inboundIntent.getStringExtra("mp_color");
+        final String campaignId = inboundIntent.getStringExtra("mp_campaign_id");
+        final String messageId = inboundIntent.getStringExtra("mp_message_id");
+
         int color = NotificationData.NOT_SET;
 
         if (colorName != null) {
@@ -195,12 +198,12 @@ public class GCMReceiver extends BroadcastReceiver {
             notificationTitle = "A message for you";
         }
 
-        final Intent notificationIntent = buildNotificationIntent(context, uriString);
+        final Intent notificationIntent = buildNotificationIntent(context, uriString, campaignId, messageId);
 
         return new NotificationData(notificationIcon, largeNotificationIcon, whiteNotificationIcon, notificationTitle, message, notificationIntent, color);
     }
 
-    private Intent buildNotificationIntent(Context context, String uriString) {
+    private Intent buildNotificationIntent(Context context, String uriString, String campaignId, String messageId) {
         Uri uri = null;
         if (null != uriString) {
             uri = Uri.parse(uriString);
@@ -211,6 +214,14 @@ public class GCMReceiver extends BroadcastReceiver {
             ret = getDefaultIntent(context);
         } else {
             ret = new Intent(Intent.ACTION_VIEW, uri);
+        }
+
+        if (campaignId != null) {
+            ret.putExtra("mp_campaign_id", campaignId);
+        }
+
+        if (messageId != null) {
+            ret.putExtra("mp_message_id", messageId);
         }
 
         return ret;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1357,12 +1357,32 @@ public class MixpanelAPI {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             if (mContext.getApplicationContext() instanceof Application) {
                 final Application app = (Application) mContext.getApplicationContext();
-                MixpanelActivityLifecycleCallbacks mixpanelActivityLifecycleCallbacks = new MixpanelActivityLifecycleCallbacks(this, mConfig);
-                app.registerActivityLifecycleCallbacks(mixpanelActivityLifecycleCallbacks);
+                mMixpanelActivityLifecycleCallbacks = new MixpanelActivityLifecycleCallbacks(this, mConfig);
+                app.registerActivityLifecycleCallbacks(mMixpanelActivityLifecycleCallbacks);
             } else {
                 MPLog.i(LOGTAG, "Context is not an Application, Mixpanel will not automatically show surveys, in-app notifications, or A/B test experiments. We won't be able to automatically flush on an app background.");
             }
         }
+    }
+
+    /**
+     * Based on the application's event lifecycle this method will determine whether the app
+     * is running in the foreground or not.
+     *
+     * If your build version is below 14 this method will always return false.
+     *
+     * @return True if the app is running in the foreground.
+     */
+    public boolean isAppInForeground() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            if (mMixpanelActivityLifecycleCallbacks != null) {
+                return mMixpanelActivityLifecycleCallbacks.isInForeground();
+            }
+        } else {
+            MPLog.e(LOGTAG, "Your build version is below 14. This method will always return false.");
+        }
+
+        return false;
     }
 
     // Package-level access. Used (at least) by GCMReceiver
@@ -2256,6 +2276,7 @@ public class MixpanelAPI {
     private final DecideMessages mDecideMessages;
     private final Map<String, String> mDeviceInfo;
     private final Map<String, Long> mEventTimings;
+    private MixpanelActivityLifecycleCallbacks mMixpanelActivityLifecycleCallbacks;
 
     // Maps each token to a singleton MixpanelAPI instance
     private static final Map<String, Map<Context, MixpanelAPI>> sInstanceMap = new HashMap<String, Map<Context, MixpanelAPI>>();
@@ -2266,6 +2287,4 @@ public class MixpanelAPI {
     private static final String LOGTAG = "MixpanelAPI.API";
     private static final String APP_LINKS_LOGTAG = "MixpanelAPI.AL";
     private static final String ENGAGE_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
-
-    private boolean mDisableDecideChecker;
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -7,7 +7,11 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+
 import com.mixpanel.android.viewcrawler.GestureTracker;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 /* package */ class MixpanelActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
@@ -24,6 +28,19 @@ import com.mixpanel.android.viewcrawler.GestureTracker;
 
     @Override
     public void onActivityStarted(Activity activity) {
+        if (activity.getIntent().hasExtra("mp_campaign_id") && activity.getIntent().hasExtra("mp_message_id")) {
+            String campaignId = activity.getIntent().getStringExtra("mp_campaign_id");
+            String messageId = activity.getIntent().getStringExtra("mp_message_id");
+
+            JSONObject pushProps = new JSONObject();
+            try {
+                pushProps.put("campaign_id", campaignId);
+                pushProps.put("message_id", messageId);
+                pushProps.put("message_type", "push");
+                mMpInstance.track("$campaign_received", pushProps);
+            } catch (JSONException e) {}
+        }
+
         if (android.os.Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API && mConfig.getAutoShowMixpanelUpdates()) {
             if (!activity.isTaskRoot()) {
                 return; // No checks, no nothing.

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 /* package */ class MixpanelActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
     private Handler mHandler = new Handler(Looper.getMainLooper());
     private Runnable check;
-    private boolean mIsForeground = false;
+    private boolean mIsForeground = true;
     private boolean mPaused = true;
     public static final int CHECK_DELAY = 500;
 
@@ -37,8 +37,11 @@ import org.json.JSONObject;
                 pushProps.put("campaign_id", campaignId);
                 pushProps.put("message_id", messageId);
                 pushProps.put("message_type", "push");
-                mMpInstance.track("$campaign_received", pushProps);
+                mMpInstance.track("$app_open", pushProps);
             } catch (JSONException e) {}
+
+            activity.getIntent().removeExtra("mp_campaign_id");
+            activity.getIntent().removeExtra("mp_message_id");
         }
 
         if (android.os.Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API && mConfig.getAutoShowMixpanelUpdates()) {
@@ -101,6 +104,10 @@ import org.json.JSONObject;
 
     @Override
     public void onActivityStopped(Activity activity) { }
+
+    protected boolean isInForeground() {
+        return mIsForeground;
+    }
 
     private final MixpanelAPI mMpInstance;
     private final MPConfig mConfig;


### PR DESCRIPTION
To achieve parity with iOS:
- `$app_open` will be tracked if the app is open from a push. `campaign_id` and `message_id` are sent as well as `message_type=push`.
- `$campaign_receive` will be tracked if the app receives a push while the app is running in the foreground. Same properties as before are sent.

Notice that this two events will only be sent if your build version is 14 and above.