### PR TITLE
Using current loop for Handler when waiting for UA integration

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/ConnectIntegrations.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ConnectIntegrations.java
@@ -52,7 +52,7 @@ import java.util.Set;
             } else {
                 mUrbanAirshipRetries++;
                 if (mUrbanAirshipRetries <= UA_MAX_RETRIES) {
-                    final Handler delayedHandler = new Handler();
+                    final Handler delayedHandler = new Handler(android.os.Looper.getMainLooper());
                     delayedHandler.postDelayed(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
Hello all, we use MixPanel library in our porject and recently we faced a startup crash upon MP initialization, after some digging we were able to fix it.
 
When MixPanel is being initialized, if there is a UrbanAirship integration message and the UrbanAirship SDK for some reason didn't return the Channel ID yet, MixPanel library will enter a Handler loop until until it's able to fetch the Channel ID from UA SDK. It might fail in this scenario since the loop is being created without the taking into consideration the main thread loop (or any thread it was created in) causing the following crash:

```
AndroidRuntime: FATAL EXCEPTION: pool-28-thread-1
AndroidRuntime: Process: com.xxxxxxx.xxxxxxxx, PID: 24019
AndroidRuntime: java.lang.RuntimeException: Can't create handler inside thread that has not called Looper.prepare()
AndroidRuntime: 	at android.os.Handler.<init>(Handler.java:203)
AndroidRuntime: 	at android.os.Handler.<init>(Handler.java:117)
AndroidRuntime: 	at com.mixpanel.android.mpmetrics.ConnectIntegrations.setUrbanAirshipPeopleProp(ConnectIntegrations.java:12)
AndroidRuntime: 	at com.mixpanel.android.mpmetrics.ConnectIntegrations.setupIntegrations(ConnectIntegrations.java:2)
AndroidRuntime: 	at com.mixpanel.android.mpmetrics.MixpanelAPI$SupportedUpdatesListener.run(MixpanelAPI.java:3)
AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
AndroidRuntime: 	at java.lang.Thread.run(Thread.java:764)
```

The fix was to add the main looper into the Handler constructor.

It would be good to add the following change to the code.

Thanks!