### PR TITLE
Persist seen in-app campaign ids accross sessions

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
@@ -13,6 +13,7 @@ import org.json.JSONArray;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -27,11 +28,11 @@ public class DecideCheckerTest extends AndroidTestCase {
         mPoster = new MockPoster();
         mEventBinder = new MockUpdatesFromMixpanel();
         mEventBinder.startUpdates();
-        mDecideMessages1 = new DecideMessages(getContext(), "TOKEN 1", null, mEventBinder);
+        mDecideMessages1 = new DecideMessages(getContext(), "TOKEN 1", null, mEventBinder, new HashSet<Integer>());
         mDecideMessages1.setDistinctId("DISTINCT ID 1");
-        mDecideMessages2 = new DecideMessages(getContext(), "TOKEN 2", null, mEventBinder);
+        mDecideMessages2 = new DecideMessages(getContext(), "TOKEN 2", null, mEventBinder, new HashSet<Integer>());
         mDecideMessages2.setDistinctId("DISTINCT ID 2");
-        mDecideMessages3 = new DecideMessages(getContext(), "TOKEN 3", null, mEventBinder);
+        mDecideMessages3 = new DecideMessages(getContext(), "TOKEN 3", null, mEventBinder, new HashSet<Integer>());
         mDecideMessages3.setDistinctId("DISTINCT ID 3");
     }
 

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URLEncoder;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -146,7 +147,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
 
             @Override
             DecideMessages constructDecideUpdates(String token, DecideMessages.OnNewResultsListener listener, UpdatesFromMixpanel binder) {
-                return new MockMessages(token, listener, binder);
+                return new MockMessages(token, listener, binder, new HashSet<Integer>());
             }
         };
 
@@ -241,7 +242,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
 
             @Override
             DecideMessages constructDecideUpdates(String token, DecideMessages.OnNewResultsListener listener, UpdatesFromMixpanel binder) {
-                return new MockMessages(token, listener, binder);
+                return new MockMessages(token, listener, binder, new HashSet<Integer>());
             }
 
             @Override
@@ -333,8 +334,8 @@ public class DecideFunctionalTest extends AndroidTestCase {
     }
 
     private class MockMessages extends DecideMessages {
-        public MockMessages(final String token, final OnNewResultsListener listener, final UpdatesFromMixpanel binder) {
-            super(getContext(), token, listener, binder);
+        public MockMessages(final String token, final OnNewResultsListener listener, final UpdatesFromMixpanel binder, HashSet<Integer> seenNotificationIds) {
+            super(getContext(), token, listener, binder, seenNotificationIds);
         }
 
         @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
@@ -9,6 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -58,7 +59,7 @@ public class DecideMessagesTest extends AndroidTestCase {
             }
         };
 
-        mDecideMessages = new DecideMessages(getContext(), "TEST TOKEN", mMockListener, mMockUpdates);
+        mDecideMessages = new DecideMessages(getContext(), "TEST TOKEN", mMockListener, mMockUpdates, new HashSet<Integer>());
         mSomeNotifications = new ArrayList<>();
 
         JSONObject notifsDesc1 = new JSONObject(

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -21,7 +21,7 @@ import java.util.Set;
         void onNewResults();
     }
 
-    public DecideMessages(Context context, String token, OnNewResultsListener listener, UpdatesFromMixpanel updatesFromMixpanel) {
+    public DecideMessages(Context context, String token, OnNewResultsListener listener, UpdatesFromMixpanel updatesFromMixpanel, HashSet<Integer> notificationIds) {
         mContext = context;
         mToken = token;
         mListener = listener;
@@ -29,7 +29,7 @@ import java.util.Set;
 
         mDistinctId = null;
         mUnseenNotifications = new LinkedList<InAppNotification>();
-        mNotificationIds = new HashSet<Integer>();
+        mNotificationIds = new HashSet<Integer>(notificationIds);
         mVariants = new JSONArray();
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -14,7 +14,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.mixpanel.android.R;
 import com.mixpanel.android.takeoverinapp.TakeoverInAppActivity;
@@ -28,7 +27,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.DateFormat;
@@ -1344,7 +1342,7 @@ public class MixpanelAPI {
     }
 
     /* package */ DecideMessages constructDecideUpdates(final String token, final DecideMessages.OnNewResultsListener listener, UpdatesFromMixpanel updatesFromMixpanel) {
-        return new DecideMessages(mContext, token, listener, updatesFromMixpanel);
+        return new DecideMessages(mContext, token, listener, updatesFromMixpanel, mPersistentIdentity.getSeenCampaignIds());
     }
 
     /* package */ UpdatesListener constructUpdatesListener() {
@@ -1551,6 +1549,7 @@ public class MixpanelAPI {
         public void trackNotificationSeen(InAppNotification notif) {
             if(notif == null) return;
 
+            mPersistentIdentity.saveCampaignAsSeen(notif.getId());
             trackNotification("$campaign_delivery", notif);
             final MixpanelAPI.People people = getPeople().withIdentity(getDistinctId());
             final DateFormat dateFormat = new SimpleDateFormat(ENGAGE_DATE_FORMAT_STRING, Locale.US);


### PR DESCRIPTION
So in case there is no connectivity and the user opens up the app again later, the SDK will make sure we don't show the same in-app twice (i.e. `decide` won't know that the notification was seen until we flush again / connectivity is restored).