### PR TITLE
Support tracking journey_id for push open events

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -37,8 +37,14 @@ import java.text.DecimalFormat;
         if (activity.getIntent().hasExtra("mp_campaign_id") && activity.getIntent().hasExtra("mp_message_id")) {
             String campaignId = activity.getIntent().getStringExtra("mp_campaign_id");
             String messageId = activity.getIntent().getStringExtra("mp_message_id");
+            String extraLogData = activity.getIntent().getStringExtra("mp");
 
             JSONObject pushProps = new JSONObject();
+            try {
+                if (extraLogData != null) {
+                    pushProps = new JSONObject(extraLogData);
+                }
+            } catch (JSONException e) {}
             try {
                 pushProps.put("campaign_id", campaignId);
                 pushProps.put("message_id", messageId);
@@ -48,6 +54,7 @@ import java.text.DecimalFormat;
 
             activity.getIntent().removeExtra("mp_campaign_id");
             activity.getIntent().removeExtra("mp_message_id");
+            activity.getIntent().removeExtra("mp");
         }
 
         if (android.os.Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API && mConfig.getAutoShowMixpanelUpdates()) {


### PR DESCRIPTION
### Current Format
#### Push payload
```
{
	‘mp_campaign_id’: $campaign_id,
 	‘mp_message_id’: $message_id
}
```
 
#### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id
	}
}
```
 
 
### New Format
#### Push payload
```
{
	‘mp_campaign_id’: $campaign_id,
 	‘mp_message_id’: $message_id,
	‘mp’: {
                ‘additional_params_1’: $param1,
		‘additional_params_2’: $param2,
	}
}
```
 
#### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id,
		‘additional_params_1’: $param1,
		‘additional_params_2’: $param2,
	}
}
```