### PR TITLE
Add android total sessions length

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/AutomaticEvents.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AutomaticEvents.java
@@ -4,6 +4,8 @@ package com.mixpanel.android.mpmetrics;
     public static final String FIRST_OPEN = "$ae_first_open";
     public static final String SESSION = "$ae_session";
     public static final String SESSION_LENGTH = "$ae_session_length";
+    public static final String TOTAL_SESSIONS = "$ae_total_app_sessions";
+    public static final String TOTAL_SESSIONS_LENGTH = "$ae_total_app_session_length";
     public static final String APP_UPDATED = "$ae_updated";
     public static final String VERSION_UPDATED = "$ae_updated_version";
     public static final String APP_CRASHED = "$ae_crashed";

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -71,8 +71,10 @@ import java.util.Locale;
                             String sessionLengthString = nf.format((System.currentTimeMillis() - sStartSessionTime) / 1000);
                             JSONObject sessionProperties = new JSONObject();
                             sessionProperties.put(AutomaticEvents.SESSION_LENGTH, sessionLengthString);
-                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS, 1);
-                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS_LENGTH, sessionLength / 1000);
+                            if (mMpInstance.getPeople().isIdentified()) {
+                                mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS, 1);
+                                mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS_LENGTH, sessionLength / 1000);
+                            }
                             mMpInstance.track(AutomaticEvents.SESSION, sessionProperties, true);
                         }
                     } catch (JSONException e) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -71,6 +71,8 @@ import java.util.Locale;
                             String sessionLengthString = nf.format((System.currentTimeMillis() - sStartSessionTime) / 1000);
                             JSONObject sessionProperties = new JSONObject();
                             sessionProperties.put(AutomaticEvents.SESSION_LENGTH, sessionLengthString);
+                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS, 1);
+                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS_LENGTH, sessionLength / 1000);
                             mMpInstance.track(AutomaticEvents.SESSION, sessionProperties, true);
                         }
                     } catch (JSONException e) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -71,10 +71,8 @@ import java.util.Locale;
                             String sessionLengthString = nf.format((System.currentTimeMillis() - sStartSessionTime) / 1000);
                             JSONObject sessionProperties = new JSONObject();
                             sessionProperties.put(AutomaticEvents.SESSION_LENGTH, sessionLengthString);
-                            if (mMpInstance.getPeople().isIdentified()) {
-                                mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS, 1);
-                                mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS_LENGTH, sessionLength / 1000);
-                            }
+                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS, 1);
+                            mMpInstance.getPeople().increment(AutomaticEvents.TOTAL_SESSIONS_LENGTH, sessionLength / 1000);
                             mMpInstance.track(AutomaticEvents.SESSION, sessionProperties, true);
                         }
                     } catch (JSONException e) {


### PR DESCRIPTION
Adding user fields like on [iOS SDK](https://github.com/mixpanel/mixpanel-iphone/blob/5be3385af99f3c4cd4c1971b834e45c41576f48e/Mixpanel/AutomaticEvents.m#L89) 

TOTAL_SESSIONS - Total user sections counter - 
TOTAL_SESSIONS_LENGTH - total user sections length in seconds