### PR TITLE
Change thread priority to THREAD_PRIORITY_BACKGROUND

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Process;
 import android.test.AndroidTestCase;
 
 import com.mixpanel.android.util.Base64Coder;
@@ -118,7 +119,7 @@ public class AutomaticEventsTest extends AndroidTestCase {
                 return new Worker() {
                     @Override
                     protected Handler restartWorkerThread() {
-                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Thread.MIN_PRIORITY);
+                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Process.THREAD_PRIORITY_BACKGROUND);
                         thread.start();
                         final Handler ret = new AnalyticsMessageHandler(thread.getLooper()) {
                             @Override
@@ -277,7 +278,7 @@ public class AutomaticEventsTest extends AndroidTestCase {
                 return new Worker() {
                     @Override
                     protected Handler restartWorkerThread() {
-                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Thread.MIN_PRIORITY);
+                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Process.THREAD_PRIORITY_BACKGROUND);
                         thread.start();
                         final Handler ret = new AnalyticsMessageHandler(thread.getLooper()) {
                             @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Process;
 import android.test.AndroidTestCase;
 
 import com.mixpanel.android.util.HttpService;
@@ -95,7 +96,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
                 return new Worker() {
                     @Override
                     protected Handler restartWorkerThread() {
-                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Thread.MIN_PRIORITY);
+                        final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Process.THREAD_PRIORITY_BACKGROUND);
                         thread.start();
                         final Handler ret = new AnalyticsMessageHandler(thread.getLooper()) {
                             @Override

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -6,6 +6,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
+import android.os.Process;
 import android.os.SystemClock;
 import android.util.DisplayMetrics;
 
@@ -249,7 +250,7 @@ import javax.net.ssl.SSLSocketFactory;
         // NOTE that the returned worker will run FOREVER, unless you send a hard kill
         // (which you really shouldn't)
         protected Handler restartWorkerThread() {
-            final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Thread.MIN_PRIORITY);
+            final HandlerThread thread = new HandlerThread("com.mixpanel.android.AnalyticsWorker", Process.THREAD_PRIORITY_BACKGROUND);
             thread.start();
             final Handler ret = new AnalyticsMessageHandler(thread.getLooper());
             return ret;


### PR DESCRIPTION
https://github.com/mixpanel/mixpanel-android/issues/487

We were using `Thread.MIN_PRIORITY` (constant value: 1) which is the equivalent to `Process. THREAD_PRIORITY_LESS_FAVORABLE` since `HandlerThread` uses `Process. setThreadPriority()`