### PR TITLE
Join all experiments by default

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1460,8 +1460,8 @@ public class MixpanelAPI {
         public void showNotificationIfAvailable(Activity parent);
 
         /**
-         * Applies A/B test changes, if they are present. By default, your application will attempt
-         * to join available experiments any time an activity is resumed, but you can disable this
+         * Applies all A/B test changes, if they are present. By default, your application will attempt
+         * to join only new experiments any time an activity is resumed, but you can disable this
          * automatic behavior by adding the following tag to the &lt;application&gt; tag in your AndroidManifest.xml
          * {@code
          *     <meta-data android:name="com.mixpanel.android.MPConfig.AutoShowMixpanelUpdates"
@@ -1475,6 +1475,15 @@ public class MixpanelAPI {
          * be informed that new experiments are ready.
          */
         public void joinExperimentIfAvailable();
+
+        /**
+         * Called when a new activity is resumed. It will attempt to join only new experiments but
+         * not existing ones so the user' session is not affected.
+         *
+         * Existing experiments with new values will automatically be applied on app background. If
+         * you want to apply all experiments, see {@link #joinExperimentIfAvailable()}
+         */
+        /* package */ void joinOnlyNewExperiments();
 
         /**
          * Shows the given in-app notification to the user. Display will occur just as if the
@@ -2136,6 +2145,11 @@ public class MixpanelAPI {
 
         @Override
         public void joinExperimentIfAvailable() {
+            mUpdatesFromMixpanel.applyPersistedUpdates();
+        }
+
+        @Override
+        public void joinOnlyNewExperiments() {
             final JSONArray variants = mDecideMessages.getVariants();
             mUpdatesFromMixpanel.setVariants(variants);
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -91,7 +91,7 @@ import java.util.Locale;
     @Override
     public void onActivityResumed(Activity activity) {
         if (android.os.Build.VERSION.SDK_INT >= MPConfig.UI_FEATURES_MIN_API && mConfig.getAutoShowMixpanelUpdates()) {
-            mMpInstance.getPeople().joinExperimentIfAvailable();
+            mMpInstance.getPeople().joinOnlyNewExperiments();
         }
 
         mCurrentActivity = new WeakReference<>(activity);


### PR DESCRIPTION
Change implementation of `joinExperimentsIfAvailable` so it does what it's supposed to do: join all experiments for a user at any point in time (i.e. latest response from `decide`).
Before, it'd only join new experiments so the user experience is not affected (e.g. a variant changed during the user' session that affects the UI).

Automatic attempts to join an experiment when the an activity is resumed, will only apply new experiments so by default the user' experience is always the same throughout the session.