### PR TITLE
Preventing NullPointerException in Pathfinder method hasClassName

### DIFF
--- a/src/main/java/com/mixpanel/android/viewcrawler/Pathfinder.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/Pathfinder.java
@@ -226,9 +226,7 @@ import java.util.List;
     private static boolean hasClassName(Object o, String className) {
         Class<?> klass = o.getClass();
         while (true) {
-
             String klassCanonicalName = klass.getCanonicalName();
-
             if (klassCanonicalName != null && klassCanonicalName.equals(className)) {
                 return true;
             }

--- a/src/main/java/com/mixpanel/android/viewcrawler/Pathfinder.java
+++ b/src/main/java/com/mixpanel/android/viewcrawler/Pathfinder.java
@@ -226,7 +226,10 @@ import java.util.List;
     private static boolean hasClassName(Object o, String className) {
         Class<?> klass = o.getClass();
         while (true) {
-            if (klass.getCanonicalName().equals(className)) {
+
+            String klassCanonicalName = klass.getCanonicalName();
+
+            if (klassCanonicalName != null && klassCanonicalName.equals(className)) {
                 return true;
             }
 


### PR DESCRIPTION
Hello guys

Yesterday my team was experimenting some codeless tracking in our production environment and I noticed that when we enabled this feature, our app started to crash when users access a particular screen. Maybe it could be our fault with the screen implementation, but i think that third party libraries should not end the user experience in production apps, so, i am send this PR in order to provide more resilience to the mixpanel-android library :).

Here's the stacktrace:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
       at com.mixpanel.android.viewcrawler.Pathfinder.hasClassName(Pathfinder.java:229)
       at com.mixpanel.android.viewcrawler.Pathfinder.matches(Pathfinder.java:202)
       at com.mixpanel.android.viewcrawler.Pathfinder.findPrefixedMatch(Pathfinder.java:178)
       at com.mixpanel.android.viewcrawler.Pathfinder.findTargetsInMatchedView(Pathfinder.java:163)
       at com.mixpanel.android.viewcrawler.Pathfinder.findTargetsInMatchedView(Pathfinder.java:165)
       at com.mixpanel.android.viewcrawler.Pathfinder.findTargetsInMatchedView(Pathfinder.java:165)
       at com.mixpanel.android.viewcrawler.Pathfinder.findTargetsInRoot(Pathfinder.java:130)
       at com.mixpanel.android.viewcrawler.ViewVisitor.visit(ViewVisitor.java:591)
       at com.mixpanel.android.viewcrawler.ViewVisitor$AddAccessibilityEventVisitor.visit(ViewVisitor.java:357)
       at com.mixpanel.android.viewcrawler.EditState$EditBinding.run(EditState.java:163)
       at com.mixpanel.android.viewcrawler.EditState$EditBinding.(EditState.java:142)
       at com.mixpanel.android.viewcrawler.EditState.applyChangesFromList(EditState.java:123)
       at com.mixpanel.android.viewcrawler.EditState.applyIntendedEdits(EditState.java:112)
       at com.mixpanel.android.viewcrawler.EditState.applyEditsOnUiThread(EditState.java:83)
       at com.mixpanel.android.viewcrawler.EditState.add(EditState.java:37)
       at com.mixpanel.android.viewcrawler.ViewCrawler$LifecycleCallbacks.onActivityResumed(ViewCrawler.java:220)
       at android.app.Application.dispatchActivityResumed(Application.java:238)
       at android.app.Activity.onResume(Activity.java:1385)
       at android.support.v4.app.FragmentActivity.onResume(FragmentActivity.java:458)
       at com.br.agipag.app.generic.CommonActivity.onResume(CommonActivity.java:64)
       at com.br.agipag.app.qrcode.scanner.ScannerActivity.onResume(ScannerActivity.java:44)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1287)
       at android.app.Activity.performResume(Activity.java:7015)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4210)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4323)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3426)
       at android.app.ActivityThread.access$1100(ActivityThread.java:229)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1821)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:7325)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```

Reading the Java\`s `getCanonicalName()` method documentation, it says that it could return null if the class doesn't have a canonicalName, so this PR contains a nullability check to prevent this `NullPointerException`.

Let me know if it helps in some way :)


