### PR TITLE
bugfix: netInfo can be null even when there is connectivity.

### DIFF
--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -62,7 +62,7 @@ public class HttpService implements RemoteService {
             final ConnectivityManager cm =
                     (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
             final NetworkInfo netInfo = cm.getActiveNetworkInfo();
-            if(netInfo == null) {
+            if (netInfo == null) {
                 isOnline = true;
                 MPLog.v(LOGTAG, "A default network has not been set so we cannot be certain whether we are offline");
             } else {

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -62,8 +62,13 @@ public class HttpService implements RemoteService {
             final ConnectivityManager cm =
                     (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
             final NetworkInfo netInfo = cm.getActiveNetworkInfo();
-            isOnline = netInfo != null && netInfo.isConnectedOrConnecting();
-            MPLog.v(LOGTAG, "ConnectivityManager says we " + (isOnline ? "are" : "are not") + " online");
+            if(netInfo == null) {
+                isOnline = true;
+                MPLog.v(LOGTAG, "A default network has not been set so we cannot be certain whether we are offline");
+            } else {
+                isOnline = netInfo.isConnectedOrConnecting();
+                MPLog.v(LOGTAG, "ConnectivityManager says we " + (isOnline ? "are" : "are not") + " online");
+            }
         } catch (final SecurityException e) {
             isOnline = true;
             MPLog.v(LOGTAG, "Don't have permission to check connectivity, will assume we are online");


### PR DESCRIPTION
This bug resulted in MixPanel requests never being sent in our locked-down Ethernet Kiosk environment, as referenced in Issue #444 

From our investigation, it is worth noting that:

- We have connectivity via Ethernet
- We have the `android.permission.ACCESS_NETWORK_STATE` permission enabled
- `connectivityManager.getActiveNetworkInfo()` always returns `null`
- `connectivityManager.getAllNetworks()` always returns either `null` or an empty array (on API 22)

Also, according to the documentation for [ConnectivityManager#getActiveNetworkInfo](https://developer.android.com/reference/android/net/ConnectivityManager.html#getActiveNetworkInfo()):

>This may return null when there is no default network.

The code in `HttpService` was assuming that a null `NetworkInfo` response signifies no connectivity but that is not always the case. In our Ethernet environment, we have connectivity but there is no default network.