### PR TITLE
Add support for event triggered inapp notifications

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -341,11 +341,12 @@ public class DecideFunctionalTest extends AndroidTestCase {
 
         @Override
         public void reportResults(List<InAppNotification> newNotifications,
+                                  List<InAppNotification> newTriggeredNotifications,
                                   JSONArray eventBindings,
                                   JSONArray variants,
                                   boolean automaticEvents,
                                   JSONArray integrations) {
-            super.reportResults(newNotifications, eventBindings, variants, automaticEvents, integrations);
+            super.reportResults(newNotifications, newTriggeredNotifications, eventBindings, variants, automaticEvents, integrations);
             mExpectations.resolve();
         }
     }

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/InAppNotificationTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/InAppNotificationTest.java
@@ -1,0 +1,68 @@
+package com.mixpanel.android.mpmetrics;
+
+import android.test.AndroidTestCase;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+public class InAppNotificationTest extends AndroidTestCase {
+    public void testMatchesEventDescription() throws BadDecideObjectException, JSONException, ParseException {
+        JSONArray displayTriggers = new JSONArray();
+        displayTriggers.put(new JSONObject("{\"event\": \"test_event_1\", \"selector\": " +
+                "{\"operator\": \">\", \"children\": [{\"operator\": \"datetime\", \"children\": [" +
+                "{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"property\": \"literal\", \"value\": {\"window\": {\"value\": 1, \"unit\": \"hour\"}}}" +
+                "]}}"));
+        displayTriggers.put(new JSONObject("{\"event\": \"test_event_2\", \"selector\": " +
+                "{\"operator\": \"==\", \"children\": [{\"operator\": \"string\", \"children\": [" +
+                "{\"property\": \"event\", \"value\": \"city\"}]}," +
+                "{\"property\": \"literal\", \"value\": \"San Francisco\"}" +
+                "]}}"));
+        JSONObject obj = new JSONObject();
+        obj.put("extras", new JSONObject("{\"image_fade\": true}"));
+        obj.put("id", 1);
+        obj.put("message_id", 1);
+        obj.put("bg_color", 1);
+        obj.put("body_color", 1);
+        obj.put("image_url", "https://www.test.com/test.jpg");
+        obj.put("display_triggers", displayTriggers);
+        obj.put("buttons", new JSONArray());
+        obj.put("close_color", 1);
+        obj.put("title_color", 1);
+        final InAppNotification notif = new TakeoverInAppNotification(obj);
+
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+        final Date dt = format.parse("2019-01-02T12:00:00");
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTime(dt);
+        SelectorEvaluator.setCalendar(calendar, true);
+
+        obj = new JSONObject();
+
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_1", obj, "test")));
+        obj.put("city", "San Francisco");
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_1", obj, "test")));
+        obj.put("prop1", "2019-01-02T10:59:59");
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_1", obj, "test")));
+        obj.put("prop1", "2019-01-02T11:00:00");
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_1", obj, "test")));
+        obj.put("prop1", "2019-01-02T11:00:01");
+        assertTrue(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_1", obj, "test")));
+
+        obj = new JSONObject();
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_2", obj, "test")));
+        obj.put("city", "Los Angeles");
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_2", obj, "test")));
+        obj.put("prop1", "2019-01-02T11:00:01");
+        assertFalse(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_2", obj, "test")));
+        obj.put("city", "San Francisco");
+        assertTrue(notif.matchesEventDescription(new AnalyticsMessages.EventDescription("test_event_2", obj, "test")));
+    }
+}

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -1,5 +1,6 @@
 package com.mixpanel.android.mpmetrics;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
@@ -488,7 +489,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
                     } else {
                         assertEquals("DECIDE_ENDPOINT?version=1&lib=android&token=Test+Message+Queuing&distinct_id=EVENTS+ID" + mAppProperties, endpointUrl);
                     }
-                    return TestUtils.bytes("{}");
+                    return TestUtils.bytes("{\"notifications\":[{\"body\":\"A\",\"image_tint_color\":4294967295,\"border_color\":4294967295,\"message_id\":85151,\"bg_color\":3858759680,\"extras\":{},\"image_url\":\"https://cdn.mxpnl.com/site_media/images/engage/inapp_messages/mini/icon_megaphone.png\",\"cta_url\":null,\"type\":\"mini\",\"id\":1191793,\"body_color\":4294967295, \"display_triggers\":[{\"event\":\"test_event\"}]}]}");
                 }
 
                 assertTrue(params.containsKey("data"));
@@ -589,6 +590,8 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
             String messageFlush = messages.poll(POLL_WAIT_SECONDS, TimeUnit.SECONDS);
             assertEquals("SENT FLUSH EVENTS_ENDPOINT", messageFlush);
+
+            assertTrue(metrics.getDecideMessages().hasNotificationsAvailable());
 
             expectedJSONMessage = messages.poll(POLL_WAIT_SECONDS, TimeUnit.SECONDS);
             JSONArray bigFlush = new JSONArray(expectedJSONMessage);

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/SelectorEvaluatorTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/SelectorEvaluatorTest.java
@@ -1,0 +1,1100 @@
+package com.mixpanel.android.mpmetrics;
+
+import android.test.AndroidTestCase;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+public class SelectorEvaluatorTest extends AndroidTestCase  {
+    public void testGetType() {
+        assertEquals(SelectorEvaluator.PropertyType.Null, SelectorEvaluator.getType(null));
+        assertEquals(SelectorEvaluator.PropertyType.Null, SelectorEvaluator.getType(JSONObject.NULL));
+        assertEquals(SelectorEvaluator.PropertyType.String, SelectorEvaluator.getType("test"));
+        assertEquals(SelectorEvaluator.PropertyType.Array, SelectorEvaluator.getType(new JSONArray()));
+        assertEquals(SelectorEvaluator.PropertyType.Object, SelectorEvaluator.getType(new JSONObject()));
+        assertEquals(SelectorEvaluator.PropertyType.Number, SelectorEvaluator.getType(new Double(0)));
+        assertEquals(SelectorEvaluator.PropertyType.Number, SelectorEvaluator.getType(new Integer(0)));
+        assertEquals(SelectorEvaluator.PropertyType.Number, SelectorEvaluator.getType(new Number() {
+            @Override
+            public int intValue() {
+                return 0;
+            }
+
+            @Override
+            public long longValue() {
+                return 0;
+            }
+
+            @Override
+            public float floatValue() {
+                return 0;
+            }
+
+            @Override
+            public double doubleValue() {
+                return 0;
+            }
+        }));
+        assertEquals(SelectorEvaluator.PropertyType.Boolean, SelectorEvaluator.getType(new Boolean(true)));
+        assertEquals(SelectorEvaluator.PropertyType.Datetime, SelectorEvaluator.getType(new Date()));
+        assertEquals(SelectorEvaluator.PropertyType.Unknown, SelectorEvaluator.getType(new Object()));
+    }
+
+    public void testToNumber() {
+        assertNull(SelectorEvaluator.toNumber(null));
+        assertNull(SelectorEvaluator.toNumber(JSONObject.NULL));
+        assertNull(SelectorEvaluator.toNumber(new Date(0)));
+        assertNull(SelectorEvaluator.toNumber(new Object()));
+        assertEquals(1.0, SelectorEvaluator.toNumber(new Date(1)));
+        assertEquals(1.0, SelectorEvaluator.toNumber(new Boolean(true)));
+        assertEquals(0.0, SelectorEvaluator.toNumber(new Boolean(false)));
+        assertEquals(1.1, SelectorEvaluator.toNumber(new Double(1.1)));
+        assertEquals(new Double(1), SelectorEvaluator.toNumber(new Integer(1)));
+        assertEquals(100.0, SelectorEvaluator.toNumber(new Number() {
+            @Override
+            public int intValue() {
+                return -1;
+            }
+
+            @Override
+            public long longValue() {
+                return -1;
+            }
+
+            @Override
+            public float floatValue() {
+                return 10.0f;
+            }
+
+            @Override
+            public double doubleValue() {
+                return 100.0;
+            }
+        }));
+        assertEquals(1.0, SelectorEvaluator.toNumber("1.0"));
+        assertEquals(0.0, SelectorEvaluator.toNumber("abc"));
+    }
+
+    public void testToBoolean() throws JSONException {
+        assertFalse(SelectorEvaluator.toBoolean(null));
+        assertFalse(SelectorEvaluator.toBoolean(JSONObject.NULL));
+        assertFalse(SelectorEvaluator.toBoolean(false));
+        assertTrue(SelectorEvaluator.toBoolean(true));
+        assertFalse(SelectorEvaluator.toBoolean(0.0));
+        assertTrue(SelectorEvaluator.toBoolean(-1.0));
+        assertFalse(SelectorEvaluator.toBoolean(""));
+        assertTrue(SelectorEvaluator.toBoolean("0.0"));
+        assertFalse(SelectorEvaluator.toBoolean(new JSONArray()));
+        assertTrue(SelectorEvaluator.toBoolean(new JSONArray("[1,2,3]")));
+        assertFalse(SelectorEvaluator.toBoolean(new Date(0)));
+        assertTrue(SelectorEvaluator.toBoolean(new Date(1)));
+        assertFalse(SelectorEvaluator.toBoolean(new JSONObject("{}")));
+        assertTrue(SelectorEvaluator.toBoolean(new JSONObject("{\"prop\": 1.0}")));
+        assertFalse(SelectorEvaluator.toBoolean(new Object()));
+    }
+
+    public void testEvaluateNumber() throws JSONException, ParseException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateNumber(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: number");
+        }
+        try {
+            SelectorEvaluator.evaluateNumber(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: number");
+        }
+        try {
+            SelectorEvaluator.evaluateNumber(new JSONObject("{\"operator\": \"number\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: number");
+        }
+        try {
+            SelectorEvaluator.evaluateNumber(new JSONObject("{\"operator\": \"number\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: number");
+        }
+        try {
+            SelectorEvaluator.evaluateNumber(new JSONObject("{\"operator\": \"number\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: number");
+        }
+
+        // missing property
+        JSONObject node = new JSONObject("{\"operator\": \"number\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        assertNull(SelectorEvaluator.evaluateNumber(node, new JSONObject("{}")));
+
+        // Datetime
+        JSONObject withDateTimeCast = new JSONObject("{\"operator\": \"number\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}" +
+                "]}");
+        final Date dt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).parse("2019-01-01T00:00:01");
+        assertEquals(new Double(dt.getTime()), SelectorEvaluator.evaluateNumber(withDateTimeCast, new JSONObject("{\"prop\": \"2019-01-01T00:00:01\"}")));
+
+        // Object
+        assertNull(SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": {}}")));
+
+        // Boolean
+        assertEquals(1.0, SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": true}")));
+        assertEquals(0.0, SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": false}")));
+
+        // Number
+        assertEquals(59.0, SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": 59}")));
+
+        // String
+        assertEquals(59.0, SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": \"59\"}")));
+        assertEquals(0.0, SelectorEvaluator.evaluateNumber(node, new JSONObject("{\"prop\": \"nan\"}")));
+    }
+
+    public void testEvaluateBoolean() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateBoolean(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: boolean");
+        }
+        try {
+            SelectorEvaluator.evaluateBoolean(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: boolean");
+        }
+        try {
+            SelectorEvaluator.evaluateBoolean(new JSONObject("{\"operator\": \"boolean\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: boolean");
+        }
+        try {
+            SelectorEvaluator.evaluateBoolean(new JSONObject("{\"operator\": \"boolean\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: boolean");
+        }
+        try {
+            SelectorEvaluator.evaluateBoolean(new JSONObject("{\"operator\": \"boolean\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: boolean");
+        }
+
+        // missing property
+        JSONObject node = new JSONObject("{\"operator\": \"boolean\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{}")));
+
+        // Boolean
+        assertTrue(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": true}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": false}")));
+
+        // Number
+        assertTrue(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": 59}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": 0}")));
+
+        // String
+        assertTrue(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": \"abc\"}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": \"\"}")));
+
+        // Array
+        assertTrue(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": [1,2,3]}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": []}")));
+
+        // Dictionary
+        assertTrue(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": {\"1\": 1}}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(node, new JSONObject("{\"prop\": {}}")));
+
+        // Datetime
+        JSONObject withDateTimeCast = new JSONObject("{\"operator\": \"boolean\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}" +
+                "]}");
+        final String zeroDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).format(new Date(0));
+        final String nonZeroDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).format(new Date(100000));
+        assertTrue(SelectorEvaluator.evaluateBoolean(withDateTimeCast, new JSONObject("{\"prop\": \"" + nonZeroDate + "\"}")));
+        assertFalse(SelectorEvaluator.evaluateBoolean(withDateTimeCast, new JSONObject("{\"prop\": \"" + zeroDate + "\"}")));
+    }
+
+    public void testEvaluateDatetime() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateDateTime(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: datetime");
+        }
+        try {
+            SelectorEvaluator.evaluateDateTime(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: datetime");
+        }
+        try {
+            SelectorEvaluator.evaluateDateTime(new JSONObject("{\"operator\": \"datetime\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: datetime");
+        }
+        try {
+            SelectorEvaluator.evaluateDateTime(new JSONObject("{\"operator\": \"datetime\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: datetime");
+        }
+        try {
+            SelectorEvaluator.evaluateDateTime(new JSONObject("{\"operator\": \"datetime\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: datetime");
+        }
+
+        // missing property
+        JSONObject node = new JSONObject("{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        assertNull(SelectorEvaluator.evaluateDateTime(node, new JSONObject("{}")));
+
+        // unsupported types
+        assertNull(SelectorEvaluator.evaluateDateTime(node, new JSONObject("{\"prop\": true}")));
+
+        // Number
+        assertEquals(new Date(10), SelectorEvaluator.evaluateDateTime(node, new JSONObject("{\"prop\": 10}")));
+
+        // String
+        final String dtStr = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).format(new Date(0));
+        assertEquals(new Date(0), SelectorEvaluator.evaluateDateTime(node, new JSONObject("{\"prop\": \"" + dtStr + "\"}")));
+        assertNull(SelectorEvaluator.evaluateDateTime(node, new JSONObject("{\"prop\": \"invalid date\"}")));
+
+        // Datetime
+        JSONObject withDateTimeCast = new JSONObject("{\"operator\": \"datetime\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}" +
+                "]}");
+        final String nonZeroDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).format(new Date(100000));
+        assertEquals(new Date(100000), SelectorEvaluator.evaluateDateTime(withDateTimeCast, new JSONObject("{\"prop\": \"" + nonZeroDate + "\"}")));
+    }
+
+    public void testEvaluateList() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateList(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: list");
+        }
+        try {
+            SelectorEvaluator.evaluateList(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: list");
+        }
+        try {
+            SelectorEvaluator.evaluateList(new JSONObject("{\"operator\": \"list\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: list");
+        }
+        try {
+            SelectorEvaluator.evaluateList(new JSONObject("{\"operator\": \"list\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: list");
+        }
+        try {
+            SelectorEvaluator.evaluateList(new JSONObject("{\"operator\": \"list\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: list");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"list\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+
+        // Array
+        assertEquals(new JSONArray("[1,2,3]"), SelectorEvaluator.evaluateList(node, new JSONObject("{\"prop\": [1,2,3]}")));
+        assertEquals(new JSONArray("[]"), SelectorEvaluator.evaluateList(node, new JSONObject("{\"prop\": []}")));
+
+        // Unsupported types
+        assertNull(SelectorEvaluator.evaluateList(node, new JSONObject("{\"prop\": 1}")));
+        assertNull(SelectorEvaluator.evaluateList(node, new JSONObject("{\"prop\": \"\"}")));
+        assertNull(SelectorEvaluator.evaluateList(node, new JSONObject("{\"prop\": {}}")));
+    }
+
+    public void testEvaluateString() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateString(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: string");
+        }
+        try {
+            SelectorEvaluator.evaluateString(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: string");
+        }
+        try {
+            SelectorEvaluator.evaluateString(new JSONObject("{\"operator\": \"string\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: string");
+        }
+        try {
+            SelectorEvaluator.evaluateString(new JSONObject("{\"operator\": \"string\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: string");
+        }
+        try {
+            SelectorEvaluator.evaluateString(new JSONObject("{\"operator\": \"string\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for cast operator: string");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"string\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+
+        // Datetime
+        JSONObject withDateTimeCast = new JSONObject("{\"operator\": \"string\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}" +
+                "]}");
+        final String dtStr = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).format(new Date(100000));
+        assertEquals(dtStr, SelectorEvaluator.evaluateString(withDateTimeCast, new JSONObject("{\"prop\": \"" + dtStr + "\"}")));
+
+        // Number
+        assertEquals("100", SelectorEvaluator.evaluateString(node, new JSONObject("{\"prop\": 100}")));
+
+        // Array
+        assertEquals("[1,2,3]", SelectorEvaluator.evaluateString(node, new JSONObject("{\"prop\": [1,2,3]}")));
+
+        // Dict
+        assertEquals("{\"a\":1}", SelectorEvaluator.evaluateString(node, new JSONObject("{\"prop\": {\"a\": 1}}")));
+
+        // null
+        assertEquals("null", SelectorEvaluator.evaluateString(node, new JSONObject("{\"prop\": null}")));
+        assertNull(SelectorEvaluator.evaluateString(node, new JSONObject("{}")));
+
+        // Boolean
+        assertEquals("true", SelectorEvaluator.evaluateString(node, new JSONObject("{\"prop\": true}")));
+    }
+
+    public void testEvaluateAnd() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateAnd(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: and");
+        }
+        try {
+            SelectorEvaluator.evaluateAnd(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: and");
+        }
+        try {
+            SelectorEvaluator.evaluateAnd(new JSONObject("{\"operator\": \"and\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: and");
+        }
+        try {
+            SelectorEvaluator.evaluateAnd(new JSONObject("{\"operator\": \"and\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: and");
+        }
+        try {
+            SelectorEvaluator.evaluateAnd(new JSONObject("{\"operator\": \"and\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: and");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"and\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        assertFalse(SelectorEvaluator.evaluateAnd(node, new JSONObject("{\"prop1\": true, \"prop2\": false}")));
+        assertFalse(SelectorEvaluator.evaluateAnd(node, new JSONObject("{\"prop1\": false, \"prop2\": false}")));
+        assertFalse(SelectorEvaluator.evaluateAnd(node, new JSONObject("{\"prop1\": false, \"prop2\": true}")));
+        assertTrue(SelectorEvaluator.evaluateAnd(node, new JSONObject("{\"prop1\": true, \"prop2\": true}")));
+    }
+
+    public void testEvaluateOr() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateOr(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: or");
+        }
+        try {
+            SelectorEvaluator.evaluateOr(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: or");
+        }
+        try {
+            SelectorEvaluator.evaluateOr(new JSONObject("{\"operator\": \"or\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: or");
+        }
+        try {
+            SelectorEvaluator.evaluateOr(new JSONObject("{\"operator\": \"or\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: or");
+        }
+        try {
+            SelectorEvaluator.evaluateOr(new JSONObject("{\"operator\": \"or\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: or");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"or\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        assertTrue(SelectorEvaluator.evaluateOr(node, new JSONObject("{\"prop1\": true, \"prop2\": false}")));
+        assertFalse(SelectorEvaluator.evaluateOr(node, new JSONObject("{\"prop1\": false, \"prop2\": false}")));
+        assertTrue(SelectorEvaluator.evaluateOr(node, new JSONObject("{\"prop1\": false, \"prop2\": true}")));
+        assertTrue(SelectorEvaluator.evaluateOr(node, new JSONObject("{\"prop1\": true, \"prop2\": true}")));
+    }
+
+    public void testEvaluateIn() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateIn(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: (not) in");
+        }
+        try {
+            SelectorEvaluator.evaluateIn(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: (not) in");
+        }
+        try {
+            SelectorEvaluator.evaluateIn(new JSONObject("{\"operator\": \"in\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: (not) in");
+        }
+        try {
+            SelectorEvaluator.evaluateIn(new JSONObject("{\"operator\": \"in\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: (not) in");
+        }
+        try {
+            SelectorEvaluator.evaluateIn(new JSONObject("{\"operator\": \"in\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: (not) in");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"in\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        assertTrue(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": 1, \"prop2\": [1,2,3]}")));
+        assertTrue(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": \"ab\", \"prop2\": \"dabc\"}")));
+        assertFalse(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": 1, \"prop2\": [11,12,1111]}")));
+        assertFalse(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": \"ab\", \"prop2\": \"cbad\"}")));
+
+        node = new JSONObject("{\"operator\": \"not in\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        assertFalse(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": 1, \"prop2\": [1,2,3]}")));
+        assertFalse(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": \"ab\", \"prop2\": \"dabc\"}")));
+        assertTrue(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": 1, \"prop2\": [11,12,1111]}")));
+        assertTrue(SelectorEvaluator.evaluateIn(node, new JSONObject("{\"prop1\": \"ab\", \"prop2\": \"cbad\"}")));
+    }
+
+    public void testEvaluatePlus() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluatePlus(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: +");
+        }
+        try {
+            SelectorEvaluator.evaluatePlus(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: +");
+        }
+        try {
+            SelectorEvaluator.evaluatePlus(new JSONObject("{\"operator\": \"+\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: +");
+        }
+        try {
+            SelectorEvaluator.evaluatePlus(new JSONObject("{\"operator\": \"+\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: +");
+        }
+        try {
+            SelectorEvaluator.evaluatePlus(new JSONObject("{\"operator\": \"+\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: +");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"+\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        assertEquals(new Double(3), SelectorEvaluator.evaluatePlus(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        assertEquals("12", SelectorEvaluator.evaluatePlus(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"2\"}")));
+        assertNull(SelectorEvaluator.evaluatePlus(node, new JSONObject("{\"prop1\": 1, \"prop2\": [11,12,1111]}")));
+    }
+
+    public void testEvaluateArithmetic() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateArithmetic(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for arithmetic operator");
+        }
+        try {
+            SelectorEvaluator.evaluateArithmetic(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for arithmetic operator");
+        }
+        try {
+            SelectorEvaluator.evaluateArithmetic(new JSONObject("{\"operator\": \"-\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for arithmetic operator");
+        }
+        try {
+            SelectorEvaluator.evaluateArithmetic(new JSONObject("{\"operator\": \"-\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for arithmetic operator");
+        }
+        try {
+            SelectorEvaluator.evaluateArithmetic(new JSONObject("{\"operator\": \"-\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for arithmetic operator");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"-\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertEquals(new Double(-1), SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        node = new JSONObject("{\"operator\": \"*\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertEquals(2.0, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        node = new JSONObject("{\"operator\": \"/\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertEquals(0.5, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        node = new JSONObject("{\"operator\": \"%\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertNull(SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 1, \"prop2\": 0}")));
+        assertEquals(0.0, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 0, \"prop2\": 1}")));
+        assertEquals(1.0, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": -1, \"prop2\": 2}")));
+        assertEquals(-1.0, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": -1, \"prop2\": -2}")));
+        assertEquals(-1.0, SelectorEvaluator.evaluateArithmetic(node, new JSONObject("{\"prop1\": 1, \"prop2\": -2}")));
+    }
+
+    public void testEvaluateEquality() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateEquality(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for equality operator");
+        }
+        try {
+            SelectorEvaluator.evaluateEquality(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for equality operator");
+        }
+        try {
+            SelectorEvaluator.evaluateEquality(new JSONObject("{\"operator\": \"=\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for equality operator");
+        }
+        try {
+            SelectorEvaluator.evaluateEquality(new JSONObject("{\"operator\": \"=\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for equality operator");
+        }
+        try {
+            SelectorEvaluator.evaluateEquality(new JSONObject("{\"operator\": \"=\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for equality operator");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"==\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        // Null
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": null, \"prop2\": null}")));
+
+        // Mixed types
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": null, \"prop2\": \"null\"}")));
+
+        // Number
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        // Boolean
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": true, \"prop2\": true}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": false, \"prop2\": false}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": true, \"prop2\": false}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": false, \"prop2\": true}")));
+
+        // String
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": \"false\", \"prop2\": \"false\"}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": \"true\", \"prop2\": \"false\"}")));
+
+        // Datetime
+        JSONObject withDateTimeCast = new JSONObject("{\"operator\": \"==\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertTrue(SelectorEvaluator.evaluateEquality(withDateTimeCast, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(withDateTimeCast, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        // Dict
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": {\"a\": 1, \"b\": 1}, \"prop2\": {\"b\": 1, \"a\": 1}}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": {\"a\": 1}, \"prop2\": {\"b\": 1}}")));
+
+        node = new JSONObject("{\"operator\": \"!=\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+
+        // Null
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": null, \"prop2\": null}")));
+
+        // Mixed types
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": null, \"prop2\": \"null\"}")));
+
+        // Number
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        // Boolean
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": true, \"prop2\": true}")));
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": false, \"prop2\": false}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": true, \"prop2\": false}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": false, \"prop2\": true}")));
+
+        // String
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": \"false\", \"prop2\": \"false\"}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": \"true\", \"prop2\": \"false\"}")));
+
+        // Datetime
+        withDateTimeCast = new JSONObject("{\"operator\": \"!=\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertFalse(SelectorEvaluator.evaluateEquality(withDateTimeCast, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(withDateTimeCast, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        // Dict
+        assertFalse(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": {\"a\": 1, \"b\": 1}, \"prop2\": {\"b\": 1, \"a\": 1}}")));
+        assertTrue(SelectorEvaluator.evaluateEquality(node, new JSONObject("{\"prop1\": {\"a\": 1}, \"prop2\": {\"b\": 1}}")));
+    }
+
+    public void testEvaluateComparison() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateComparison(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for comparison operator");
+        }
+        try {
+            SelectorEvaluator.evaluateComparison(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for comparison operator");
+        }
+        try {
+            SelectorEvaluator.evaluateComparison(new JSONObject("{\"operator\": \">\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for comparison operator");
+        }
+        try {
+            SelectorEvaluator.evaluateComparison(new JSONObject("{\"operator\": \">\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for comparison operator");
+        }
+        try {
+            SelectorEvaluator.evaluateComparison(new JSONObject("{\"operator\": \">\", \"children\": [{}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for comparison operator");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \">\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 2, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"2\", \"prop2\": \"1\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"2\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"1\"}")));
+
+        node = new JSONObject("{\"operator\": \">=\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 2, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"2\", \"prop2\": \"1\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"2\"}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"1\"}")));
+
+        node = new JSONObject("{\"operator\": \"<\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 2, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"2\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"2\", \"prop2\": \"1\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"1\"}")));
+
+        node = new JSONObject("{\"operator\": \"<=\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 2}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 2, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"2\"}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"2\", \"prop2\": \"1\"}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": \"1\", \"prop2\": \"1\"}")));
+
+        // Datetime
+        node = new JSONObject("{\"operator\": \"<\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 11}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        node = new JSONObject("{\"operator\": \"<=\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 11}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        node = new JSONObject("{\"operator\": \">\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 1}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 11}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        node = new JSONObject("{\"operator\": \">=\", \"children\": [" +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}]}," +
+                "{\"operator\": \"datetime\", \"children\": [{\"property\": \"event\", \"value\": \"prop2\"}]}" +
+                "]}");
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 1}")));
+        assertTrue(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 11, \"prop2\": 11}")));
+        assertFalse(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": 1, \"prop2\": 11}")));
+
+        assertNull(SelectorEvaluator.evaluateComparison(node, new JSONObject("{\"prop1\": [1,2,2], \"prop2\": 1}")));
+    }
+
+    public void testEvaluateDefined() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateDefined(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for (not) defined operator");
+        }
+        try {
+            SelectorEvaluator.evaluateDefined(new JSONObject("{\"operator\": \"string\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for (not) defined operator");
+        }
+        try {
+            SelectorEvaluator.evaluateDefined(new JSONObject("{\"operator\": \"defined\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for (not) defined operator");
+        }
+        try {
+            SelectorEvaluator.evaluateDefined(new JSONObject("{\"operator\": \"defined\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for (not) defined operator");
+        }
+        try {
+            SelectorEvaluator.evaluateDefined(new JSONObject("{\"operator\": \"defined\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for (not) defined operator");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"defined\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        assertTrue(SelectorEvaluator.evaluateDefined(node, new JSONObject("{\"prop\": null}")));
+        assertFalse(SelectorEvaluator.evaluateDefined(node, new JSONObject("{\"prop1\": null}")));
+    }
+
+    public void testEvaluateNot() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateNot(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: not");
+        }
+        try {
+            SelectorEvaluator.evaluateNot(new JSONObject("{\"operator\": \"string\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: not");
+        }
+        try {
+            SelectorEvaluator.evaluateNot(new JSONObject("{\"operator\": \"not\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: not");
+        }
+        try {
+            SelectorEvaluator.evaluateNot(new JSONObject("{\"operator\": \"not\", \"children\": []}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: not");
+        }
+        try {
+            SelectorEvaluator.evaluateNot(new JSONObject("{\"operator\": \"not\", \"children\": [{}, {}]}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid node for operator: not");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"not\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        // Null or undefined returns True
+        assertTrue(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": null}")));
+        assertTrue(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop1\": false}")));
+        // Boolean
+        assertFalse(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": true}")));
+        assertTrue(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": false}")));
+        // Null for all other types
+        assertNull(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": []}")));
+        assertNull(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": {}}")));
+        assertNull(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": 1}")));
+        assertNull(SelectorEvaluator.evaluateNot(node, new JSONObject("{\"prop\": \"abc\"}")));
+    }
+
+    public void testEvaluateOperand() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateOperand(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Missing required keys: property/value");
+        }
+        try {
+            SelectorEvaluator.evaluateOperand(new JSONObject("{\"property\": \"event\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Missing required keys: property/value");
+        }
+        try {
+            SelectorEvaluator.evaluateOperand(new JSONObject("{\"value\": \"prop\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Missing required keys: property/value");
+        }
+        try {
+            SelectorEvaluator.evaluateOperand(new JSONObject("{\"property\": \"invalid\", \"value\": \"prop\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid operand: Invalid property type: invalid");
+        }
+
+        JSONObject node = new JSONObject("{\"property\": \"event\", \"value\": \"prop\"}");
+        assertEquals(1, SelectorEvaluator.evaluateOperand(node, new JSONObject("{\"prop\": 1}")));
+
+        node = new JSONObject("{\"property\": \"literal\", \"value\": \"prop\"}");
+        assertEquals("prop", SelectorEvaluator.evaluateOperand(node, new JSONObject("{}")));
+
+        node = new JSONObject("{\"property\": \"literal\", \"value\": \"now\"}");
+        assertTrue(SelectorEvaluator.evaluateOperand(node, new JSONObject("{}")) instanceof Date);
+
+        node = new JSONObject("{\"property\": \"literal\", \"value\": {\"window\":{\"unit\": \"day\", \"value\": -1}}}");
+        assertTrue(SelectorEvaluator.evaluateOperand(node, new JSONObject("{}")) instanceof Date);
+    }
+
+    public void testEvaluateWindow() throws JSONException, ParseException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateWindow(new JSONObject("{}"));
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid window specification for value key {}", e.getMessage());
+        }
+        try {
+            SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\": {}}"));
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid window specification for value key {\"window\":{}}", e.getMessage());
+        }
+        try {
+            SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\": {\"unit\": \"day\"}}"));
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid window specification for value key {\"window\":{\"unit\":\"day\"}}", e.getMessage());
+        }
+        try {
+            SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\": {\"value\": \"1\"}}"));
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid window specification for value key {\"window\":{\"value\":\"1\"}}", e.getMessage());
+        }
+        try {
+            SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\": {\"unit\": \"blah\", \"value\": \"1\"}}"));
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid unit specification for window blah", e.getMessage());
+        }
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+        final Date dt = format.parse("2019-01-02T12:00:00");
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTime(dt);
+        SelectorEvaluator.setCalendar(calendar, true);
+
+        assertEquals("2019-01-03T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"day\", \"value\": -1}}"))));
+        assertEquals("2019-01-02T13:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"hour\", \"value\": -1}}"))));
+        assertEquals("2019-01-09T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"week\", \"value\": -1}}"))));
+        assertEquals("2019-02-01T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"month\", \"value\": -1}}"))));
+        assertEquals("2018-12-03T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"month\", \"value\": 1}}"))));
+        assertEquals("2018-12-26T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"week\", \"value\": 1}}"))));
+        assertEquals("2019-01-02T11:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"hour\", \"value\": 1}}"))));
+        assertEquals("2019-01-01T12:00:00", format.format(SelectorEvaluator.evaluateWindow(new JSONObject("{\"window\":{\"unit\": \"day\", \"value\": 1}}"))));
+    }
+
+    public void testEvaluateOperator() throws JSONException {
+        // Error conditions
+        try {
+            SelectorEvaluator.evaluateOperator(new JSONObject("{}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Missing required keys: operator");
+        }
+        try {
+            SelectorEvaluator.evaluateOperator(new JSONObject("{\"operator\": \"unknown\"}"), new JSONObject());
+            assertTrue(false);
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Unknown operator: unknown");
+        }
+
+        JSONObject node = new JSONObject("{\"operator\": \"and\", \"children\": [{\"property\": \"event\", \"value\": \"prop1\"}," +
+                "{\"property\": \"event\", \"value\": \"prop2\"}]}");
+        JSONObject prop = new JSONObject("{\"prop1\": true, \"prop2\": false}");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "or");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "in");
+        prop.put("prop1", 1);
+        prop.put("prop2", new JSONArray("[1,2,3]"));
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "not in");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        prop.put("prop1", 1);
+        prop.put("prop2", 2);
+        node.put("operator", "+");
+        assertEquals(3.0, (Double) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "-");
+        assertEquals(-1.0, (Double) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "*");
+        assertEquals(2.0, (Double) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "/");
+        assertEquals(0.5, (Double) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "%");
+        assertEquals(1.0, (Double) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "==");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "!=");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", ">");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "<");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        prop.put("prop2", 1);
+        node.put("operator", ">");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", ">=");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "<");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "<=");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node = new JSONObject("{\"operator\": \"boolean\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}");
+        prop = new JSONObject("{\"prop\": 1}");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "datetime");
+        assertTrue(SelectorEvaluator.evaluateOperator(node, prop) instanceof Date);
+        node.put("operator", "list");
+        prop.put("prop", new JSONArray("[1,2,3]"));
+        assertEquals(new JSONArray("[1,2,3]"), SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "number");
+        prop.put("prop", "1");
+        assertEquals(1.0, SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "string");
+        prop.put("prop", 1);
+        assertEquals("1", SelectorEvaluator.evaluateOperator(node, prop).toString());
+
+        node.put("operator", "defined");
+        prop.remove("prop");
+        assertFalse((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+        node.put("operator", "not defined");
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+
+        node.put("operator", "not");
+        prop.put("prop", false);
+        assertTrue((boolean) SelectorEvaluator.evaluateOperator(node, prop));
+    }
+
+    public void testEvaluate() throws JSONException {
+        JSONObject node = new JSONObject("{\"operator\": \"and\", " +
+                "\"children\": [" +
+                "{\"operator\": \"not\", \"children\": [{\"property\": \"literal\", \"value\": false}]}," +
+                "{\"operator\": \"==\", \"children\": [" +
+                "{\"property\": \"event\", \"value\": \"prop\"}," +
+                "{\"operator\": \"number\", \"children\": [{\"property\": \"event\", \"value\": \"prop\"}]}" +
+                "]}" +
+                "]}");
+        JSONObject props = new JSONObject("{\"prop\": 1}");
+        final SelectorEvaluator evaluator = new SelectorEvaluator(node);
+        assertTrue(evaluator.evaluate(props));
+    }
+}

--- a/src/main/java/com/mixpanel/android/mpmetrics/DisplayTrigger.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/DisplayTrigger.java
@@ -1,0 +1,94 @@
+package com.mixpanel.android.mpmetrics;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.mixpanel.android.util.MPLog;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/* package */ class DisplayTrigger implements Parcelable {
+    private static final String LOGTAG = "MixpanelAPI.DisplayTrigger";
+    private static final String ANY_EVENT = "$any_event";
+    private static final String EVENT_KEY = "event";
+    private static final String SELECTOR_KEY = "selector";
+
+    private final String mEventName;
+    private final JSONObject mJSONSelector;
+    private final SelectorEvaluator mEvaluator;
+
+    public DisplayTrigger(JSONObject displayTrigger) throws BadDecideObjectException {
+        SelectorEvaluator evaluator = null;
+        try{
+            mEventName = displayTrigger.getString(EVENT_KEY);
+            mJSONSelector = displayTrigger.optJSONObject(SELECTOR_KEY);
+            if (mJSONSelector != null) {
+                evaluator = new SelectorEvaluator(mJSONSelector);
+            }
+        } catch (JSONException e) {
+            throw new BadDecideObjectException("Event triggered notification JSON was unexpected or bad", e);
+        }
+        mEvaluator = evaluator;
+    }
+
+    public DisplayTrigger(Parcel in) {
+        mEventName = in.readString();
+        JSONObject tempSelector = null;
+        SelectorEvaluator evaluator = null;
+        try {
+            tempSelector = new JSONObject(in.readString());
+        } catch (JSONException e) {
+            MPLog.e(LOGTAG, "Error parsing selector from display_trigger", e);
+        }
+        mJSONSelector = tempSelector;
+        if (mJSONSelector != null) {
+            evaluator = new SelectorEvaluator(mJSONSelector);
+        }
+        mEvaluator = evaluator;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mEventName);
+        dest.writeString(mJSONSelector.toString());
+    }
+
+    public boolean matchesEventDescription(AnalyticsMessages.EventDescription eventDescription) {
+        if (null != eventDescription) {
+            if (mEventName.equals(ANY_EVENT) ||
+                    eventDescription.getEventName().equals(mEventName)) {
+                if (mEvaluator != null) {
+                    try {
+                        return mEvaluator.evaluate(eventDescription.getProperties());
+                    } catch (Exception e) {
+                        MPLog.e(LOGTAG, "Error evaluating selector", e);
+                        return false;
+                    }
+                } else {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<DisplayTrigger> CREATOR = new Parcelable.Creator<DisplayTrigger>() {
+
+        @Override
+        public DisplayTrigger createFromParcel(Parcel source) {
+            return new DisplayTrigger(source);
+        }
+
+        @Override
+        public DisplayTrigger[] newArray(int size) {
+            return new DisplayTrigger[size];
+        }
+    };
+}

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -135,6 +135,7 @@ public class MPConfig {
     // Max size of the number of notifications we will hold in memory. Since they may contain images,
     // we don't want to suck up all of the memory on the device.
     /* package */ static final int MAX_NOTIFICATION_CACHE_COUNT = 2;
+    /* package */ static final int MAX_EVENT_TRIGGERED_NOTIFICATION_CACHE_COUNT = 2;
 
     // Instances are safe to store, since they're immutable and always the same.
     public static MPConfig getInstance(Context context) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -15,6 +15,7 @@ import com.mixpanel.android.viewcrawler.GestureTracker;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.ref.WeakReference;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -55,6 +56,7 @@ import java.util.Locale;
         if (check != null) {
             mHandler.removeCallbacks(check);
         }
+        mCurrentActivity = null;
 
         mHandler.postDelayed(check = new Runnable(){
             @Override
@@ -92,6 +94,8 @@ import java.util.Locale;
             mMpInstance.getPeople().joinExperimentIfAvailable();
         }
 
+        mCurrentActivity = new WeakReference<>(activity);
+
         mPaused = false;
         boolean wasBackground = !mIsForeground;
         mIsForeground = true;
@@ -112,6 +116,10 @@ import java.util.Locale;
 
     protected boolean isInForeground() {
         return mIsForeground;
+    }
+
+    protected Activity getCurrentActivity() {
+        return mCurrentActivity != null ? mCurrentActivity.get() : null;
     }
 
     private void trackCampaignOpenedIfNeeded(Intent intent) {
@@ -149,4 +157,5 @@ import java.util.Locale;
 
     private final MixpanelAPI mMpInstance;
     private final MPConfig mConfig;
+    private WeakReference<Activity> mCurrentActivity;
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/SelectorEvaluator.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SelectorEvaluator.java
@@ -1,0 +1,592 @@
+package com.mixpanel.android.mpmetrics;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Locale;
+
+/* package */ class SelectorEvaluator {
+    private static final String ENGAGE_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
+    // Key words
+    private static final String OPERATOR_KEY = "operator";
+    private static final String CHILDREN_KEY = "children";
+    private static final String PROPERTY_KEY = "property";
+    private static final String VALUE_KEY = "value";
+    private static final String EVENT_KEY = "event";
+    private static final String LITERAL_KEY = "literal";
+    private static final String WINDOW_KEY = "window";
+    private static final String UNIT_KEY = "unit";
+    private static final String HOUR_KEY = "hour";
+    private static final String DAY_KEY = "day";
+    private static final String WEEK_KEY = "week";
+    private static final String MONTH_KEY = "month";
+    // Typecast operators
+    private static final String BOOLEAN_OPERATOR = "boolean";
+    private static final String DATETIME_OPERATOR = "datetime";
+    private static final String LIST_OPERATOR = "list";
+    private static final String NUMBER_OPERATOR = "number";
+    private static final String STRING_OPERATOR = "string";
+    // Binary operators
+    private static final String AND_OPERATOR = "and";
+    private static final String OR_OPERATOR = "or";
+    private static final String IN_OPERATOR = "in";
+    private static final String NOT_IN_OPERATOR = "not in";
+    private static final String PLUS_OPERATOR = "+";
+    private static final String MINUS_OPERATOR = "-";
+    private static final String MUL_OPERATOR = "*";
+    private static final String DIV_OPERATOR = "/";
+    private static final String MOD_OPERATOR = "%";
+    private static final String EQUALS_OPERATOR = "==";
+    private static final String NOT_EQUALS_OPERATOR = "!=";
+    private static final String GREATER_THAN_OPERATOR = ">";
+    private static final String GREATER_THAN_EQUAL_OPERATOR = ">=";
+    private static final String LESS_THAN_OPERATOR = "<";
+    private static final String LESS_THAN_EQUAL_OPERATOR = "<=";
+    // Unary operators
+    private static final String NOT_OPERATOR = "not";
+    private static final String DEFINED_OPERATOR = "defined";
+    private static final String NOT_DEFINED_OPERATOR = "not defined";
+    private static final String NOW_LITERAL = "now";
+
+    enum PropertyType {
+        Array, Boolean, Datetime, Null, Number, Object, String, Unknown
+    }
+
+    SelectorEvaluator(JSONObject selector) throws IllegalArgumentException {
+        if (!selector.has(OPERATOR_KEY) || !selector.has(CHILDREN_KEY)) {
+            throw new IllegalArgumentException("Missing required keys: " + OPERATOR_KEY + " " + CHILDREN_KEY);
+        }
+        mSelector = selector;
+    }
+
+    static PropertyType getType(Object value) {
+        if (value == null || value.equals(JSONObject.NULL)) {
+            return PropertyType.Null;
+        }
+        if (value instanceof String) {
+            return PropertyType.String;
+        }
+        if (value instanceof JSONArray) {
+            return PropertyType.Array;
+        }
+        if (value instanceof JSONObject) {
+            return PropertyType.Object;
+        }
+        if (value instanceof Double || value instanceof Integer || value instanceof Number) {
+            return PropertyType.Number;
+        }
+        if (value instanceof Boolean) {
+            return PropertyType.Boolean;
+        }
+        if (value instanceof Date) {
+            return PropertyType.Datetime;
+        }
+
+        return PropertyType.Unknown;
+    }
+
+    // Typecast operators
+    static Double toNumber(Object value) {
+        switch (getType(value)) {
+            case Null:
+                return null;
+            case Datetime:
+                final Date dt = (Date) value;
+                return dt.getTime() > 0 ? new Double(dt.getTime()) : null;
+            case Boolean:
+                final Boolean b = (Boolean) value;
+                return b ? 1.0 : 0.0;
+            case Number:
+                if (value instanceof Double) {
+                    return (Double) value;
+                }
+                if (value instanceof Integer) {
+                    return ((Integer) value).doubleValue();
+                }
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue();
+                }
+            case String:
+                try {
+                    return Double.parseDouble((String) value);
+                } catch (NumberFormatException e) {
+                    return 0.0;
+                }
+            default:
+                return null;
+        }
+    }
+
+    static Boolean toBoolean(Object value) {
+        switch (getType(value)) {
+            case Null:
+                return false;
+            case Boolean:
+                return (Boolean) value;
+            case Number:
+                return toNumber(value) != 0.0;
+            case String:
+                return ((String) value).length() > 0;
+            case Array:
+                return ((JSONArray) value).length() > 0;
+            case Datetime:
+                return ((Date) value).getTime() > 0;
+            case Object:
+                return ((JSONObject) value).length() > 0;
+            default:
+                return false;
+        }
+    }
+
+    static Double evaluateNumber(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(NUMBER_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for cast operator: " + NUMBER_OPERATOR);
+        }
+
+        return toNumber(evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties));
+    }
+
+    static Boolean evaluateBoolean(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(BOOLEAN_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for cast operator: " + BOOLEAN_OPERATOR);
+        }
+
+        return toBoolean(evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties));
+    }
+
+    static Date evaluateDateTime(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(DATETIME_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for cast operator: " + DATETIME_OPERATOR);
+        }
+
+        final Object value = evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties);
+        switch (getType(value)) {
+            case Number:
+                return new Date(toNumber(value).longValue());
+            case String:
+                try {
+                    return (new SimpleDateFormat(ENGAGE_DATE_FORMAT_STRING, Locale.US)).parse((String) value);
+                } catch (ParseException e) {
+                    return null;
+                }
+            case Datetime:
+                return (Date) value;
+            default:
+                return null;
+        }
+    }
+
+    static JSONArray evaluateList(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(LIST_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for cast operator: " + LIST_OPERATOR);
+        }
+
+        final Object value = evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties);
+        if (getType(value) == PropertyType.Array) {
+            return (JSONArray) value;
+        }
+
+        return null;
+    }
+
+    static String evaluateString(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(STRING_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for cast operator: " + STRING_OPERATOR);
+        }
+        final Object value = evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties);
+        if (getType(value) == PropertyType.Datetime) {
+            return new SimpleDateFormat(ENGAGE_DATE_FORMAT_STRING, Locale.US).format((Date) value);
+        }
+
+        return value != null ? value.toString() : null;
+    }
+
+    // Binary Operators
+    static Boolean evaluateAnd(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(AND_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for operator: " + AND_OPERATOR);
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        return toBoolean(evaluateNode(children.getJSONObject(0), properties)) &&
+                toBoolean(evaluateNode(children.getJSONObject(1), properties));
+    }
+
+    static Boolean evaluateOr(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(OR_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for operator: " + OR_OPERATOR);
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        return toBoolean(evaluateNode(children.getJSONObject(0), properties)) ||
+                toBoolean(evaluateNode(children.getJSONObject(1), properties));
+    }
+
+    static Boolean evaluateIn(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !(node.getString(OPERATOR_KEY).equals(IN_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(NOT_IN_OPERATOR)) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for operator: (not) " + IN_OPERATOR);
+        }
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        final Object l = evaluateNode(children.getJSONObject(0), properties);
+        final Object r = evaluateNode(children.getJSONObject(1), properties);
+
+        Boolean v = false;
+        final String ls = l.toString();
+        switch (getType(r)) {
+            case Array:
+                final JSONArray arr = (JSONArray) r;
+                for (int i = 0; i < arr.length(); i++) {
+                    if (ls.equals(arr.getString(i))) {
+                        v = true;
+                        break;
+                    }
+                }
+                break;
+            case String:
+                v = ((String) r).contains(ls);
+                break;
+        }
+
+        return node.getString(OPERATOR_KEY).equals(IN_OPERATOR) ? v : !v;
+    }
+
+    static Object evaluatePlus(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(PLUS_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for operator: " + PLUS_OPERATOR);
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        final Object l = evaluateNode(children.getJSONObject(0), properties);
+        final Object r = evaluateNode(children.getJSONObject(1), properties);
+
+        if (getType(l) == PropertyType.Number && getType(r) == PropertyType.Number) {
+            return toNumber(l) + toNumber(r);
+        }
+        if (getType(l) == PropertyType.String && getType(r) == PropertyType.String) {
+            return l + ((String) r);
+        }
+
+        return null;
+    }
+
+    static Double evaluateArithmetic(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !(node.getString(OPERATOR_KEY).equals(MINUS_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(MUL_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(DIV_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(MOD_OPERATOR)) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for arithmetic operator");
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        final Object l = evaluateNode(children.getJSONObject(0), properties);
+        final Object r = evaluateNode(children.getJSONObject(1), properties);
+
+        if (getType(l) == PropertyType.Number && getType(r) == PropertyType.Number) {
+            final double ld = toNumber(l);
+            final double rd = toNumber(r);
+            switch (node.getString(OPERATOR_KEY)) {
+                case MINUS_OPERATOR:
+                    return ld-rd;
+                case MUL_OPERATOR:
+                    return ld*rd;
+                case DIV_OPERATOR:
+                    if (rd != 0.0) {
+                        return ld/rd;
+                    }
+                    return null;
+                case MOD_OPERATOR:
+                    if (rd == 0.0) {
+                        return null;
+                    }
+                    if (ld == 0.0) {
+                        return 0.0;
+                    }
+                    if ((ld < 0 && rd > 0) || (ld > 0 && rd < 0)) {
+                        return -(Math.floor(ld/rd) * rd-ld);
+                    }
+                    return ld % rd;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean equals(Object l, Object r) {
+        if (getType(l) == getType(r)) {
+            switch (getType(l)) {
+                case Null:
+                    return true;
+                case Number:
+                    return toNumber(l).equals(toNumber(r));
+                case Boolean:
+                    return toBoolean(l).equals(toBoolean(r));
+                case Datetime:
+                case String:
+                case Array:
+                    return l.equals(r);
+            }
+        }
+
+        return false;
+    }
+
+    static Boolean evaluateEquality(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !(node.getString(OPERATOR_KEY).equals(EQUALS_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(NOT_EQUALS_OPERATOR)) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for equality operator");
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        final Object l = evaluateNode(children.getJSONObject(0), properties);
+        final Object r = evaluateNode(children.getJSONObject(1), properties);
+        Boolean v = false;
+        if (getType(l) == getType(r)) {
+            switch (getType(l)) {
+                case Object:
+                    final JSONObject lo = (JSONObject) l;
+                    final JSONObject ro = (JSONObject) r;
+
+                    if (lo.length() == ro.length()) {
+                        v = true;
+                        String k;
+                        Iterator<String> keys = lo.keys();
+                        while(keys.hasNext()) {
+                            k = keys.next();
+                            if (!equals(lo.get(k), ro.opt(k))) {
+                                v = false;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    v = equals(l, r);
+            }
+        }
+
+        return node.getString(OPERATOR_KEY).equals(NOT_EQUALS_OPERATOR) ? !v : v;
+    }
+
+    static Boolean evaluateComparison(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !(node.getString(OPERATOR_KEY).equals(GREATER_THAN_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(GREATER_THAN_EQUAL_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(LESS_THAN_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(LESS_THAN_EQUAL_OPERATOR)) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 2) {
+            throw new IllegalArgumentException("Invalid node for comparison operator");
+        }
+
+        JSONArray children = node.getJSONArray(CHILDREN_KEY);
+        final Object l = evaluateNode(children.getJSONObject(0), properties);
+        final Object r = evaluateNode(children.getJSONObject(1), properties);
+        if (getType(l) == getType(r)) {
+            if  (getType(l) == PropertyType.Number || getType(l) == PropertyType.Datetime) {
+                final Double ld = toNumber(l);
+                final Double rd = toNumber(r);
+                switch (node.getString(OPERATOR_KEY)) {
+                    case GREATER_THAN_OPERATOR:
+                        return ld > rd;
+                    case GREATER_THAN_EQUAL_OPERATOR:
+                        return ld >= rd;
+                    case LESS_THAN_OPERATOR:
+                        return ld < rd;
+                    case LESS_THAN_EQUAL_OPERATOR:
+                        return ld <= rd;
+                }
+            } else if (getType(l) == PropertyType.String) {
+                final String ls = (String) l;
+                final String rs = (String) r;
+
+                final int compare = ls.compareTo(rs);
+                switch (node.getString(OPERATOR_KEY)) {
+                    case GREATER_THAN_OPERATOR:
+                        return compare > 0;
+                    case GREATER_THAN_EQUAL_OPERATOR:
+                        return compare >= 0;
+                    case LESS_THAN_OPERATOR:
+                        return compare < 0;
+                    case LESS_THAN_EQUAL_OPERATOR:
+                        return compare <= 0;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    static Boolean evaluateDefined(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !(node.getString(OPERATOR_KEY).equals(DEFINED_OPERATOR) ||
+                node.getString(OPERATOR_KEY).equals(NOT_DEFINED_OPERATOR)) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for (not) defined operator");
+        }
+
+        final boolean v = evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0),
+                properties) == null ? false : true;
+        return node.getString(OPERATOR_KEY).equals(DEFINED_OPERATOR) ? v : !v;
+    }
+
+    static Boolean evaluateNot(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY) || !node.getString(OPERATOR_KEY).equals(NOT_OPERATOR) ||
+                node.optJSONArray(CHILDREN_KEY) == null || node.getJSONArray(CHILDREN_KEY).length() != 1) {
+            throw new IllegalArgumentException("Invalid node for operator: " + NOT_OPERATOR);
+        }
+
+        final Object v = evaluateNode(node.getJSONArray(CHILDREN_KEY).getJSONObject(0), properties);
+        switch (getType(v)) {
+            case Boolean:
+                return !toBoolean(v);
+            case Null:
+                return true;
+        }
+        return null;
+    }
+
+    static Date evaluateWindow(JSONObject node) throws JSONException {
+        final JSONObject window = node.optJSONObject(WINDOW_KEY);
+        if (window == null || !window.has(VALUE_KEY) || !window.has(UNIT_KEY)) {
+            throw new IllegalArgumentException("Invalid window specification for value key " + node.toString());
+        }
+
+        Calendar calendar;
+        if (sCalendar == null) {
+            calendar = Calendar.getInstance();
+            calendar.setTime(new Date());
+        } else {
+            calendar = (Calendar) sCalendar.clone();
+        }
+
+        final Integer value = -1 * window.getInt(VALUE_KEY);
+
+        switch (window.getString(UNIT_KEY)) {
+            case HOUR_KEY:
+                calendar.add(Calendar.HOUR, value);
+                break;
+            case DAY_KEY:
+                calendar.add(Calendar.DAY_OF_YEAR, value);
+                break;
+            case WEEK_KEY:
+                calendar.add(Calendar.DAY_OF_YEAR, 7*value);
+                break;
+            case MONTH_KEY:
+                calendar.add(Calendar.DAY_OF_YEAR, 30*value);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid unit specification for window " + window.getString(UNIT_KEY));
+        }
+
+        return calendar.getTime();
+    }
+
+    static Object evaluateOperand(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(PROPERTY_KEY) || !node.has(VALUE_KEY)) {
+            throw new IllegalArgumentException("Missing required keys: " + PROPERTY_KEY + "/" + VALUE_KEY);
+        }
+
+        switch (node.getString(PROPERTY_KEY)) {
+            case EVENT_KEY:
+                return properties.opt(node.getString(VALUE_KEY));
+            case LITERAL_KEY:
+                if (getType(node.get(VALUE_KEY)) == PropertyType.String &&
+                        node.getString(VALUE_KEY).equalsIgnoreCase(NOW_LITERAL)) {
+                    return new Date();
+                }
+                final Object value = node.get(VALUE_KEY);
+                switch (getType(value)) {
+                    case Object:
+                        return evaluateWindow((JSONObject) value);
+                    default:
+                        return value;
+                }
+            default:
+                throw new IllegalArgumentException("Invalid operand: Invalid property type: " + node.getString(PROPERTY_KEY));
+        }
+    }
+
+    static Object evaluateOperator(JSONObject node, JSONObject properties) throws JSONException {
+        if (!node.has(OPERATOR_KEY)) {
+            throw new IllegalArgumentException("Missing required keys: " + OPERATOR_KEY);
+        }
+
+        switch (node.getString(OPERATOR_KEY)) {
+            case AND_OPERATOR:
+                return evaluateAnd(node, properties);
+            case OR_OPERATOR:
+                return evaluateOr(node, properties);
+            case IN_OPERATOR:
+            case NOT_IN_OPERATOR:
+                return evaluateIn(node, properties);
+            case PLUS_OPERATOR:
+                return evaluatePlus(node, properties);
+            case MINUS_OPERATOR:
+            case MUL_OPERATOR:
+            case DIV_OPERATOR:
+            case MOD_OPERATOR:
+                return evaluateArithmetic(node, properties);
+            case EQUALS_OPERATOR:
+            case NOT_EQUALS_OPERATOR:
+                return evaluateEquality(node, properties);
+            case GREATER_THAN_OPERATOR:
+            case GREATER_THAN_EQUAL_OPERATOR:
+            case LESS_THAN_OPERATOR:
+            case LESS_THAN_EQUAL_OPERATOR:
+                return evaluateComparison(node, properties);
+            case BOOLEAN_OPERATOR:
+                return evaluateBoolean(node, properties);
+            case DATETIME_OPERATOR:
+                return evaluateDateTime(node, properties);
+            case LIST_OPERATOR:
+                return evaluateList(node, properties);
+            case NUMBER_OPERATOR:
+                return evaluateNumber(node, properties);
+            case STRING_OPERATOR:
+                return evaluateString(node, properties);
+            case DEFINED_OPERATOR:
+            case NOT_DEFINED_OPERATOR:
+                return evaluateDefined(node, properties);
+            case NOT_OPERATOR:
+                return evaluateNot(node, properties);
+            default:
+                throw new IllegalArgumentException("Unknown operator: " + node.getString(OPERATOR_KEY));
+        }
+    }
+
+    private static Object evaluateNode(JSONObject node, JSONObject properties) throws JSONException {
+        if (node.has(PROPERTY_KEY)) {
+            return evaluateOperand(node, properties);
+        }
+
+        return evaluateOperator(node, properties);
+    }
+
+    public boolean evaluate(JSONObject properties) throws JSONException {
+        return toBoolean(evaluateOperator(mSelector, properties));
+    }
+
+    private final JSONObject mSelector;
+    private static Calendar sCalendar; // For testing purposes only!
+
+    /* package */ static void setCalendar(Calendar calendar, boolean isTestMode) {
+        if (isTestMode) {
+            sCalendar = calendar;
+        }
+    }
+}


### PR DESCRIPTION
**Event Triggered InApps**

Currently users have no control over when an InApp notification shows up. With this release users can now control when an InApp gets displayed based on an event that they track within their app. This "trigger" event is defined during message creation. You can additionally filter the event based on properties that are tracked along with the event for even finer controls.