### PR TITLE
Allow changing event endpoint at runtime through MPConfig

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 
 import com.mixpanel.android.BuildConfig;
+import com.mixpanel.android.util.MPConstants;
 import com.mixpanel.android.util.MPLog;
 import com.mixpanel.android.util.OfflineMode;
 
@@ -253,26 +254,29 @@ public class MPConfig {
         mNotificationChannelName = notificationChannelName;
 
         String eventsEndpoint = metaData.getString("com.mixpanel.android.MPConfig.EventsEndpoint");
-        if (null == eventsEndpoint) {
-            eventsEndpoint = "https://api.mixpanel.com/track?ip=" + (getUseIpAddressForGeolocation() ? "1" : "0");
+        if (eventsEndpoint != null) {
+            setEventsEndpoint(eventsEndpoint);
+        } else {
+            setMixpanelEventsEndpoint();
         }
-        setEventsEndpoint(eventsEndpoint);
 
         String peopleEndpoint = metaData.getString("com.mixpanel.android.MPConfig.PeopleEndpoint");
-        if (null == peopleEndpoint) {
-            peopleEndpoint = "https://api.mixpanel.com/engage";
+        if (peopleEndpoint != null) {
+            setPeopleEndpoint(peopleEndpoint);
+        } else {
+            setMixpanelPeopleEndpoint();
         }
-        mPeopleEndpoint = peopleEndpoint;
 
         String decideEndpoint = metaData.getString("com.mixpanel.android.MPConfig.DecideEndpoint");
-        if (null == decideEndpoint) {
-            decideEndpoint = "https://decide.mixpanel.com/decide";
+        if (decideEndpoint != null) {
+            setDecideEndpoint(decideEndpoint);
+        } else {
+            setMixpanelDecideEndpoint();
         }
-        mDecideEndpoint = decideEndpoint;
 
         String editorUrl = metaData.getString("com.mixpanel.android.MPConfig.EditorUrl");
         if (null == editorUrl) {
-            editorUrl = "wss://switchboard.mixpanel.com/connect/";
+            editorUrl = MPConstants.URL.SWITCHBOARD;
         }
         mEditorUrl = editorUrl;
 
@@ -330,6 +334,10 @@ public class MPConfig {
         return mEventsEndpoint;
     }
 
+    public void setMixpanelEventsEndpoint() {
+        setEventsEndpoint(MPConstants.URL.EVENT + (getUseIpAddressForGeolocation() ? "1" : "0"));
+    }
+
     public void setEventsEndpoint(String eventsEndpoint) {
         mEventsEndpoint = eventsEndpoint;
     }
@@ -339,9 +347,25 @@ public class MPConfig {
         return mPeopleEndpoint;
     }
 
+    public void setMixpanelPeopleEndpoint() {
+        setPeopleEndpoint(MPConstants.URL.PEOPLE);
+    }
+
+    public void setPeopleEndpoint(String peopleEndpoint) {
+        mPeopleEndpoint = peopleEndpoint;
+    }
+
     // Preferred URL for pulling decide data
     public String getDecideEndpoint() {
         return mDecideEndpoint;
+    }
+
+    public void setMixpanelDecideEndpoint() {
+        setDecideEndpoint(MPConstants.URL.DECIDE);
+    }
+
+    public void setDecideEndpoint(String decideEndpoint) {
+        mDecideEndpoint = decideEndpoint;
     }
 
     // Check for and show eligible in app notifications on Activity changes
@@ -478,8 +502,8 @@ public class MPConfig {
     private final boolean mDisableViewCrawler;
     private final String[] mDisableViewCrawlerForProjects;
     private String mEventsEndpoint;
-    private final String mPeopleEndpoint;
-    private final String mDecideEndpoint;
+    private String mPeopleEndpoint;
+    private String mDecideEndpoint;
     private final boolean mAutoShowMixpanelUpdates;
     private final String mEditorUrl;
     private final String mResourcePackageName;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -254,9 +254,9 @@ public class MPConfig {
 
         String eventsEndpoint = metaData.getString("com.mixpanel.android.MPConfig.EventsEndpoint");
         if (null == eventsEndpoint) {
-            eventsEndpoint = "https://api.mixpanel.com/track?ip=" + (mUseIpAddressForGeolocation ? "1" : "0");
+            eventsEndpoint = "https://api.mixpanel.com/track?ip=" + (getUseIpAddressForGeolocation() ? "1" : "0");
         }
-        mEventsEndpoint = eventsEndpoint;
+        setEventsEndpoint(eventsEndpoint);
 
         String peopleEndpoint = metaData.getString("com.mixpanel.android.MPConfig.PeopleEndpoint");
         if (null == peopleEndpoint) {
@@ -283,33 +283,7 @@ public class MPConfig {
             mDisableViewCrawlerForProjects = new String[0];
         }
 
-        MPLog.v(LOGTAG,
-                "Mixpanel (" + VERSION + ") configured with:\n" +
-                "    AutoShowMixpanelUpdates " + getAutoShowMixpanelUpdates() + "\n" +
-                "    BulkUploadLimit " + getBulkUploadLimit() + "\n" +
-                "    FlushInterval " + getFlushInterval() + "\n" +
-                "    DataExpiration " + getDataExpiration() + "\n" +
-                "    MinimumDatabaseLimit " + getMinimumDatabaseLimit() + "\n" +
-                "    DisableAppOpenEvent " + getDisableAppOpenEvent() + "\n" +
-                "    DisableViewCrawler " + getDisableViewCrawler() + "\n" +
-                "    DisableGestureBindingUI " + getDisableGestureBindingUI() + "\n" +
-                "    DisableEmulatorBindingUI " + getDisableEmulatorBindingUI() + "\n" +
-                "    EnableDebugLogging " + DEBUG + "\n" +
-                "    TestMode " + getTestMode() + "\n" +
-                "    EventsEndpoint " + getEventsEndpoint() + "\n" +
-                "    PeopleEndpoint " + getPeopleEndpoint() + "\n" +
-                "    DecideEndpoint " + getDecideEndpoint() + "\n" +
-                "    EditorUrl " + getEditorUrl() + "\n" +
-                "    ImageCacheMaxMemoryFactor " + getImageCacheMaxMemoryFactor() + "\n" +
-                "    DisableDecideChecker " + getDisableDecideChecker() + "\n" +
-                "    IgnoreInvisibleViewsEditor " + getIgnoreInvisibleViewsEditor() + "\n" +
-                "    NotificationDefaults " + getNotificationDefaults() + "\n" +
-                "    MinimumSessionDuration: " + getMinimumSessionDuration() + "\n" +
-                "    SessionTimeoutDuration: " + getSessionTimeoutDuration() + "\n" +
-                "    NotificationChannelId: " + getNotificationChannelId() + "\n" +
-                "    NotificationChannelName: " + getNotificationChannelName() + "\n" +
-                "    NotificationChannelImportance: " + getNotificationChannelImportance()
-        );
+        MPLog.v(LOGTAG, toString());
     }
 
     // Max size of queue before we require a flush. Must be below the limit the service will accept.
@@ -354,6 +328,10 @@ public class MPConfig {
     // Preferred URL for tracking events
     public String getEventsEndpoint() {
         return mEventsEndpoint;
+    }
+
+    public void setEventsEndpoint(String eventsEndpoint) {
+        mEventsEndpoint = eventsEndpoint;
     }
 
     // Preferred URL for tracking people
@@ -408,6 +386,10 @@ public class MPConfig {
         return mNotificationChannelImportance;
     }
 
+    public boolean getUseIpAddressForGeolocation() {
+        return mUseIpAddressForGeolocation;
+    }
+
     // Pre-configured package name for resources, if they differ from the application package name
     //
     // mContext.getPackageName() actually returns the "application id", which
@@ -456,6 +438,35 @@ public class MPConfig {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Mixpanel (" + VERSION + ") configured with:\n" +
+                "    AutoShowMixpanelUpdates " + getAutoShowMixpanelUpdates() + "\n" +
+                "    BulkUploadLimit " + getBulkUploadLimit() + "\n" +
+                "    FlushInterval " + getFlushInterval() + "\n" +
+                "    DataExpiration " + getDataExpiration() + "\n" +
+                "    MinimumDatabaseLimit " + getMinimumDatabaseLimit() + "\n" +
+                "    DisableAppOpenEvent " + getDisableAppOpenEvent() + "\n" +
+                "    DisableViewCrawler " + getDisableViewCrawler() + "\n" +
+                "    DisableGestureBindingUI " + getDisableGestureBindingUI() + "\n" +
+                "    DisableEmulatorBindingUI " + getDisableEmulatorBindingUI() + "\n" +
+                "    EnableDebugLogging " + DEBUG + "\n" +
+                "    TestMode " + getTestMode() + "\n" +
+                "    EventsEndpoint " + getEventsEndpoint() + "\n" +
+                "    PeopleEndpoint " + getPeopleEndpoint() + "\n" +
+                "    DecideEndpoint " + getDecideEndpoint() + "\n" +
+                "    EditorUrl " + getEditorUrl() + "\n" +
+                "    ImageCacheMaxMemoryFactor " + getImageCacheMaxMemoryFactor() + "\n" +
+                "    DisableDecideChecker " + getDisableDecideChecker() + "\n" +
+                "    IgnoreInvisibleViewsEditor " + getIgnoreInvisibleViewsEditor() + "\n" +
+                "    NotificationDefaults " + getNotificationDefaults() + "\n" +
+                "    MinimumSessionDuration: " + getMinimumSessionDuration() + "\n" +
+                "    SessionTimeoutDuration: " + getSessionTimeoutDuration() + "\n" +
+                "    NotificationChannelId: " + getNotificationChannelId() + "\n" +
+                "    NotificationChannelName: " + getNotificationChannelName() + "\n" +
+                "    NotificationChannelImportance: " + getNotificationChannelImportance();
+    }
+
     private final int mBulkUploadLimit;
     private final int mFlushInterval;
     private final int mDataExpiration;
@@ -466,7 +477,7 @@ public class MPConfig {
     private final boolean mDisableAppOpenEvent;
     private final boolean mDisableViewCrawler;
     private final String[] mDisableViewCrawlerForProjects;
-    private final String mEventsEndpoint;
+    private String mEventsEndpoint;
     private final String mPeopleEndpoint;
     private final String mDecideEndpoint;
     private final boolean mAutoShowMixpanelUpdates;

--- a/src/main/java/com/mixpanel/android/util/MPConstants.java
+++ b/src/main/java/com/mixpanel/android/util/MPConstants.java
@@ -1,0 +1,15 @@
+package com.mixpanel.android.util;
+
+/**
+ * Created by sergioalonso on 2/15/18.
+ */
+
+public class MPConstants {
+    public static class URL {
+        public static final String DECIDE = "https://decide.mixpanel.com/decide";
+        public static final String EVENT = "https://api.mixpanel.com/track?ip=";
+        public static final String PEOPLE = "https://api.mixpanel.com/engage";
+        public static final String SWITCHBOARD = "wss://switchboard.mixpanel.com/connect/";
+    }
+
+}


### PR DESCRIPTION
Change mp default event tracking endpoint (https://api.mixpanel.com/track?ip=1) at runtime by running the following:
```
MPConfig.getInstance(this).setEventsEndpoint("https://myapp.company.com/trackendpoint/");
```

(*) Remember that if you just need to override our tracking endpoint always, you are safe by keeping using the following meta-tag in your `AndroidManifest.xml`

```
<meta-data android:name="com.mixpanel.android.MPConfig.EventsEndpoint"
            android:value="https://myapp.company.com/trackendpoint/" />
```
