### PR TITLE
update log output to be consistent with meta-data naming

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -269,8 +269,8 @@ public class MPConfig {
                 "    DisableFallback " + getDisableFallback() + "\n" +
                 "    DisableAppOpenEvent " + getDisableAppOpenEvent() + "\n" +
                 "    DisableViewCrawler " + getDisableViewCrawler() + "\n" +
-                "    DisableDeviceUIBinding " + getDisableGestureBindingUI() + "\n" +
-                "    DisableEmulatorUIBinding " + getDisableEmulatorBindingUI() + "\n" +
+                "    DisableGestureBindingUI " + getDisableGestureBindingUI() + "\n" +
+                "    DisableEmulatorBindingUI " + getDisableEmulatorBindingUI() + "\n" +
                 "    EnableDebugLogging " + DEBUG + "\n" +
                 "    TestMode " + getTestMode() + "\n" +
                 "    EventsEndpoint " + getEventsEndpoint() + "\n" +


### PR DESCRIPTION
It took me a few minutes to realize why my attempts to change these meta-data properties were failing. After, I spotted the inconsistent naming, I figured I'd submit a PR for a low-risk fix that changes only the log output rather than the base variable names so that ALL the logged values can be appended to `com.mixpanel.android.MPConfig` consistently.