### PR TITLE
Add support for minimum and maximum values for Tweak variables

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -145,12 +145,30 @@ public class MixpanelAPI {
     }
 
     /**
+     * Declare a double-valued tweak, and return a reference you can use to read the value of the tweak.
+     * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
+     * in your app without re-deploying your application through the app store.
+     */
+    public static Tweak<Double> doubleTweak(String tweakName, double defaultValue, double minimumValue, double maximumValue) {
+        return sSharedTweaks.doubleTweak(tweakName, defaultValue, minimumValue, maximumValue);
+    }
+
+    /**
      * Declare a float-valued tweak, and return a reference you can use to read the value of the tweak.
      * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
      * in your app without re-deploying your application through the app store.
      */
     public static Tweak<Float> floatTweak(String tweakName, float defaultValue) {
         return sSharedTweaks.floatTweak(tweakName, defaultValue);
+    }
+
+    /**
+     * Declare a float-valued tweak, and return a reference you can use to read the value of the tweak.
+     * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
+     * in your app without re-deploying your application through the app store.
+     */
+    public static Tweak<Float> floatTweak(String tweakName, float defaultValue, float minimumValue, float maximumValue) {
+        return sSharedTweaks.floatTweak(tweakName, defaultValue, minimumValue, maximumValue);
     }
 
     /**
@@ -163,12 +181,30 @@ public class MixpanelAPI {
     }
 
     /**
+     * Declare a long-valued tweak, and return a reference you can use to read the value of the tweak.
+     * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
+     * in your app without re-deploying your application through the app store.
+     */
+    public static Tweak<Long> longTweak(String tweakName, long defaultValue, long minimumValue, long maximumValue) {
+        return sSharedTweaks.longTweak(tweakName, defaultValue, minimumValue, maximumValue);
+    }
+
+    /**
      * Declare an int-valued tweak, and return a reference you can use to read the value of the tweak.
      * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
      * in your app without re-deploying your application through the app store.
      */
     public static Tweak<Integer> intTweak(String tweakName, int defaultValue) {
         return sSharedTweaks.intTweak(tweakName, defaultValue);
+    }
+
+    /**
+     * Declare an int-valued tweak, and return a reference you can use to read the value of the tweak.
+     * Tweaks can be changed in Mixpanel A/B tests, and can allow you to alter your customers' experience
+     * in your app without re-deploying your application through the app store.
+     */
+    public static Tweak<Integer> intTweak(String tweakName, int defaultValue, int minimumValue, int maximumValue) {
+        return sSharedTweaks.intTweak(tweakName, defaultValue, minimumValue, maximumValue);
     }
 
     /**

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -196,6 +196,14 @@ public class Tweaks {
             return ret;
         }
 
+        public Number getMinimum() {
+            return minimum;
+        }
+
+        public Number getMaximum() {
+            return maximum;
+        }
+
         public final @TweakType int type;
 
         protected final Object value;
@@ -220,7 +228,7 @@ public class Tweaks {
 
 
     /* package */ Tweak<String> stringTweak(final String tweakName, final String defaultValue) {
-        declareTweak(tweakName, defaultValue, STRING_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, STRING_TYPE);
         return new Tweak<String>() {
             @Override
             public String get() {
@@ -231,7 +239,19 @@ public class Tweaks {
     }
 
     /* package */ Tweak<Double> doubleTweak(final String tweakName, final double defaultValue) {
-        declareTweak(tweakName, defaultValue, DOUBLE_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, DOUBLE_TYPE);
+        return new Tweak<Double>() {
+            @Override
+            public Double get() {
+                final TweakValue tweakValue = getValue(tweakName);
+                final Number result = tweakValue.getNumberValue();
+                return result.doubleValue();
+            }
+        };
+    }
+
+    /* package */ Tweak<Double> doubleTweak(final String tweakName, final double defaultValue, final double minimumValue, final double maximumValue) {
+        declareTweak(tweakName, defaultValue, minimumValue, maximumValue, DOUBLE_TYPE);
         return new Tweak<Double>() {
             @Override
             public Double get() {
@@ -243,7 +263,19 @@ public class Tweaks {
     }
 
     /* package */  Tweak<Float> floatTweak(final String tweakName, final float defaultValue) {
-        declareTweak(tweakName, defaultValue, DOUBLE_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, DOUBLE_TYPE);
+        return new Tweak<Float>() {
+            @Override
+            public Float get() {
+                final TweakValue tweakValue = getValue(tweakName);
+                final Number result = tweakValue.getNumberValue();
+                return result.floatValue();
+            }
+        };
+    }
+
+    /* package */  Tweak<Float> floatTweak(final String tweakName, final float defaultValue, final float minimumValue, final float maximumValue) {
+        declareTweak(tweakName, defaultValue, minimumValue, maximumValue, DOUBLE_TYPE);
         return new Tweak<Float>() {
             @Override
             public Float get() {
@@ -255,7 +287,19 @@ public class Tweaks {
     }
 
     /* package */  Tweak<Long> longTweak(final String tweakName, final long defaultValue) {
-        declareTweak(tweakName, defaultValue, LONG_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, LONG_TYPE);
+        return new Tweak<Long>() {
+            @Override
+            public Long get() {
+                final TweakValue tweakValue = getValue(tweakName);
+                final Number result = tweakValue.getNumberValue();
+                return result.longValue();
+            }
+        };
+    }
+
+    /* package */  Tweak<Long> longTweak(final String tweakName, final long defaultValue, final long minimumValue, final long maximumValue) {
+        declareTweak(tweakName, defaultValue, minimumValue, maximumValue, LONG_TYPE);
         return new Tweak<Long>() {
             @Override
             public Long get() {
@@ -267,7 +311,19 @@ public class Tweaks {
     }
 
     /* package */ Tweak<Integer> intTweak(final String tweakName, final int defaultValue) {
-        declareTweak(tweakName, defaultValue, LONG_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, LONG_TYPE);
+        return new Tweak<Integer>() {
+            @Override
+            public Integer get() {
+                final TweakValue tweakValue = getValue(tweakName);
+                final Number result = tweakValue.getNumberValue();
+                return result.intValue();
+            }
+        };
+    }
+
+    /* package */ Tweak<Integer> intTweak(final String tweakName, final int defaultValue, final int minimumValue, final int maximumValue) {
+        declareTweak(tweakName, defaultValue, minimumValue, maximumValue, LONG_TYPE);
         return new Tweak<Integer>() {
             @Override
             public Integer get() {
@@ -279,7 +335,7 @@ public class Tweaks {
     }
 
     /* package */ Tweak<Byte> byteTweak(final String tweakName, final byte defaultValue) {
-        declareTweak(tweakName, defaultValue, LONG_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, LONG_TYPE);
         return new Tweak<Byte>() {
             @Override
             public Byte get() {
@@ -291,7 +347,7 @@ public class Tweaks {
     }
 
     /* package */ Tweak<Short> shortTweak(final String tweakName, final short defaultValue) {
-        declareTweak(tweakName, defaultValue, LONG_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, LONG_TYPE);
         return new Tweak<Short>() {
             @Override
             public Short get() {
@@ -303,7 +359,7 @@ public class Tweaks {
     }
 
     /* package */ Tweak<Boolean> booleanTweak(final String tweakName, final boolean defaultValue) {
-        declareTweak(tweakName, defaultValue, BOOLEAN_TYPE);
+        declareTweak(tweakName, defaultValue, null, null, BOOLEAN_TYPE);
         return new Tweak<Boolean>() {
             @Override
             public Boolean get() {
@@ -317,13 +373,13 @@ public class Tweaks {
         return mTweakValues.get(tweakName);
     }
 
-    private void declareTweak(String tweakName, Object defaultValue, @TweakType int tweakType) {
+    private void declareTweak(String tweakName, Object defaultValue, Number minimumValue, Number maximumValue, @TweakType int tweakType) {
         if (mTweakValues.containsKey(tweakName)) {
             MPLog.w(LOGTAG, "Attempt to define a tweak \"" + tweakName + "\" twice with the same name");
             return;
         }
 
-        final TweakValue value = new TweakValue(tweakType, defaultValue, null, null, defaultValue);
+        final TweakValue value = new TweakValue(tweakType, defaultValue, minimumValue, maximumValue, defaultValue);
         mTweakValues.put(tweakName, value);
         mTweakDefaultValues.put(tweakName, value);
         final int listenerSize = mTweakDeclaredListeners.size();

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -127,37 +127,34 @@ public class Tweaks {
             name = aName;
             minimum = aMin;
             maximum = aMax;
-            if(minimum != null && maximum != null) {
+            if (minimum != null && maximum != null) {
                 try {
-                    if (((Number) aDefaultValue).longValue() < minimum.longValue()) {
+                    if (Math.min(Math.max(((Number) aDefaultValue).longValue(), minimum.longValue()), maximum.longValue()) == minimum.longValue()) {
                         MPLog.w(LOGTAG, "Attempt to define a tweak \"" + name + "\" with default value " + aDefaultValue + " which is below the minimum. " +
                                 "Tweak \"" + name + "\" will be set to the minimum value " + minimum + ".");
-                        aDefaultValue = minimum;
-                    } else if (((Number) aDefaultValue).longValue() > maximum.longValue()) {
+                    } else if (Math.min(Math.max(((Number) aDefaultValue).longValue(), minimum.longValue()), maximum.longValue()) == maximum.longValue()) {
                         MPLog.w(LOGTAG, "Attempt to define a tweak \"" + name + "\" with default value " + aDefaultValue + " which is above the maximum. " +
                                 "Tweak \"" + name + "\" will be set to the maximum value " + maximum + ".");
-                        aDefaultValue = maximum;
                     }
-                } catch(ClassCastException e) {
+                    aDefaultValue = Math.min(Math.max(((Number) aDefaultValue).longValue(), minimum.longValue()), maximum.longValue());
+                } catch (ClassCastException e) {
                     ; // ok
                 }
                 try {
-                    if (((Number) value).longValue() < minimum.longValue()) {
+                    if (Math.min(Math.max(((Number) value).longValue(), minimum.longValue()), maximum.longValue()) == minimum.longValue()) {
                         MPLog.w(LOGTAG, "Attempt to define a tweak \"" + name + "\" with value " + value + " which is below the minimum. " +
                                 "Tweak \"" + name + "\" will be set to the minimum value " + minimum);
-                        value = minimum;
-                    } else if (((Number) value).longValue() > maximum.longValue()) {
+                    } else if (Math.min(Math.max(((Number) value).longValue(), minimum.longValue()), maximum.longValue()) == maximum.longValue()) {
                         MPLog.w(LOGTAG, "Attempt to define a tweak \"" + name + "\" with value " + value + " which is above the maximum. " +
                                 "Tweak \"" + name + "\" will be set to the maximum value " + maximum);
-                        value = maximum;
                     }
-                } catch(ClassCastException e) {
+                    value = Math.min(Math.max(((Number) value).longValue(), minimum.longValue()), maximum.longValue());
+                } catch (ClassCastException e) {
                     ; // ok
                 }
             }
             defaultValue = aDefaultValue;
             this.value = value;
-
         }
 
         public TweakValue updateValue(Object newValue) {

--- a/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/ViewCrawler.java
@@ -537,8 +537,8 @@ public class ViewCrawler implements UpdatesFromMixpanel, TrackingDebug, ViewVisi
                         final String tweakName = tweak.getKey();
                         j.beginObject();
                         j.name("name").value(tweakName);
-                        j.name("minimum").value((Number) null);
-                        j.name("maximum").value((Number) null);
+                        j.name("minimum").value(desc.getMinimum());
+                        j.name("maximum").value(desc.getMaximum());
                         switch (desc.type) {
                             case Tweaks.BOOLEAN_TYPE:
                                 j.name("type").value("boolean");


### PR DESCRIPTION
Add support for minimum and maximum values for Tweak variables. In the Mixpanel A/B testing builder this restricts numerical Tweak values to be within a specified range: 
![image](https://cloud.githubusercontent.com/assets/9201737/24628722/6188b912-186c-11e7-9d36-ee7cf08a9f66.png)

The syntax of a Tweak with min and max looks like:
`Tweak<Integer> testInt = MixpanelAPI.intTweak("Test Int", 2, 0, 10);`

This PR brings the Android library up to parity with iOS which allows for minimum and maximum values on Tweak variables.