### PR TITLE
Add button support for push notifications

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
@@ -2,16 +2,19 @@ package com.mixpanel.android.mpmetrics;
 
 import android.app.Notification;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
 import android.test.AndroidTestCase;
 
 import org.mockito.ArgumentMatcher;
 
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,19 +22,24 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
     private final String VALID_RESOURCE_NAME = "com_mixpanel_android_logo";
     private final int VALID_RESOURCE_ID = R.drawable.com_mixpanel_android_logo;
+    private final String VALID_IMAGE_URL = "https://dev.images.mxpnl.com/1939595/fc767ba09b1a5420bdbcee71c7ae9904.png";
+    private final String INVALID_IMAGE_URL = "http:/badurl";
     private final String INVALID_RESOURCE_NAME = "NOT A VALID RESOURCE";
     private final String DEFAULT_TITLE = "DEFAULT TITLE";
     private final int DEFAULT_ICON_ID = android.R.drawable.sym_def_app_icon;
     private final Intent DEFAULT_INTENT = new Intent(Intent.ACTION_BUG_REPORT); // ACTION_BUG_REPORT is chosen because it's identifiably weird
+    private Context context;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         System.setProperty("org.mockito.android.target", getContext().getCacheDir().getPath());
 
+        this.context = getContext();
+
         now = System.currentTimeMillis();
         builderSpy = spy(new Notification.Builder(getContext()));
-        mpPushSpy = spy(new MixpanelPushNotification(this.getContext(), builderSpy, getTestResources(), now));
+        mpPushSpy = spy(new MixpanelPushNotification(context, builderSpy, getTestResources(), now));
 
         when(mpPushSpy.getDefaultTitle()).thenReturn(DEFAULT_TITLE);
         when(mpPushSpy.getDefaultIcon()).thenReturn(DEFAULT_ICON_ID);
@@ -48,7 +56,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp_title", "TITLE");
         mpPushSpy.createNotification(intent);
 
-        verify(builderSpy).setDefaults(MPConfig.getInstance(getContext()).getNotificationDefaults());
+        verify(builderSpy).setDefaults(MPConfig.getInstance(context).getNotificationDefaults());
         verify(builderSpy).setWhen(now);
         verify(builderSpy).setContentTitle("TITLE");
         verify(builderSpy).setContentText("MESSAGE");
@@ -86,26 +94,62 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
     }
 
     public void testIcon() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        intent.putExtra("mp_icnm", VALID_RESOURCE_NAME);
-        mpPushSpy.createNotification(intent);
-        verify(builderSpy).setSmallIcon(VALID_RESOURCE_ID);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_icnm", VALID_RESOURCE_NAME);
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy).setSmallIcon(VALID_RESOURCE_ID);
+        }
     }
 
     public void testNoIcon() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        mpPushSpy.createNotification(intent);
-        verify(builderSpy).setSmallIcon(DEFAULT_ICON_ID);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy).setSmallIcon(DEFAULT_ICON_ID);
+        }
     }
 
     public void testInvalidIcon() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        intent.putExtra("mp_icnm", INVALID_RESOURCE_NAME);
-        mpPushSpy.createNotification(intent);
-        verify(builderSpy).setSmallIcon(DEFAULT_ICON_ID);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_icnm", INVALID_RESOURCE_NAME);
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy).setSmallIcon(DEFAULT_ICON_ID);
+        }
+    }
+
+    public void testExpandedImageUsingValidUrl() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_img", VALID_IMAGE_URL);
+
+            Bitmap fakeBitmap = getFakeBitmap();
+
+            when(mpPushSpy.getBitmapFromUrl(VALID_IMAGE_URL)).thenReturn(fakeBitmap);
+
+            mpPushSpy.createNotification(intent);
+            verify(mpPushSpy).getBitmapFromUrl(VALID_IMAGE_URL);
+            verify(mpPushSpy).setBigPictureStyle(fakeBitmap);
+        }
+    }
+
+    public void testExpandedImageUsingInvalidUrl() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_img", INVALID_IMAGE_URL);
+
+            when(mpPushSpy.getBitmapFromUrl(INVALID_IMAGE_URL)).thenReturn(null);
+
+            mpPushSpy.createNotification(intent);
+            verify(mpPushSpy).getBitmapFromUrl(INVALID_IMAGE_URL);
+            verify(mpPushSpy).setBigTextStyle("MESSAGE");
+        }
     }
 
     public void testThumbnailImageUsingResourceName() {
@@ -138,18 +182,22 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
     }
 
     public void testIconColor() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        intent.putExtra("mp_color", "#ff9900");
-        mpPushSpy.createNotification(intent);
-        verify(builderSpy).setColor(Color.parseColor("#ff9900"));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_color", "#ff9900");
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy).setColor(Color.parseColor("#ff9900"));
+        }
     }
 
     public void testNoIconColor() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        mpPushSpy.createNotification(intent);
-        verify(builderSpy, never()).setColor(anyInt());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy, never()).setColor(anyInt());
+        }
     }
 
     public void testCTA() {
@@ -182,22 +230,153 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
     }
 
     public void testActionButtons() {
-        final Intent intent = new Intent();
-        intent.putExtra("mp_message", "MESSAGE");
-        intent.putExtra("mp_buttons", "[{\"lbl\": \"Button 1\", \"uri\": \"my-app://action\"}, {\"icnm\": \"" + VALID_RESOURCE_NAME + "\", \"lbl\": \"Button 2\", \"uri\": \"my-app://action2\"}, {\"lbl\": \"Button 3\", \"uri\": \"https://mixpanel.com\", \"icnm\": \"" + INVALID_RESOURCE_NAME + "\"}]");
-        mpPushSpy.createNotification(intent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_buttons", "[{\"lbl\": \"Button 1\", \"uri\": \"my-app://action\"}, {\"icnm\": \"" + VALID_RESOURCE_NAME + "\", \"lbl\": \"Button 2\", \"uri\": \"my-app://action2\"}, {\"lbl\": \"Button 3\", \"uri\": \"https://mixpanel.com\", \"icnm\": \"" + INVALID_RESOURCE_NAME + "\"}]");
+            mpPushSpy.createNotification(intent);
 
-        verify(mpPushSpy, atLeastOnce()).createAction(-1,"Button 1", "my-app://action");
-        verify(mpPushSpy, atLeastOnce()).createAction(VALID_RESOURCE_ID, "Button 2", "my-app://action2");
-        verify(mpPushSpy, atLeastOnce()).createAction(-1,"Button 3", "https://mixpanel.com");
-        verify(builderSpy, times(3)).addAction(any(Notification.Action.class));
+            verify(mpPushSpy, atLeastOnce()).createAction(-1, "Button 1", "my-app://action");
+            verify(mpPushSpy, atLeastOnce()).createAction(VALID_RESOURCE_ID, "Button 2", "my-app://action2");
+            verify(mpPushSpy, atLeastOnce()).createAction(-1, "Button 3", "https://mixpanel.com");
+            verify(builderSpy, times(3)).addAction(any(Notification.Action.class));
+        }
     }
 
     public void testNoActionButtons() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            mpPushSpy.createNotification(intent);
+            verify(builderSpy, never()).addAction(any(Notification.Action.class));
+        }
+    }
+
+    public void testValidNotificationBadge() {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
+        intent.putExtra("mp_bdgcnt", 2);
         mpPushSpy.createNotification(intent);
-        verify(builderSpy, never()).addAction(any(Notification.Action.class));
+        verify(builderSpy).setNumber(2);
+    }
+
+    public void testInvalidNotificationBadge() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        intent.putExtra("mp_bdgcnt", 0);
+        mpPushSpy.createNotification(intent);
+        verify(builderSpy, never()).setNumber(any(Integer.class));
+    }
+
+    public void testChannelId() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_channel_id", "12345");
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy).setChannelId("12345");
+            assertEquals(notification.getChannelId(), "12345");
+        }
+    }
+
+    public void testNoChannelId() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy).setChannelId(MixpanelPushNotification.NotificationData.DEFAULT_CHANNEL_ID);
+            assertEquals(notification.getChannelId(), MixpanelPushNotification.NotificationData.DEFAULT_CHANNEL_ID);
+        }
+    }
+
+    public void testSubText() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_subtxt", "SUBTEXT");
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy).setSubText("SUBTEXT");
+        }
+    }
+
+    public void testNoSubText() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy, never()).setSubText(any(String.class));
+        }
+    }
+
+    public void testTicker() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        intent.putExtra("mp_ticker", "TICK");
+        Notification notification = mpPushSpy.createNotification(intent);
+        verify(builderSpy).setTicker("TICK");
+    }
+
+    public void testNoTicker() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        Notification notification = mpPushSpy.createNotification(intent);
+        verify(builderSpy).setTicker("MESSAGE");
+    }
+
+    public void testSticky() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        intent.putExtra("mp_sticky", "true");
+        Notification notification = mpPushSpy.createNotification(intent);
+        int flag = notification.flags;
+        assertTrue((flag | Notification.FLAG_AUTO_CANCEL) != flag);
+    }
+
+    public void testNoSticky() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        Notification notification = mpPushSpy.createNotification(intent);
+        int flag = notification.flags;
+        assertEquals(flag | Notification.FLAG_AUTO_CANCEL, flag);
+    }
+
+    public void testTimestamp() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_time", "2014-10-02T15:01:23.045123456Z");
+            Notification notification = mpPushSpy.createNotification(intent);
+            Instant instant = Instant.parse("2014-10-02T15:01:23.045123456Z");
+            verify(builderSpy).setShowWhen(true);
+            verify(builderSpy).setWhen(instant.toEpochMilli());
+        }
+    }
+
+    public void testNoTimestamp() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            verify(builderSpy, never()).setWhen(any(Long.class));
+        }
+    }
+
+    public void testVisibility() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            intent.putExtra("mp_visibility", Notification.VISIBILITY_SECRET);
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy).setVisibility(Notification.VISIBILITY_SECRET);
+        }
+    }
+
+    public void testDefaultVisibility() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            final Intent intent = new Intent();
+            intent.putExtra("mp_message", "MESSAGE");
+            Notification notification = mpPushSpy.createNotification(intent);
+            verify(builderSpy).setVisibility(Notification.VISIBILITY_PRIVATE);
+        }
     }
 
     private static final class URIMatcher implements ArgumentMatcher<Uri> {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
@@ -181,6 +181,25 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         verify(mpPushSpy).buildNotificationIntent(DEFAULT_INTENT, null, null, null);
     }
 
+    public void testActionButtons() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        intent.putExtra("mp_buttons", "[{\"lbl\": \"Button 1\", \"uri\": \"my-app://action\"}, {\"icnm\": \"" + VALID_RESOURCE_NAME + "\", \"lbl\": \"Button 2\", \"uri\": \"my-app://action2\"}, {\"lbl\": \"Button 3\", \"uri\": \"https://mixpanel.com\", \"icnm\": \"" + INVALID_RESOURCE_NAME + "\"}]");
+        mpPushSpy.createNotification(intent);
+
+        verify(mpPushSpy, atLeastOnce()).createAction(-1,"Button 1", "my-app://action");
+        verify(mpPushSpy, atLeastOnce()).createAction(VALID_RESOURCE_ID, "Button 2", "my-app://action2");
+        verify(mpPushSpy, atLeastOnce()).createAction(-1,"Button 3", "https://mixpanel.com");
+        verify(builderSpy, times(3)).addAction(any(Notification.Action.class));
+    }
+
+    public void testNoActionButtons() {
+        final Intent intent = new Intent();
+        intent.putExtra("mp_message", "MESSAGE");
+        mpPushSpy.createNotification(intent);
+        verify(builderSpy, never()).addAction(any(Notification.Action.class));
+    }
+
     private static final class URIMatcher implements ArgumentMatcher<Uri> {
         public URIMatcher(String expectedUri) {
             this.expectedUri = expectedUri;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -140,7 +140,11 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
         Notification notification = mixpanelPushNotification.createNotification(messageIntent);
         if (null != notification) {
             final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.notify(0, notification);
+            if (mixpanelPushNotification.data.tag != null) {
+                notificationManager.notify(mixpanelPushNotification.data.tag, 0, notification);
+            } else {
+                notificationManager.notify(0, notification);
+            }
         }
     }
 


### PR DESCRIPTION
adds support for a new push data key `mp_buttons` to specify action buttons in a push notification

![2019-09-09 10 48 42](https://user-images.githubusercontent.com/556882/64546077-94625600-d2ef-11e9-9f74-b1f7b9ef5dcc.gif)
