### PR TITLE
Fix id issue with push tags

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -148,7 +148,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
             final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             final int id = new Random().nextInt(Integer.MAX_VALUE);
             if (mixpanelPushNotification.data.tag != null) {
-                notificationManager.notify(mixpanelPushNotification.data.tag, id, notification);
+                notificationManager.notify(mixpanelPushNotification.data.tag, 0, notification);
             } else {
                 notificationManager.notify(id, notification);
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -13,6 +13,8 @@ import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.mixpanel.android.util.MPLog;
 
+import java.util.Random;
+
 
 /**
  * Service for handling Firebase Cloud Messaging callbacks.
@@ -144,10 +146,11 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
 
         if (null != notification) {
             final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            final int id = new Random().nextInt(Integer.MAX_VALUE);
             if (mixpanelPushNotification.data.tag != null) {
-                notificationManager.notify(mixpanelPushNotification.data.tag, 0, notification);
+                notificationManager.notify(mixpanelPushNotification.data.tag, id, notification);
             } else {
-                notificationManager.notify(0, notification);
+                notificationManager.notify(id, notification);
             }
         }
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFCMMessagingService.java
@@ -148,6 +148,7 @@ public class MixpanelFCMMessagingService extends FirebaseMessagingService {
             final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             final int id = new Random().nextInt(Integer.MAX_VALUE);
             if (mixpanelPushNotification.data.tag != null) {
+                //Use 0 as id so that we can reference notification solely by tag
                 notificationManager.notify(mixpanelPushNotification.data.tag, 0, notification);
             } else {
                 notificationManager.notify(id, notification);


### PR DESCRIPTION
Generates a random id instead of using 0 so the device will, by default, show multiple notifications instead of always replacing the notification