### PR TITLE
properties for $campaign_open for the cta url and if the button was p…

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MockMixpanel.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MockMixpanel.java
@@ -168,7 +168,7 @@ class MockMixpanel extends MixpanelAPI {
         }
 
         @Override
-        public void trackNotification(String eventName, InAppNotification notif) {
+        public void trackNotification(String eventName, InAppNotification notif, JSONObject properties) {
             Assert.fail("Unexpected call");
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/InAppFragment.java
@@ -35,6 +35,9 @@ import com.mixpanel.android.R;
 import com.mixpanel.android.util.MPLog;
 import com.mixpanel.android.util.ViewUtils;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 /**
  * Attached to an Activity when you display a mini in-app notification.
  *
@@ -135,6 +138,7 @@ public class InAppFragment extends Fragment {
             public boolean onSingleTapUp(MotionEvent event) {
                 final MiniInAppNotification inApp = (MiniInAppNotification) mDisplayState.getInAppNotification();
 
+                JSONObject trackingProperties = null;
                 final String uriString = inApp.getCtaUrl();
                 if (uriString != null && uriString.length() > 0) {
                     Uri uri;
@@ -148,11 +152,18 @@ public class InAppFragment extends Fragment {
                     try {
                         Intent viewIntent = new Intent(Intent.ACTION_VIEW, uri);
                         mParent.startActivity(viewIntent);
-                        mMixpanel.getPeople().trackNotification("$campaign_open", inApp);
                     } catch (ActivityNotFoundException e) {
                         MPLog.i(LOGTAG, "User doesn't have an activity for notification URI " + uri);
                     }
+
+                    try {
+                        trackingProperties = new JSONObject();
+                        trackingProperties.put("url", uriString);
+                    } catch (final JSONException e) {
+                        MPLog.e(LOGTAG, "Can't put url into json properties");
+                    }
                 }
+                mMixpanel.getPeople().trackNotification("$campaign_open", inApp, trackingProperties);
 
                 remove();
                 return true;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1165,8 +1165,10 @@ public class MixpanelAPI {
          * @param eventName the name to use when the event is tracked.
          *
          * @param notif the {@link com.mixpanel.android.mpmetrics.InAppNotification} associated with the event you'd like to track.
+         *
+         * @param properties additional properties to be tracked with the event.
          */
-        public void trackNotification(String eventName, InAppNotification notif);
+        public void trackNotification(String eventName, InAppNotification notif, JSONObject properties);
 
         /**
          * Returns an InAppNotification object if one is available and being held by the library, or null if
@@ -1586,7 +1588,7 @@ public class MixpanelAPI {
             if(notif == null) return;
 
             mPersistentIdentity.saveCampaignAsSeen(notif.getId());
-            trackNotification("$campaign_delivery", notif);
+            trackNotification("$campaign_delivery", notif, null);
             final MixpanelAPI.People people = getPeople().withIdentity(getDistinctId());
             final DateFormat dateFormat = new SimpleDateFormat(ENGAGE_DATE_FORMAT_STRING, Locale.US);
             final JSONObject notifProperties = notif.getCampaignProperties();
@@ -1622,8 +1624,20 @@ public class MixpanelAPI {
         }
 
         @Override
-        public void trackNotification(final String eventName, final InAppNotification notif) {
-            track(eventName, notif.getCampaignProperties());
+        public void trackNotification(final String eventName, final InAppNotification notif, final JSONObject properties) {
+            JSONObject notificationProperties = notif.getCampaignProperties();
+            if (properties != null) {
+                try {
+                    Iterator<String> keyIterator = properties.keys();
+                    while (keyIterator.hasNext()) {
+                        String key = keyIterator.next();
+                        notificationProperties.put(key, properties.get(key));
+                    }
+                } catch (final JSONException e) {
+                    MPLog.e(LOGTAG, "Exception merging provided properties with notification properties", e);
+                }
+            }
+            track(eventName, notificationProperties);
         }
 
         @Override

--- a/src/main/java/com/mixpanel/android/takeoverinapp/TakeoverInAppActivity.java
+++ b/src/main/java/com/mixpanel/android/takeoverinapp/TakeoverInAppActivity.java
@@ -205,7 +205,7 @@ public class TakeoverInAppActivity extends Activity {
                     String whichButton = "primary";
                     final TakeoverInAppNotification takeoverInApp = (TakeoverInAppNotification)inApp;
                     if (takeoverInApp.getNumButtons() == 2) {
-                        whichButton = (buttonIndex == 0) ? "primary" : "secondary";
+                        whichButton = (buttonIndex == 0) ? "secondary" : "primary";
                     }
                     try {
                         if (trackingProperties == null) {


### PR DESCRIPTION
…rimary or secondary. also now always track $campaign_open if they tap on either button or mini, instead of only if there was a ctal url

this is currently untested. i don't know how to use gradle to point the test app at my local changes. will ask in person later this week