### PR TITLE
Persist variants as soon as we receive them

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideCheckerTest.java
@@ -234,7 +234,10 @@ public class DecideCheckerTest extends AndroidTestCase {
 
         @Override
         public void applyPersistedUpdates() {
+        }
 
+        @Override
+        public void storeVariants(JSONArray variants) {
         }
 
         @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -350,7 +350,10 @@ public class DecideFunctionalTest extends AndroidTestCase {
 
         @Override
         public void applyPersistedUpdates() {
+        }
 
+        @Override
+        public void storeVariants(JSONArray variants) {
         }
 
         @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideMessagesTest.java
@@ -38,6 +38,10 @@ public class DecideMessagesTest extends AndroidTestCase {
             }
 
             @Override
+            public void storeVariants(JSONArray variants) {
+            }
+
+            @Override
             public void setEventBindings(JSONArray bindings) {
                 ; // TODO should observe bindings here
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DecideMessages.java
@@ -104,6 +104,7 @@ import java.util.Set;
                 newContent = true;
             }
         }
+        mUpdatesFromMixpanel.storeVariants(mVariants);
 
         if (mAutomaticEventsEnabled == null && !automaticEvents) {
             MPDbAdapter.getInstance(mContext).cleanupAutomaticEvents(mToken);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1990,6 +1990,11 @@ public class MixpanelAPI {
         }
 
         @Override
+        public void storeVariants(JSONArray variants) {
+            // No op
+        }
+
+        @Override
         public void applyPersistedUpdates() {
             // No op
         }

--- a/src/main/java/com/mixpanel/android/viewcrawler/UpdatesFromMixpanel.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/UpdatesFromMixpanel.java
@@ -11,6 +11,7 @@ public interface UpdatesFromMixpanel {
     public void startUpdates();
     public void applyPersistedUpdates();
     public void setEventBindings(JSONArray bindings);
+    public void storeVariants(JSONArray variants);
     public void setVariants(JSONArray variants);
     public Tweaks getTweaks();
     public void addOnMixpanelTweaksUpdatedListener(OnMixpanelTweaksUpdatedListener listener);


### PR DESCRIPTION
We have historically relied on `joinExperimentsIfAvailable()` to persist experiment-related information. With this PR we will split that functionality and will persist what we get from decide as soon as it's received so we don't need to wait until `MixpanelActivityLifecycleCallbacks` does its job :)

If a user only opens the app and does not go into any other activity, new updates from decide will never be applied (unless you manually call `joinExperimentsIfAvailable()`). Now, the next time the app is open updated variants will be used.