### PR TITLE
Keep extras in the intent when tracking push open

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -146,9 +146,6 @@ import java.util.Locale;
                     mMpInstance.track("$app_open", pushProps);
                 } catch (JSONException e) {}
 
-                intent.removeExtra("mp_campaign_id");
-                intent.removeExtra("mp_message_id");
-                intent.removeExtra("mp");
             }
         } catch (BadParcelableException e) {
             // https://github.com/mixpanel/mixpanel-android/issues/251


### PR DESCRIPTION
Take out the lines that removed the extra keys (mp, mp_campaign_id and mp_message_id) from the intent when $app_open was tracked. This was originally intended to remove Mixpanel traces from the intent so it would not interfere with other libraries but this prevents multiple instances of Mixpanel from tracking the event which is the preferable outcome.