### PR TITLE
changes to identify to get rid of alias on signups (#28)

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/PersistentIdentityTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/PersistentIdentityTest.java
@@ -200,9 +200,20 @@ public class PersistentIdentityTest extends AndroidTestCase {
         final String eventsDistinctId = mPersistentIdentity.getEventsDistinctId();
         assertEquals("eventsDistinctId should be same as anonymousId before identify", generatedAnonymousId, eventsDistinctId);
 
-
         mPersistentIdentity.setEventsDistinctId("identified_id");
         assertNotSame("anonymous id doesn't differ from eventsDistinctId post identify", generatedAnonymousId, mPersistentIdentity.getEventsDistinctId());
+    }
+
+    public void testHadPersistedDistinctId() {
+        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
+        final String eventsDistinctId = mPersistentIdentity.getEventsDistinctId();
+        assertNotNull("events distinct id is not null");
+        assertNull("no anonymous id yet", mPersistentIdentity.getAnonymousId());
+
+        mPersistentIdentity.setAnonymousIdIfAbsent("anon_id");
+
+        assertNotNull("anonymous id cannot be null", mPersistentIdentity.getAnonymousId());
+        assertTrue("hadPersistedDistinctId cannot be false", mPersistentIdentity.getHadPersistedDistinctId());
     }
 
     private PersistentIdentity mPersistentIdentity;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -502,6 +502,8 @@ public class MixpanelAPI {
     private void identify(String distinctId, boolean markAsUserId) {
         if (hasOptedOutTracking()) return;
         synchronized (mPersistentIdentity) {
+            String currentEventsDistinctId = mPersistentIdentity.getEventsDistinctId();
+            mPersistentIdentity.setAnonymousIdIfAbsent(currentEventsDistinctId);
             mPersistentIdentity.setEventsDistinctId(distinctId);
             if(markAsUserId) {
                 mPersistentIdentity.markEventsUserIdPresent();
@@ -1997,6 +1999,7 @@ public class MixpanelAPI {
             dataObj.put(actionType, properties);
             dataObj.put("$token", mToken);
             dataObj.put("$time", System.currentTimeMillis());
+            dataObj.put("$had_persisted_distinct_id", mPersistentIdentity.getHadPersistedDistinctId());
             if (null != anonymousId) {
                 dataObj.put("$device_id", anonymousId);
             }
@@ -2272,6 +2275,7 @@ public class MixpanelAPI {
             final String userId = getUserId();
             messageProps.put("time", timeSeconds);
             messageProps.put("distinct_id", distinctId);
+            messageProps.put("$had_persisted_distinct_id", mPersistentIdentity.getHadPersistedDistinctId());
             if(anonymousId != null) {
                 messageProps.put("$device_id", anonymousId);
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
@@ -159,6 +159,13 @@ import com.mixpanel.android.util.MPLog;
         return mAnonymousId;
     }
 
+    public synchronized boolean getHadPersistedDistinctId() {
+        if (! mIdentitiesLoaded) {
+           readIdentities();
+        }
+        return mHadPersistedDistinctId;
+    }
+
     public synchronized String getEventsDistinctId() {
         if (! mIdentitiesLoaded) {
             readIdentities();
@@ -174,6 +181,18 @@ import com.mixpanel.android.util.MPLog;
             return mEventsDistinctId;
         }
         return null;
+    }
+
+    public synchronized void setAnonymousIdIfAbsent(String anonymousId) {
+        if (! mIdentitiesLoaded) {
+            readIdentities();
+        }
+        if (mAnonymousId != null) {
+            return;
+        }
+        mAnonymousId = anonymousId;
+        mHadPersistedDistinctId = true;
+        writeIdentities();
     }
 
     public synchronized void setEventsDistinctId(String eventsDistinctId) {
@@ -630,6 +649,7 @@ import com.mixpanel.android.util.MPLog;
         mEventsUserIdPresent = prefs.getBoolean("events_user_id_present", false);
         mPeopleDistinctId = prefs.getString("people_distinct_id", null);
         mAnonymousId = prefs.getString("anonymous_id", null);
+        mHadPersistedDistinctId = prefs.getBoolean("had_persisted_distinct_id", false);
         mWaitingPeopleRecords = null;
 
         final String storedWaitingRecord = prefs.getString("waiting_array", null);
@@ -663,7 +683,6 @@ import com.mixpanel.android.util.MPLog;
         if (prefs == null) {
             return;
         }
-
         mIsUserOptOut = prefs.getBoolean("opt_out_" + token, false);
     }
 
@@ -689,6 +708,7 @@ import com.mixpanel.android.util.MPLog;
             prefsEditor.putBoolean("events_user_id_present", mEventsUserIdPresent);
             prefsEditor.putString("people_distinct_id", mPeopleDistinctId);
             prefsEditor.putString("anonymous_id", mAnonymousId);
+            prefsEditor.putBoolean("had_persisted_distinct_id", mHadPersistedDistinctId);
             if (mWaitingPeopleRecords == null) {
                 prefsEditor.remove("waiting_array");
             } else {
@@ -718,6 +738,7 @@ import com.mixpanel.android.util.MPLog;
     private boolean mEventsUserIdPresent;
     private String mPeopleDistinctId;
     private String mAnonymousId;
+    private boolean mHadPersistedDistinctId;
     private JSONArray mWaitingPeopleRecords;
     private Boolean mIsUserOptOut;
     private static Integer sPreviousVersionCode;


### PR DESCRIPTION
* Adding a flag when there is already persisted distinct id