### PR TITLE
Prevent NullPointerException crash

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -58,10 +58,9 @@ public class Tweaks {
             MPLog.w(LOGTAG, "Attempt to reference a tweak \"" + tweakName + "\" which has never been defined.");
             return false;
         }
-        if(container == null || container.value == null)
-            return value == null;
-        
         final TweakValue container = mTweakValues.get(tweakName);
+        if (container == null || container.value == null)
+            return value == null;
         return !container.value.equals(value);
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/Tweaks.java
@@ -58,7 +58,9 @@ public class Tweaks {
             MPLog.w(LOGTAG, "Attempt to reference a tweak \"" + tweakName + "\" which has never been defined.");
             return false;
         }
-
+        if(container == null || container.value == null)
+            return value == null;
+        
         final TweakValue container = mTweakValues.get(tweakName);
         return !container.value.equals(value);
     }


### PR DESCRIPTION
The crash is happening "randomly" (at least for us now) and asynchronously so we cannot try-catch it:
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference
       at com.mixpanel.android.mpmetrics.Tweaks.isNewValue(Tweaks.java:63)
       at com.mixpanel.android.viewcrawler.ViewCrawler$ViewCrawlerHandler.applyVariantsAndEventBindings(ViewCrawler.java:931)
       at com.mixpanel.android.viewcrawler.ViewCrawler$ViewCrawlerHandler.handleVariantsReceived(ViewCrawler.java:791)
       at com.mixpanel.android.viewcrawler.ViewCrawler$ViewCrawlerHandler.handleMessage(ViewCrawler.java:348)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:154)
       at android.os.HandlerThread.run(HandlerThread.java:61)