### PR TITLE
setShowWhen to true

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -253,6 +253,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         final Notification.Builder builder = new Notification.Builder(context).
                 setTicker(notificationData.message).
                 setWhen(System.currentTimeMillis()).
+                setShowWhen(true).
                 setContentTitle(notificationData.title).
                 setContentText(notificationData.message).
                 setContentIntent(intent).


### PR DESCRIPTION
For apps targeting Build.VERSION_CODES.N and above, time is not shown anymore by default by using setWhen and must be opted into by using setShowWhen(boolean)