### PR TITLE
Replace deprecated alias to solve "Task.leftShift(Closure)" warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ android {
 allprojects {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+            options.compilerArgs doLast "-Xlint:unchecked" doLast "-Xlint:deprecation"
         }
     }
 }


### PR DESCRIPTION
I think this is all you need to solve this warning:

```
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
```