### PR TITLE
ViewCrawler improvements

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
@@ -253,6 +253,11 @@ public class DecideCheckerTest extends AndroidTestCase {
         }
 
         @Override
+        public void applyPersistedUpdates() {
+
+        }
+
+        @Override
         public void setEventBindings(JSONArray bindings) {
             assertTrue(mStarted);
             bindingsSeen.add(bindings);

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -346,6 +346,12 @@ public class DecideFunctionalTest extends AndroidTestCase {
     }
 
     private class MockUpdates implements UpdatesFromMixpanel {
+
+        @Override
+        public void applyPersistedUpdates() {
+
+        }
+
         @Override
         public void startUpdates() {
             ;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
@@ -34,6 +34,10 @@ public class DecideMessagesTest extends AndroidTestCase {
             }
 
             @Override
+            public void applyPersistedUpdates() {
+            }
+
+            @Override
             public void setEventBindings(JSONArray bindings) {
                 ; // TODO should observe bindings here
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -174,10 +174,14 @@ import javax.net.ssl.SSLSocketFactory;
             this.message = message;
         }
 
+        @Override
+        public String toString() {
+            return message.toString();
+        }
+
         public JSONObject getMessage() {
             return message;
         }
-
 
         private final JSONObject message;
     }
@@ -191,6 +195,7 @@ import javax.net.ssl.SSLSocketFactory;
             super(token);
             this.checkDecide = checkDecide;
         }
+
 
         public boolean shouldCheckDecide() {
             return checkDecide;

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideChecker.java
@@ -83,7 +83,9 @@ import javax.net.ssl.SSLSocketFactory;
             final String distinctId = updates.getDistinctId();
             try {
                 final Result result = runDecideCheck(updates.getToken(), distinctId, poster);
-                updates.reportResults(result.notifications, result.eventBindings, result.variants, result.automaticEvents);
+                if (result != null) {
+                    updates.reportResults(result.notifications, result.eventBindings, result.variants, result.automaticEvents);
+                }
             } catch (final UnintelligibleMessageException e) {
                 MPLog.e(LOGTAG, e.getMessage(), e);
             }
@@ -104,25 +106,25 @@ import javax.net.ssl.SSLSocketFactory;
 
         MPLog.v(LOGTAG, "Mixpanel decide server response was:\n" + responseString);
 
-        Result parsed = new Result();
-        if (null != responseString) {
-            parsed = parseDecideResponse(responseString);
-        }
+        Result parsedResult = null;
+        if (responseString != null) {
+            parsedResult = parseDecideResponse(responseString);
 
-        final Iterator<InAppNotification> notificationIterator = parsed.notifications.iterator();
-        while (notificationIterator.hasNext()) {
-            final InAppNotification notification = notificationIterator.next();
-            final Bitmap image = getNotificationImage(notification, mContext);
-            if (null == image) {
-                MPLog.i(LOGTAG, "Could not retrieve image for notification " + notification.getId() +
-                        ", will not show the notification.");
-                notificationIterator.remove();
-            } else {
-                notification.setImage(image);
+            final Iterator<InAppNotification> notificationIterator = parsedResult.notifications.iterator();
+            while (notificationIterator.hasNext()) {
+                final InAppNotification notification = notificationIterator.next();
+                final Bitmap image = getNotificationImage(notification, mContext);
+                if (null == image) {
+                    MPLog.i(LOGTAG, "Could not retrieve image for notification " + notification.getId() +
+                            ", will not show the notification.");
+                    notificationIterator.remove();
+                } else {
+                    notification.setImage(image);
+                }
             }
         }
 
-        return parsed;
+        return parsedResult;
     }// runDecideCheck
 
     /* package */ static Result parseDecideResponse(String responseString)

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -30,7 +30,7 @@ import java.util.Set;
         mDistinctId = null;
         mUnseenNotifications = new LinkedList<InAppNotification>();
         mNotificationIds = new HashSet<Integer>(notificationIds);
-        mVariants = new JSONArray();
+        mVariants = null;
     }
 
     public String getToken() {
@@ -82,7 +82,7 @@ import java.util.Set;
             }
         }
 
-        if (hasNewVariants) {
+        if (hasNewVariants && mVariants != null) {
             mLoadedVariants.clear();
 
             for (int i = 0; i < newVariantsLength; i++) {
@@ -94,16 +94,19 @@ import java.util.Set;
                 }
             }
         }
+
         if (mAutomaticEventsEnabled == null && !automaticEvents) {
             MPDbAdapter.getInstance(mContext).cleanupAutomaticEvents(mToken);
         }
         mAutomaticEventsEnabled = automaticEvents;
 
         // in the case we do not receive a new variant, this means the A/B test should be turned off
-        if (newVariantsLength == 0 && mLoadedVariants.size() > 0) {
-            mLoadedVariants.clear();
+        if (newVariantsLength == 0) {
             mVariants = new JSONArray();
-            newContent = true;
+            if (mLoadedVariants.size() > 0) {
+                mLoadedVariants.clear();
+                newContent = true;
+            }
         }
 
         MPLog.v(LOGTAG, "New Decide content has become available. " +
@@ -156,7 +159,7 @@ import java.util.Set;
     }
 
     public synchronized boolean hasUpdatesAvailable() {
-        return (! mUnseenNotifications.isEmpty()) || mVariants.length() > 0;
+        return (! mUnseenNotifications.isEmpty()) || (mVariants != null && mVariants.length() > 0);
     }
 
     public Boolean isAutomaticEventsEnabled() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1330,6 +1330,12 @@ public class MixpanelAPI {
         return false;
     }
 
+
+    /* package */ void onBackground() {
+        flush();
+        mUpdatesFromMixpanel.applyPersistedUpdates();
+    }
+
     // Package-level access. Used (at least) by GCMReceiver
     // when OS-level events occur.
     /* package */ interface InstanceProcessor {
@@ -1978,6 +1984,11 @@ public class MixpanelAPI {
 
         @Override
         public void startUpdates() {
+            // No op
+        }
+
+        @Override
+        public void applyPersistedUpdates() {
             // No op
         }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -95,7 +95,7 @@ import java.text.DecimalFormat;
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
-                    mMpInstance.flush();
+                    mMpInstance.onBackground();
                 }
             }
         }, CHECK_DELAY);

--- a/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelTweaksUpdatedListener.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelTweaksUpdatedListener.java
@@ -6,5 +6,12 @@ import java.util.Set;
  * For use with {@link MixpanelAPI.People#addOnMixpanelTweaksUpdatedListener(OnMixpanelTweaksUpdatedListener)}
  */
 public interface OnMixpanelTweaksUpdatedListener {
+    /**
+     * Called when the Mixpanel library has updated tweaks.
+     * This method will not be called once per tweak update, but rather any time a batch of updates
+     * becomes available.
+     *
+     * @param updatedTweaksName The set of tweak names that were updated.
+     */
     public void onMixpanelTweakUpdated(Set<String> updatedTweaksName);
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelTweaksUpdatedListener.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/OnMixpanelTweaksUpdatedListener.java
@@ -1,8 +1,10 @@
 package com.mixpanel.android.mpmetrics;
 
+import java.util.Set;
+
 /**
  * For use with {@link MixpanelAPI.People#addOnMixpanelTweaksUpdatedListener(OnMixpanelTweaksUpdatedListener)}
  */
 public interface OnMixpanelTweaksUpdatedListener {
-    public void onMixpanelTweakUpdated();
+    public void onMixpanelTweakUpdated(Set<String> updatedTweaksName);
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -230,9 +230,13 @@ public class Tweaks {
             return maximum;
         }
 
+        public Object getValue() {
+            return value;
+        }
+
         public final @TweakType int type;
 
-        protected final Object value;
+        private final Object value;
         private final Object defaultValue;
         private final Number minimum;
         private final Number maximum;

--- a/src/main/java/com/mixpanel/android/viewcrawler/EditorConnection.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/EditorConnection.java
@@ -58,6 +58,10 @@ import java.nio.ByteBuffer;
         return !mClient.isClosed() && !mClient.isClosing() && !mClient.isFlushAndClose();
     }
 
+    public boolean isConnected() {
+        return mClient.isOpen();
+    }
+
     public BufferedOutputStream getBufferedOutputStream() {
         return new BufferedOutputStream(new WebSocketOutputStream());
     }

--- a/src/main/java/com/mixpanel/android/viewcrawler/UpdatesFromMixpanel.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/UpdatesFromMixpanel.java
@@ -9,6 +9,7 @@ import org.json.JSONArray;
    implemented in client code. */
 public interface UpdatesFromMixpanel {
     public void startUpdates();
+    public void applyPersistedUpdates();
     public void setEventBindings(JSONArray bindings);
     public void setVariants(JSONArray variants);
     public Tweaks getTweaks();


### PR DESCRIPTION
- Persist ab tweaks / UI updates
- AB tweaks / codeless events were removed if a decide response failed (i.e. no connectivity)
- Call `onMixpanelTweakUpdated` after tweaks are updated
- When connected to our codeless visual editor, codeless events would be sent twice.
- When connected to our codeless visual editor, removing a codeless event would not completely remove in that moment.
- When connected to our codeless visual editor, a decide response would override changes made during the session.