### PR TITLE
Use GAID as Distinct ID for new users

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -15,7 +15,6 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 
 import com.mixpanel.android.R;
 import com.mixpanel.android.takeoverinapp.TakeoverInAppActivity;
@@ -255,7 +254,6 @@ public class MixpanelAPI {
         registerMixpanelActivityLifecycleCallbacks();
 
         if (sendAppOpen()) {
-            track("$app_open", null);
             track("$app_open", null);
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
@@ -9,15 +9,12 @@ import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.lang.reflect.Method;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
@@ -39,7 +36,7 @@ import com.mixpanel.android.util.MPLog;
             try {
                 waitingObjects = new JSONArray(waitingPeopleRecords);
             } catch (final JSONException e) {
-                MPLog.e(LOGTAG, "Waiting people records we  re unreadable.");
+                MPLog.e(LOGTAG, "Waiting people records were unreadable.");
                 return null;
             }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
@@ -547,7 +547,6 @@ import com.mixpanel.android.util.MPLog;
 
     // All access should be synchronized on this
     private void readIdentities() {
-        MPLog.e(LOGTAG, "readIdentities");
         SharedPreferences prefs = null;
         try {
             prefs = mLoadStoredPreferences.get();
@@ -621,14 +620,12 @@ import com.mixpanel.android.util.MPLog;
 
     // All access should be synchronized on this
     private void writeIdentities() {
-        MPLog.e(LOGTAG, "writeIdentities");
         try {
             final SharedPreferences prefs = mLoadStoredPreferences.get();
             final SharedPreferences.Editor prefsEditor = prefs.edit();
 
             prefsEditor.putString("events_distinct_id", mEventsDistinctId);
             prefsEditor.putString("people_distinct_id", mPeopleDistinctId);
-            MPLog.e(LOGTAG, "Distinct ID: " + mEventsDistinctId);
             if (mWaitingPeopleRecords == null) {
                 prefsEditor.remove("waiting_array");
             } else {


### PR DESCRIPTION
Use GAID as Distinct ID for new users, also adding this as a super property and a people property. This PR uses delay to wait for the asynch GAID to return, and only then starts to process events and people updates requested on the main thread. Although this might not be a final solution due to the asycnh issues with getting the GAID, hopefully it can serve as inspiration for one.