### PR TITLE
Remove waiting_array in SharedPrefs and move it to sqlite

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -1062,7 +1062,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
         differentToken.track("other event", null);
         differentToken.getPeople().set("other people prop", "Word"); // should be queued up.
 
-        assertEquals(1, messages.size());
+        assertEquals(2, messages.size());
 
         AnalyticsMessages.EventDescription eventMessage = (AnalyticsMessages.EventDescription) messages.get(0);
 

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/PersistentIdentityTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/PersistentIdentityTest.java
@@ -4,10 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.test.AndroidTestCase;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -32,7 +28,6 @@ public class PersistentIdentityTest extends AndroidTestCase {
         prefsEditor.putString("events_distinct_id", "EVENTS DISTINCT ID");
         prefsEditor.putString("people_distinct_id", "PEOPLE DISTINCT ID");
         prefsEditor.putString("push_id", "PUSH ID");
-        prefsEditor.putString("waiting_array", "[ {\"thing\": 1}, {\"thing\": 2} ]");
         prefsEditor.putString("super_properties", "{\"thing\": \"superprops\"}");
         prefsEditor.commit();
 
@@ -48,73 +43,6 @@ public class PersistentIdentityTest extends AndroidTestCase {
         Future<SharedPreferences> mixpanelLoader = loader.loadPreferences(getContext(), TEST_MIXPANEL_PREFERENCES, null);
 
         mPersistentIdentity = new PersistentIdentity(referrerLoader, testLoader, timeEventsLoader, mixpanelLoader);
-    }
-
-    public void testStaticWaitingPeopleRecordsWithId() throws JSONException {
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        JSONArray records = PersistentIdentity.waitingPeopleRecordsForSending(testPreferences);
-        assertEquals(records.length(), 2);
-        for (int i = 0; i < records.length(); i++) {
-            JSONObject obj = records.getJSONObject(i);
-            assertTrue(obj.has("thing"));
-            assertEquals(obj.getString("$distinct_id"), "PEOPLE DISTINCT ID");
-        }
-        JSONArray unseenRecords = PersistentIdentity.waitingPeopleRecordsForSending(testPreferences);
-        assertNull(unseenRecords);
-    }
-
-    public void testStaticWaitingPeopleRecordsNoId() {
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        testPreferences.edit().remove("people_distinct_id").commit();
-        JSONArray records = PersistentIdentity.waitingPeopleRecordsForSending(testPreferences);
-        assertNull(records);
-    }
-
-    public void testStaticWaitingPeopleRecordsNoRecords() {
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        testPreferences.edit().remove("waiting_array").commit();
-        JSONArray records = PersistentIdentity.waitingPeopleRecordsForSending(testPreferences);
-        assertNull(records);
-    }
-
-    public void testWaitingPeopleRecordsWithId() throws JSONException {
-        JSONArray records = mPersistentIdentity.waitingPeopleRecordsForSending();
-        assertEquals(records.length(), 2);
-        for (int i = 0; i < records.length(); i++) {
-            JSONObject obj = records.getJSONObject(i);
-            assertTrue(obj.has("thing"));
-            assertEquals(obj.getString("$distinct_id"), "PEOPLE DISTINCT ID");
-        }
-        JSONArray unseenRecords = mPersistentIdentity.waitingPeopleRecordsForSending();
-        assertNull(unseenRecords);
-    }
-
-    public void testWaitingPeopleRecordsWithNoId() throws JSONException {
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        testPreferences.edit().remove("people_distinct_id").commit();
-        JSONArray unseenRecords = mPersistentIdentity.waitingPeopleRecordsForSending();
-        assertNull(unseenRecords);
-    }
-
-    public void testWaitingPeopleRecordsWithNoRecords() throws JSONException {
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        testPreferences.edit().remove("waiting_array").commit();
-        JSONArray unseenRecords = mPersistentIdentity.waitingPeopleRecordsForSending();
-        assertNull(unseenRecords);
-    }
-
-    public void testStoreWaitingPeopleRecord() throws JSONException {
-        mPersistentIdentity.storeWaitingPeopleRecord(new JSONObject("{\"new1\": 1}"));
-        mPersistentIdentity.storeWaitingPeopleRecord(new JSONObject("{\"new2\": 2}"));
-
-        SharedPreferences testPreferences = getContext().getSharedPreferences(TEST_PREFERENCES, Context.MODE_PRIVATE);
-        String waitingString = testPreferences.getString("waiting_array", "FAIL");
-        JSONArray waitingArray = new JSONArray(waitingString);
-        assertEquals(waitingArray.length(), 4);
-        JSONObject new1 = waitingArray.getJSONObject(2);
-        assertEquals(1, new1.getInt("new1"));
-        JSONObject new2 = waitingArray.getJSONObject(3);
-        assertEquals(2, new2.getInt("new2"));
     }
 
     public void testReferrerProperties() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -98,6 +98,15 @@ import javax.net.ssl.SSLSocketFactory;
         mWorker.runMessage(m);
     }
 
+    // Must be thread safe.
+    public void pushAnonymousPeopleMessage(final PushAnonymousPeopleDescription pushAnonymousPeopleDescription) {
+        final Message m = Message.obtain();
+        m.what = PUSH_ANONYMOUS_PEOPLE_RECORDS;
+        m.obj = pushAnonymousPeopleDescription;
+
+        mWorker.runMessage(m);
+    }
+
     public void postToServer(final FlushDescription flushDescription) {
         final Message m = Message.obtain();
         m.what = FLUSH_QUEUE;
@@ -207,6 +216,10 @@ import javax.net.ssl.SSLSocketFactory;
             return message;
         }
 
+        public boolean isAnonymous() {
+            return !message.has("$distinct_id");
+        }
+
         private final JSONObject message;
     }
 
@@ -226,6 +239,24 @@ import javax.net.ssl.SSLSocketFactory;
         }
 
         private final JSONObject message;
+    }
+
+    static class PushAnonymousPeopleDescription extends MixpanelDescription {
+        public PushAnonymousPeopleDescription(String distinctId, String token) {
+            super(token);
+            this.mDistinctId = distinctId;
+        }
+
+        @Override
+        public String toString() {
+            return this.mDistinctId;
+        }
+
+        public String getDistinctId() {
+            return this.mDistinctId;
+        }
+
+        private final String mDistinctId;
     }
 
     static class FlushDescription extends MixpanelDescription {
@@ -329,11 +360,13 @@ import javax.net.ssl.SSLSocketFactory;
 
                     if (msg.what == ENQUEUE_PEOPLE) {
                         final PeopleDescription message = (PeopleDescription) msg.obj;
+                        final MPDbAdapter.Table peopleTable = message.isAnonymous() ? MPDbAdapter.Table.ANONYMOUS_PEOPLE : MPDbAdapter.Table.PEOPLE;
 
                         logAboutMessageToMixpanel("Queuing people record for sending later");
                         logAboutMessageToMixpanel("    " + message.toString());
                         token = message.getToken();
-                        returnCode = mDbAdapter.addJSON(message.getMessage(), token, MPDbAdapter.Table.PEOPLE, false);
+                        int numRowsTable = mDbAdapter.addJSON(message.getMessage(), token, peopleTable, false);
+                        returnCode = message.isAnonymous() ? 0 : numRowsTable;
                     } else if (msg.what == ENQUEUE_GROUP) {
                         final GroupDescription message = (GroupDescription) msg.obj;
 
@@ -357,6 +390,11 @@ import javax.net.ssl.SSLSocketFactory;
                         } catch (final JSONException e) {
                             MPLog.e(LOGTAG, "Exception tracking event " + eventDescription.getEventName(), e);
                         }
+                    } else if (msg.what == PUSH_ANONYMOUS_PEOPLE_RECORDS) {
+                        final PushAnonymousPeopleDescription pushAnonymousPeopleDescription = (PushAnonymousPeopleDescription) msg.obj;
+                        final String distinctId = pushAnonymousPeopleDescription.getDistinctId();
+                        token = pushAnonymousPeopleDescription.getToken();
+                        mDbAdapter.pushAnonymousUpdatesToPeopleDb(token, distinctId);
                     } else if (msg.what == FLUSH_QUEUE) {
                         logAboutMessageToMixpanel("Flushing queue due to scheduled or forced flush");
                         updateFlushFrequency();
@@ -697,6 +735,7 @@ import javax.net.ssl.SSLSocketFactory;
     private static final int ENQUEUE_EVENTS = 1; // push given JSON message to events DB
     private static final int FLUSH_QUEUE = 2; // submit events, people, and groups data
     private static final int ENQUEUE_GROUP = 3; // push given JSON message to groups DB
+    private static final int PUSH_ANONYMOUS_PEOPLE_RECORDS = 4; // push anonymous people DB updates to people DB
     private static final int KILL_WORKER = 5; // Hard-kill the worker thread, discarding all events on the event queue. This is for testing, or disasters.
     private static final int EMPTY_QUEUES = 6; // Remove any local (and pending to be flushed) events or people/group updates from the db
     private static final int INSTALL_DECIDE_CHECK = 12; // Run this DecideCheck at intervals until it isDestroyed()

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -403,7 +403,7 @@ import javax.net.ssl.SSLSocketFactory;
                         final PushAnonymousPeopleDescription pushAnonymousPeopleDescription = (PushAnonymousPeopleDescription) msg.obj;
                         final String distinctId = pushAnonymousPeopleDescription.getDistinctId();
                         token = pushAnonymousPeopleDescription.getToken();
-                        mDbAdapter.pushAnonymousUpdatesToPeopleDb(token, distinctId);
+                        returnCode = mDbAdapter.pushAnonymousUpdatesToPeopleDb(token, distinctId);
                     } else if (msg.what == CLEAR_ANONYMOUS_UPDATES) {
                         final MixpanelDescription mixpanelDescription = (MixpanelDescription) msg.obj;
                         token = mixpanelDescription.getToken();

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
@@ -1,6 +1,7 @@
 package com.mixpanel.android.mpmetrics;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +11,7 @@ import org.json.JSONObject;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
@@ -31,6 +33,7 @@ import com.mixpanel.android.util.MPLog;
     public enum Table {
         EVENTS ("events"),
         PEOPLE ("people"),
+        ANONYMOUS_PEOPLE ("anonymous_people"),
         GROUPS ("groups");
 
         Table(String name) {
@@ -57,8 +60,8 @@ import com.mixpanel.android.util.MPLog;
     private static final int MIN_DB_VERSION = 4;
 
     // If you increment DATABASE_VERSION, don't forget to define migration
-    private static final int DATABASE_VERSION = 6; // current database version
-    private static final int MAX_DB_VERSION = 6; // Max database version onUpdate can migrate to.
+    private static final int DATABASE_VERSION = 7; // current database version
+    private static final int MAX_DB_VERSION = 7; // Max database version onUpdate can migrate to.
 
     private static final String CREATE_EVENTS_TABLE =
        "CREATE TABLE " + Table.EVENTS.getName() + " (_id INTEGER PRIMARY KEY AUTOINCREMENT, " +
@@ -78,6 +81,12 @@ import com.mixpanel.android.util.MPLog;
                     KEY_CREATED_AT + " INTEGER NOT NULL, " +
                     KEY_AUTOMATIC_DATA + " INTEGER DEFAULT 0, " +
                     KEY_TOKEN + " STRING NOT NULL DEFAULT '')";
+    private static final String CREATE_ANONYMOUS_PEOPLE_TABLE =
+            "CREATE TABLE " + Table.ANONYMOUS_PEOPLE.getName() + " (_id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    KEY_DATA + " STRING NOT NULL, " +
+                    KEY_CREATED_AT + " INTEGER NOT NULL, " +
+                    KEY_AUTOMATIC_DATA + " INTEGER DEFAULT 0, " +
+                    KEY_TOKEN + " STRING NOT NULL DEFAULT '')";
     private static final String EVENTS_TIME_INDEX =
         "CREATE INDEX IF NOT EXISTS time_idx ON " + Table.EVENTS.getName() +
         " (" + KEY_CREATED_AT + ");";
@@ -87,6 +96,9 @@ import com.mixpanel.android.util.MPLog;
     private static final String GROUPS_TIME_INDEX =
             "CREATE INDEX IF NOT EXISTS time_idx ON " + Table.GROUPS.getName() +
                     " (" + KEY_CREATED_AT + ");";
+    private static final String ANONYMOUS_PEOPLE_TIME_INDEX =
+            "CREATE INDEX IF NOT EXISTS time_idx ON " + Table.ANONYMOUS_PEOPLE.getName() +
+                    " (" + KEY_CREATED_AT + ");";
 
     private final MPDatabaseHelper mDb;
 
@@ -95,6 +107,7 @@ import com.mixpanel.android.util.MPLog;
             super(context, dbName, null, DATABASE_VERSION);
             mDatabaseFile = context.getDatabasePath(dbName);
             mConfig = MPConfig.getInstance(context);
+            mContext = context;
         }
 
         /**
@@ -112,9 +125,11 @@ import com.mixpanel.android.util.MPLog;
             db.execSQL(CREATE_EVENTS_TABLE);
             db.execSQL(CREATE_PEOPLE_TABLE);
             db.execSQL(CREATE_GROUPS_TABLE);
+            db.execSQL(CREATE_ANONYMOUS_PEOPLE_TABLE);
             db.execSQL(EVENTS_TIME_INDEX);
             db.execSQL(PEOPLE_TIME_INDEX);
             db.execSQL(GROUPS_TIME_INDEX);
+            db.execSQL(ANONYMOUS_PEOPLE_TIME_INDEX);
         }
 
         @Override
@@ -124,21 +139,31 @@ import com.mixpanel.android.util.MPLog;
             if (oldVersion >= MIN_DB_VERSION && newVersion <= MAX_DB_VERSION) {
                 if (oldVersion == 4) {
                     migrateTableFrom4To5(db);
+                    migrateTableFrom5To6(db);
+                    migrateTableFrom6To7(db);
                 }
 
-                if (newVersion == 6) {
+                if (oldVersion == 5) {
                     migrateTableFrom5To6(db);
+                    migrateTableFrom6To7(db);
+                }
+
+                if (oldVersion == 6) {
+                    migrateTableFrom6To7(db);
                 }
             } else {
                 db.execSQL("DROP TABLE IF EXISTS " + Table.EVENTS.getName());
                 db.execSQL("DROP TABLE IF EXISTS " + Table.PEOPLE.getName());
                 db.execSQL("DROP TABLE IF EXISTS " + Table.GROUPS.getName());
+                db.execSQL("DROP TABLE IF EXISTS " + Table.ANONYMOUS_PEOPLE.getName());
                 db.execSQL(CREATE_EVENTS_TABLE);
                 db.execSQL(CREATE_PEOPLE_TABLE);
                 db.execSQL(CREATE_GROUPS_TABLE);
+                db.execSQL(CREATE_ANONYMOUS_PEOPLE_TABLE);
                 db.execSQL(EVENTS_TIME_INDEX);
                 db.execSQL(PEOPLE_TIME_INDEX);
                 db.execSQL(GROUPS_TIME_INDEX);
+                db.execSQL(ANONYMOUS_PEOPLE_TIME_INDEX);
             }
         }
 
@@ -187,8 +212,63 @@ import com.mixpanel.android.util.MPLog;
             db.execSQL(GROUPS_TIME_INDEX);
         }
 
+        private void migrateTableFrom6To7(SQLiteDatabase db) {
+            db.execSQL(CREATE_ANONYMOUS_PEOPLE_TABLE);
+            db.execSQL(ANONYMOUS_PEOPLE_TIME_INDEX);
+
+            File prefsDir = new File(mContext.getApplicationInfo().dataDir, "shared_prefs");
+
+            if (prefsDir.exists() && prefsDir.isDirectory()) {
+                String[] storedPrefsFiles = prefsDir.list(new FilenameFilter() {
+                    @Override
+                    public boolean accept(File dir, String name) {
+                        return name.startsWith("com.mixpanel.android.mpmetrics.MixpanelAPI_");
+                    }
+                });
+
+                for (String storedPrefFile : storedPrefsFiles) {
+                    String storedPrefName = storedPrefFile.split("\\.xml")[0];
+                    SharedPreferences s = mContext.getSharedPreferences(storedPrefName, Context.MODE_PRIVATE);
+                    final String waitingPeopleUpdates = s.getString("waiting_array", null);
+                    if (waitingPeopleUpdates != null) {
+                        try {
+                            JSONArray waitingObjects = new JSONArray(waitingPeopleUpdates);
+                            db.beginTransaction();
+                            try {
+                                for (int i = 0; i < waitingObjects.length(); i++) {
+                                    try {
+                                        final JSONObject j = waitingObjects.getJSONObject(i);
+                                        String token = j.getString("$token");
+
+                                        final ContentValues cv = new ContentValues();
+                                        cv.put(KEY_DATA, j.toString());
+                                        cv.put(KEY_CREATED_AT, System.currentTimeMillis());
+                                        cv.put(KEY_AUTOMATIC_DATA, false);
+                                        cv.put(KEY_TOKEN, token);
+                                        db.insert(Table.ANONYMOUS_PEOPLE.getName(), null, cv);
+                                    } catch (JSONException e) {
+                                        // ignore record
+                                    }
+                                }
+                                db.setTransactionSuccessful();
+                            } finally {
+                                db.endTransaction();
+                            }
+                        } catch (JSONException e) {
+                            // waiting array is corrupted. dismiss.
+                        }
+
+                        SharedPreferences.Editor e = s.edit();
+                        e.remove("waiting_array");
+                        e.apply();
+                    }
+                }
+            }
+        }
+
         private final File mDatabaseFile;
         private final MPConfig mConfig;
+        private final Context mContext;
     }
 
     public MPDbAdapter(Context context) {
@@ -267,6 +347,61 @@ import com.mixpanel.android.util.MPLog;
             mDb.close();
         }
         return count;
+    }
+
+    /**
+     * Copies anonymous people updates to people db after a user has been identified
+     * @param token project token
+     * @param distinctId people profile distinct id
+     */
+    public void pushAnonymousUpdatesToPeopleDb(String token, String distinctId) {
+        Cursor selectCursor = null;
+        try {
+            final SQLiteDatabase db = mDb.getWritableDatabase();
+            StringBuffer allAnonymousQuery = new StringBuffer("SELECT * FROM " + Table.ANONYMOUS_PEOPLE.getName() + " WHERE " + KEY_TOKEN + " = '" + token + "'");
+
+            selectCursor = db.rawQuery(allAnonymousQuery.toString(), null);
+            db.beginTransaction();
+            try {
+                while (selectCursor.moveToNext()) {
+                    try {
+                        ContentValues values = new ContentValues();
+                        values.put(KEY_CREATED_AT, selectCursor.getLong(selectCursor.getColumnIndex(KEY_CREATED_AT)));
+                        values.put(KEY_AUTOMATIC_DATA, selectCursor.getInt(selectCursor.getColumnIndex(KEY_AUTOMATIC_DATA)));
+                        values.put(KEY_TOKEN, selectCursor.getString(selectCursor.getColumnIndex(KEY_TOKEN)));
+
+                        JSONObject updatedData = new JSONObject(selectCursor.getString(selectCursor.getColumnIndex(KEY_DATA)));
+                        updatedData.put("$distinct_id", distinctId);
+                        values.put(KEY_DATA, updatedData.toString());
+                        db.insert(Table.PEOPLE.getName(), null, values);
+                        int rowId = selectCursor.getInt(selectCursor.getColumnIndex("_id"));
+                        db.delete(Table.ANONYMOUS_PEOPLE.getName(), "_id = " + rowId, null);
+                    } catch (final JSONException e) {
+                        // Ignore this object
+                    }
+                }
+                db.setTransactionSuccessful();
+            } finally {
+                db.endTransaction();
+            }
+        } catch (final SQLiteException e) {
+            MPLog.e(LOGTAG, "Could not push anonymous updates records from " + Table.ANONYMOUS_PEOPLE.getName() + ". Re-initializing database.", e);
+
+            if (selectCursor != null) {
+                selectCursor.close();
+                selectCursor = null;
+            }
+            // We assume that in general, the results of a SQL exception are
+            // unrecoverable, and could be associated with an oversized or
+            // otherwise unusable DB. Better to bomb it and get back on track
+            // than to leave it junked up (and maybe filling up the disk.)
+            mDb.deleteDatabase();
+        } finally {
+            if (selectCursor != null) {
+                selectCursor.close();
+            }
+            mDb.close();
+        }
     }
 
     /**
@@ -379,7 +514,6 @@ import com.mixpanel.android.util.MPLog;
     public void deleteDB() {
         mDb.deleteDatabase();
     }
-
 
     /**
      * Returns the data string to send to Mixpanel and the maximum ID of the row that

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
@@ -298,7 +298,7 @@ import com.mixpanel.android.util.MPLog;
      * to the SQLiteDatabase.
      * @param j the JSON to record
      * @param token token of the project
-     * @param table the table to insert into, one of "events", "people", or "groups"
+     * @param table the table to insert into, one of "events", "people", "groups" or "anonymous_people"
      * @param isAutomaticRecord mark the record as an automatic event or not
      * @return the number of rows in the table, or DB_OUT_OF_MEMORY_ERROR/DB_UPDATE_ERROR
      * on failure
@@ -407,7 +407,7 @@ import com.mixpanel.android.util.MPLog;
     /**
      * Removes events with an _id <= last_id from table
      * @param last_id the last id to delete
-     * @param table the table to remove events from, one of "events", "people", or "groups"
+     * @param table the table to remove events from, one of "events", "people", "groups" or "anonymous_people"
      * @param includeAutomaticEvents whether or not automatic events should be included in the cleanup
      */
     public void cleanupEvents(String last_id, Table table, String token, boolean includeAutomaticEvents) {
@@ -437,7 +437,7 @@ import com.mixpanel.android.util.MPLog;
     /**
      * Removes events before time.
      * @param time the unix epoch in milliseconds to remove events before
-     * @param table the table to remove events from, one of "events", "people", or "groups"
+     * @param table the table to remove events from, one of "events", "people", "groups" or "anonymous_people"
      */
     public void cleanupEvents(long time, Table table) {
         final String tableName = table.getName();
@@ -460,7 +460,7 @@ import com.mixpanel.android.util.MPLog;
 
     /**
      * Removes all events given a project token.
-     * @param table the table to remove events from, one of "events", "people", or "groups"
+     * @param table the table to remove events from, one of "events", "people", "groups" or "anonymous_people"
      * @param token token of the project to remove events from
      */
     public void cleanupAllEvents(Table table, String token) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1005,6 +1005,7 @@ public class MixpanelAPI {
         // and waiting People Analytics properties. Will have no effect
         // on messages already queued to send with AnalyticsMessages.
         mPersistentIdentity.clearPreferences();
+        getAnalyticsMessages().clearAnonymousUpdatesMessage(new AnalyticsMessages.MixpanelDescription(mToken));
         identify(getDistinctId(), false);
         mConnectIntegrations.reset();
         mUpdatesFromMixpanel.storeVariants(new JSONArray());

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1834,9 +1834,9 @@ public class MixpanelAPI {
         final SharedPreferencesLoader.OnPrefsLoadedListener listener = new SharedPreferencesLoader.OnPrefsLoadedListener() {
             @Override
             public void onPrefsLoaded(SharedPreferences preferences) {
-                final JSONArray records = PersistentIdentity.waitingPeopleRecordsForSending(preferences);
-                if (null != records) {
-                    sendAllPeopleRecords(records);
+                final String distinctId = PersistentIdentity.getPeopleDistinctId(preferences);
+                if (null != distinctId) {
+                    pushWaitingPeopleRecord(distinctId);
                 }
             }
         };
@@ -1900,7 +1900,7 @@ public class MixpanelAPI {
                 mPersistentIdentity.setPeopleDistinctId(distinctId);
                 mDecideMessages.setDistinctId(distinctId);
             }
-            pushWaitingPeopleRecord();
+            pushWaitingPeopleRecord(distinctId);
          }
 
         @Override
@@ -2756,11 +2756,7 @@ public class MixpanelAPI {
 
     private void recordPeopleMessage(JSONObject message) {
         if (hasOptedOutTracking()) return;
-        if (message.has("$distinct_id")) {
-           mMessages.peopleMessage(new AnalyticsMessages.PeopleDescription(message, mToken));
-        } else {
-           mPersistentIdentity.storeWaitingPeopleRecord(message);
-        }
+        mMessages.peopleMessage(new AnalyticsMessages.PeopleDescription(message, mToken));
     }
 
     private void recordGroupMessage(JSONObject message) {
@@ -2772,26 +2768,9 @@ public class MixpanelAPI {
         }
     }
 
-    private void pushWaitingPeopleRecord() {
+    private void pushWaitingPeopleRecord(String distinctId) {
         if (hasOptedOutTracking()) return;
-        final JSONArray records = mPersistentIdentity.waitingPeopleRecordsForSending();
-        if (null != records) {
-            sendAllPeopleRecords(records);
-        }
-    }
-
-    // MUST BE THREAD SAFE. Called from crazy places. mPersistentIdentity may not exist
-    // when this is called (from its crazy thread)
-    private void sendAllPeopleRecords(JSONArray records) {
-        if (hasOptedOutTracking()) return;
-        for (int i = 0; i < records.length(); i++) {
-            try {
-                final JSONObject message = records.getJSONObject(i);
-                mMessages.peopleMessage(new AnalyticsMessages.PeopleDescription(message, mToken));
-            } catch (final JSONException e) {
-                MPLog.e(LOGTAG, "Malformed people record stored pending identity, will not send it.", e);
-            }
-        }
+        mMessages.pushAnonymousPeopleMessage(new AnalyticsMessages.PushAnonymousPeopleDescription(distinctId, mToken));
     }
 
     private static void registerAppLinksListeners(Context context, final MixpanelAPI mixpanel) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -264,9 +264,9 @@ public class MixpanelAPI {
         mSessionMetadata = new SessionMetadata();
         mUpdatesFromMixpanel = constructUpdatesFromMixpanel(context, token);
         mTrackingDebug = constructTrackingDebug();
+        mMessages = getAnalyticsMessages();
         mPersistentIdentity = getPersistentIdentity(context, referrerPreferences, token);
         mEventTimings = mPersistentIdentity.getTimeEvents();
-        mMessages = getAnalyticsMessages();
 
         if (optOutTrackingDefault && (hasOptedOutTracking() || !mPersistentIdentity.hasOptOutFlag(token))) {
             optOutTracking();
@@ -2770,7 +2770,6 @@ public class MixpanelAPI {
     }
 
     private void pushWaitingPeopleRecord(String distinctId) {
-        if (hasOptedOutTracking()) return;
         mMessages.pushAnonymousPeopleMessage(new AnalyticsMessages.PushAnonymousPeopleDescription(distinctId, mToken));
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
@@ -22,38 +22,9 @@ import com.mixpanel.android.util.MPLog;
 // In order to use writeEdits, we have to suppress the linter's check for commit()/apply()
 @SuppressLint("CommitPrefEdits")
 /* package */ class PersistentIdentity {
-    public static final int MAX_WAITING_PEOPLE_RECORDS = 1000;
-
     // Should ONLY be called from an OnPrefsLoadedListener (since it should NEVER be called concurrently)
-    public static JSONArray waitingPeopleRecordsForSending(SharedPreferences storedPreferences) {
-        JSONArray ret = null;
-        final String peopleDistinctId = storedPreferences.getString("people_distinct_id", null);
-        final String waitingPeopleRecords = storedPreferences.getString("waiting_array", null);
-        if ((null != waitingPeopleRecords) && (null != peopleDistinctId)) {
-            JSONArray waitingObjects = null;
-            try {
-                waitingObjects = new JSONArray(waitingPeopleRecords);
-            } catch (final JSONException e) {
-                MPLog.e(LOGTAG, "Waiting people records were unreadable.");
-                return null;
-            }
-
-            ret = new JSONArray();
-            for (int i = 0; i < waitingObjects.length(); i++) {
-                try {
-                    final JSONObject ob = waitingObjects.getJSONObject(i);
-                    ob.put("$distinct_id", peopleDistinctId);
-                    ret.put(ob);
-                } catch (final JSONException e) {
-                    MPLog.e(LOGTAG, "Unparsable object found in waiting people records", e);
-                }
-            }
-
-            final SharedPreferences.Editor editor = storedPreferences.edit();
-            editor.remove("waiting_array");
-            writeEdits(editor);
-        }
-        return ret;
+    public static String getPeopleDistinctId(SharedPreferences storedPreferences) {
+        return storedPreferences.getString("people_distinct_id", null);
     }
 
     public static void writeReferrerPrefs(Context context, String preferencesName, Map<String, String> properties) {
@@ -225,41 +196,6 @@ import com.mixpanel.android.util.MPLog;
         }
         mPeopleDistinctId = peopleDistinctId;
         writeIdentities();
-    }
-
-    public synchronized void storeWaitingPeopleRecord(JSONObject record) {
-        if (! mIdentitiesLoaded) {
-            readIdentities();
-        }
-        if (null == mWaitingPeopleRecords) {
-            mWaitingPeopleRecords = new JSONArray();
-        } else if (mWaitingPeopleRecords.length() >= MAX_WAITING_PEOPLE_RECORDS) {
-            return;
-        }
-
-        mWaitingPeopleRecords.put(record);
-        writeIdentities();
-    }
-
-    /* package */ synchronized JSONArray getWaitingPeopleRecords() {
-        if (! mIdentitiesLoaded) {
-            readIdentities();
-        }
-        return mWaitingPeopleRecords;
-    }
-
-    public synchronized JSONArray waitingPeopleRecordsForSending() {
-        JSONArray ret = null;
-        try {
-            final SharedPreferences prefs = mLoadStoredPreferences.get();
-            ret = waitingPeopleRecordsForSending(prefs);
-            readIdentities();
-        } catch (final ExecutionException e) {
-            MPLog.e(LOGTAG, "Couldn't read waiting people records from shared preferences.", e.getCause());
-        } catch (final InterruptedException e) {
-            MPLog.e(LOGTAG, "Couldn't read waiting people records from shared preferences.", e);
-        }
-        return ret;
     }
 
     public synchronized void clearPreferences() {
@@ -653,16 +589,6 @@ import com.mixpanel.android.util.MPLog;
         mPeopleDistinctId = prefs.getString("people_distinct_id", null);
         mAnonymousId = prefs.getString("anonymous_id", null);
         mHadPersistedDistinctId = prefs.getBoolean("had_persisted_distinct_id", false);
-        mWaitingPeopleRecords = null;
-
-        final String storedWaitingRecord = prefs.getString("waiting_array", null);
-        if (storedWaitingRecord != null) {
-            try {
-                mWaitingPeopleRecords = new JSONArray(storedWaitingRecord);
-            } catch (final JSONException e) {
-                MPLog.e(LOGTAG, "Could not interpret waiting people JSON record " + storedWaitingRecord);
-            }
-        }
 
         if (mEventsDistinctId == null) {
             mAnonymousId = UUID.randomUUID().toString();
@@ -737,11 +663,6 @@ import com.mixpanel.android.util.MPLog;
             prefsEditor.putString("people_distinct_id", mPeopleDistinctId);
             prefsEditor.putString("anonymous_id", mAnonymousId);
             prefsEditor.putBoolean("had_persisted_distinct_id", mHadPersistedDistinctId);
-            if (mWaitingPeopleRecords == null) {
-                prefsEditor.remove("waiting_array");
-            } else {
-                prefsEditor.putString("waiting_array", mWaitingPeopleRecords.toString());
-            }
             writeEdits(prefsEditor);
         } catch (final ExecutionException e) {
             MPLog.e(LOGTAG, "Can't write distinct ids to shared preferences.", e.getCause());
@@ -767,7 +688,6 @@ import com.mixpanel.android.util.MPLog;
     private String mPeopleDistinctId;
     private String mAnonymousId;
     private boolean mHadPersistedDistinctId;
-    private JSONArray mWaitingPeopleRecords;
     private Boolean mIsUserOptOut;
     private static Integer sPreviousVersionCode;
     private static Boolean sIsFirstAppLaunch;

--- a/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/PersistentIdentity.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 


### PR DESCRIPTION
Fixes several open issues (https://github.com/mixpanel/mixpanel-android/issues/470, https://github.com/mixpanel/mixpanel-android/issues/180)

Anonymous people updates are now asynchronously stored in sqlite instead of `SharedPreferences`, one by one.

**Previous behavior**:
A people update to an unidentified user would involve reading all people updates, append the new update and store the newly created structure to an xml file. This method is not performant, which could lead to OOO errors, ANRs and lead to problems by having multiple threads accessing `PersistentIdentity`.

**Current behavior**:
Each people update is now asynchronously handled by our worker thread and appended to a sqlite table. This method is more performant, removes the limitation of only storing 1000 people updates, won't cause ANRs or synchronization problems when storing user preferences. 