### PR TITLE
Push notification improvements

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/FCMMessagingServiceTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/FCMMessagingServiceTest.java
@@ -14,8 +14,7 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
     @Override
     public void setUp() throws PackageManager.NameNotFoundException {
         // ACTION_BUG_REPORT is chosen because it's identifiably weird
-        final Intent defaultIntent = new Intent(Intent.ACTION_BUG_REPORT);
-        mFCMMessaging = new TestFCMMessagingService(defaultIntent);
+        mDefaultIntent = new Intent(Intent.ACTION_BUG_REPORT);
         final Map<String, Integer> resources = new HashMap<String, Integer>();
         resources.put("ic_pretend_icon", 12345);
         mResourceIds = new TestUtils.TestResourceIds(resources);
@@ -29,7 +28,7 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
 
     public void testNotificationEmptyIntent() {
         final Intent intent = new Intent();
-        assertNull(mFCMMessaging.readInboundIntent(this.getContext(), intent, mResourceIds));
+        assertNull(MixpanelFCMMessagingService.readInboundIntent(this.getContext(), intent, mResourceIds, mDefaultIntent));
     }
 
     public void testCompleteNotification() {
@@ -38,7 +37,7 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
         intent.putExtra("mp_icnm", "ic_pretend_icon");
         intent.putExtra("mp_title", "TITLE");
         intent.putExtra("mp_cta", mGoodUri.toString());
-        final MixpanelFCMMessagingService.NotificationData created = mFCMMessaging.readInboundIntent(getContext(), intent, mResourceIds);
+        final MixpanelFCMMessagingService.NotificationData created = MixpanelFCMMessagingService.readInboundIntent(getContext(), intent, mResourceIds, mDefaultIntent);
 
         assertEquals(created.icon, 12345);
         assertEquals(created.title, "TITLE");
@@ -50,7 +49,7 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
     public void testMinimalNotification(){
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
-        final MixpanelFCMMessagingService.NotificationData created = mFCMMessaging.readInboundIntent(getContext(), intent, mResourceIds);
+        final MixpanelFCMMessagingService.NotificationData created = MixpanelFCMMessagingService.readInboundIntent(getContext(), intent, mResourceIds, mDefaultIntent);
         assertEquals(created.icon, mDefaultIcon);
         assertEquals(created.title, mDefaultTitle);
         assertEquals(created.message, "MESSAGE");
@@ -61,7 +60,7 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_icnm", "NO SUCH ICON");
-        final MixpanelFCMMessagingService.NotificationData created = mFCMMessaging.readInboundIntent(getContext(), intent, mResourceIds);
+        final MixpanelFCMMessagingService.NotificationData created = MixpanelFCMMessagingService.readInboundIntent(getContext(), intent, mResourceIds, mDefaultIntent);
 
         assertEquals(created.icon, mDefaultIcon);
     }
@@ -70,26 +69,13 @@ public class FCMMessagingServiceTest extends AndroidTestCase {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_cta", (String) null);
-        final MixpanelFCMMessagingService.NotificationData created = mFCMMessaging.readInboundIntent(getContext(), intent, mResourceIds);
+        final MixpanelFCMMessagingService.NotificationData created = MixpanelFCMMessagingService.readInboundIntent(getContext(), intent, mResourceIds, mDefaultIntent);
         assertNull(created.intent.getData());
-    }
-
-    private static class TestFCMMessagingService extends MixpanelFCMMessagingService {
-        public TestFCMMessagingService(Intent aDummy) {
-            dummyIntent = aDummy;
-        }
-
-        @Override
-        public Intent getDefaultIntent(Context context) {
-            return dummyIntent;
-        }
-
-        public final Intent dummyIntent;
     }
 
     private CharSequence mDefaultTitle;
     private int mDefaultIcon;
-    private TestFCMMessagingService mFCMMessaging;
+    private Intent mDefaultIntent;
     private ResourceIds mResourceIds;
     private Uri mGoodUri;
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -14,8 +14,11 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
-import android.support.v4.app.NotificationCompat;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.mixpanel.android.util.MPLog;
@@ -110,25 +113,55 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         public static final int NOT_SET = -1;
     }
 
+    /* package */ static void init() {
+        FirebaseInstanceId.getInstance().getInstanceId()
+                .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+                    @Override
+                    public void onComplete(Task<InstanceIdResult> task) {
+                        if (task.isSuccessful()) {
+                            String registrationId = task.getResult().getToken();
+                            addToken(registrationId);
+                        }
+                    }
+                });
+    }
+
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
+        MPLog.d(LOGTAG, "MP FCM on new message received");
         onMessageReceived(getApplicationContext(), remoteMessage.toIntent());
     }
 
     @Override
-    public void onNewToken(final String token) {
+    public void onNewToken(String token) {
         super.onNewToken(token);
-        MPLog.d(LOGTAG, "MP FCM new push token: " + token);
-        MixpanelAPI.allInstances(new MixpanelAPI.InstanceProcessor() {
-            @Override
-            public void process(MixpanelAPI api) {
-                api.getPeople().setPushRegistrationId(token);
-            }
-        });
+        MPLog.d(LOGTAG, "MP FCM on new push token: " + token);
+        addToken(token);
     }
 
-    public void onMessageReceived(Context context, Intent messageIntent) {
+    /**
+     * Util method to let subclasses customize the payload through the push notification intent.
+     *
+     * @param context The application context
+     * @param intent Push payload intent. Could be modified before calling super() from a sub-class.
+     *
+     */
+    protected void onMessageReceived(Context context, Intent intent) {
+        showPushNotification(context, intent);
+    }
+
+    /**
+     * Only use this method if you have implemented your own custom FirebaseMessagingService. This
+     * is useful when you use multiple push providers.
+     * Displays a Mixpanel push notification on the device.
+     *
+     * @param context The application context you are tracking
+     * @param messageIntent Intent that bundles the data used to build a notification. If the intent
+     *                      is not valid, the notification will not be shown.
+     *                      See {@link #showPushNotification(Context, Intent)}
+     */
+    public static void showPushNotification(Context context, Intent messageIntent) {
         final MPConfig config = MPConfig.getInstance(context);
         String resourcePackage = config.getResourcePackageName();
         if (null == resourcePackage) {
@@ -145,7 +178,24 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         }
     }
 
-    private Notification buildNotification(Context context, Intent inboundIntent, ResourceIds iconIds) {
+    /**
+     * Only use this method if you have implemented your own custom FirebaseMessagingService. This
+     * is useful when you use multiple push providers.
+     * This method should be called from a onNewToken callback. It adds a new FCM token to a Mixpanel
+     * people profile.
+     *
+     * @param token Firebase Cloud Messaging token to be added to the people profile.
+     */
+    public static void addToken(final String token) {
+        MixpanelAPI.allInstances(new MixpanelAPI.InstanceProcessor() {
+            @Override
+            public void process(MixpanelAPI api) {
+                api.getPeople().setPushRegistrationId(token);
+            }
+        });
+    }
+
+    private static Notification buildNotification(Context context, Intent inboundIntent, ResourceIds iconIds) {
         final MixpanelFCMMessagingService.NotificationData notificationData = readInboundIntent(context, inboundIntent, iconIds);
         if (null == notificationData) {
             return null;
@@ -166,10 +216,8 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
             notification = makeNotificationSDK21OrHigher(context, contentIntent, notificationData);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             notification = makeNotificationSDK16OrHigher(context, contentIntent, notificationData);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            notification = makeNotificationSDK11OrHigher(context, contentIntent, notificationData);
         } else {
-            notification = makeNotificationSDKLessThan11(context, contentIntent, notificationData);
+            notification = makeNotificationSDK11OrHigher(context, contentIntent, notificationData);
         }
 
         return notification;
@@ -180,7 +228,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
      */
     @SuppressLint("NewApi")
     @TargetApi(26)
-    protected Notification makeNotificationSDK26OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
+    protected static Notification makeNotificationSDK26OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
         NotificationManager mNotificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
@@ -228,29 +276,8 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
     }
 
     @SuppressWarnings("deprecation")
-    @TargetApi(9)
-    protected Notification makeNotificationSDKLessThan11(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
-        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context).
-                setSmallIcon(notificationData.icon).
-                setTicker(notificationData.message).
-                setWhen(System.currentTimeMillis()).
-                setContentTitle(notificationData.title).
-                setContentText(notificationData.message).
-                setContentIntent(intent).
-                setDefaults(MPConfig.getInstance(context).getNotificationDefaults());
-
-        if (notificationData.largeIcon != MixpanelFCMMessagingService.NotificationData.NOT_SET) {
-            builder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), notificationData.largeIcon));
-        }
-
-        final Notification n = builder.getNotification();
-        n.flags |= Notification.FLAG_AUTO_CANCEL;
-        return n;
-    }
-
-    @SuppressWarnings("deprecation")
     @TargetApi(11)
-    protected Notification makeNotificationSDK11OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
+    protected static Notification makeNotificationSDK11OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setSmallIcon(notificationData.icon).
                 setTicker(notificationData.message).
@@ -271,7 +298,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
 
     @SuppressLint("NewApi")
     @TargetApi(16)
-    protected Notification makeNotificationSDK16OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
+    protected static Notification makeNotificationSDK16OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setSmallIcon(notificationData.icon).
                 setTicker(notificationData.message).
@@ -293,7 +320,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
 
     @SuppressLint("NewApi")
     @TargetApi(21)
-    protected Notification makeNotificationSDK21OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
+    protected static Notification makeNotificationSDK21OrHigher(Context context, PendingIntent intent, MixpanelFCMMessagingService.NotificationData notificationData) {
         final Notification.Builder builder = new Notification.Builder(context).
                 setTicker(notificationData.message).
                 setWhen(System.currentTimeMillis()).
@@ -322,7 +349,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         return n;
     }
 
-    /* package */ NotificationData readInboundIntent(Context context, Intent inboundIntent, ResourceIds iconIds) {
+    /* package */ static NotificationData readInboundIntent(Context context, Intent inboundIntent, ResourceIds iconIds) {
         final PackageManager manager = context.getPackageManager();
 
         final String message = inboundIntent.getStringExtra("mp_message");
@@ -398,7 +425,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         return new MixpanelFCMMessagingService.NotificationData(notificationIcon, largeNotificationIcon, whiteNotificationIcon, notificationTitle, message, notificationIntent, color);
     }
 
-    private Intent buildNotificationIntent(Context context, String uriString, String campaignId, String messageId, String extraLogData) {
+    private static Intent buildNotificationIntent(Context context, String uriString, String campaignId, String messageId, String extraLogData) {
         Uri uri = null;
         if (null != uriString) {
             uri = Uri.parse(uriString);
@@ -427,12 +454,12 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
     }
 
 
-    /* package */ Intent getDefaultIntent(Context context) {
+    /* package */ static Intent getDefaultIntent(Context context) {
         final PackageManager manager = context.getPackageManager();
         return manager.getLaunchIntentForPackage(context.getPackageName());
     }
 
-    private void trackCampaignReceived(final String campaignId, final String messageId, final String extraLogData) {
+    private static void trackCampaignReceived(final String campaignId, final String messageId, final String extraLogData) {
         if (campaignId != null && messageId != null) {
             MixpanelAPI.allInstances(new MixpanelAPI.InstanceProcessor() {
                 @Override


### PR DESCRIPTION
This PR adds fixes various bugs and adds some improvements to our sdk push notification capabilities:

### Allow sub-classes to override push notifications payload
```java
public class CustomMixpanelFirebaseMessaging extends MixpanelFCMMessagingService {
    @Override
    protected void onMessageReceived(Context context, Intent intent) {
        if (intent.getExtras().containsKey("mp_message")) {
            intent.putExtra("mp_message", "CUSTOM MESSAGE");
        }
        super.onMessageReceived(context, intent);
    }
}
```
### Support when more than one push provider is used
Google doesn't allow an app to have more than one handler for `com.google.firebase.MESSAGING_EVENT` intent filter. Only the first registered service will handle a firebase message. If you need to use multiple push providers, you can now easily access Mixpanel FCM handler from your custom class. Register your custom FirebaseMessagingService service and:
```java
public class PushProvidersHandler extends FirebaseMessagingService {
    @Override
    public void onNewToken(String s) {
        super.onNewToken(s);
        MixpanelFCMMessagingService.addToken(s);
    }

    @Override
    public void onMessageReceived(RemoteMessage remoteMessage) {
        super.onMessageReceived(remoteMessage);
        if (remoteMessage.getData().containsKey("mp_message")) {
            MixpanelFCMMessagingService.showPushNotification(getApplicationContext(), remoteMessage.toIntent());
        }
    }
}
```
