### PR TITLE
Add superProperties param in initializer for First App Open

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -140,7 +140,7 @@ public class AutomaticEventsTest extends AndroidTestCase {
             }
         };
 
-        mCleanMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, false) {
+        mCleanMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, false, null) {
 
             @Override
         /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/DecideFunctionalTest.java
@@ -235,7 +235,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
             "}"
         );
 
-        MixpanelAPI api = new MixpanelAPI(getContext(), mMockPreferences, useToken, false) {
+        MixpanelAPI api = new MixpanelAPI(getContext(), mMockPreferences, useToken, false, null) {
             @Override
             AnalyticsMessages getAnalyticsMessages() {
                 return mMockMessages;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -63,6 +63,6 @@ public class MPConfigTest extends AndroidTestCase {
     }
 
     private MixpanelAPI mixpanelApi(final MPConfig config) {
-        return new MixpanelAPI(getContext(), new TestUtils.EmptyPreferences(getContext()), TOKEN, config, false);
+        return new MixpanelAPI(getContext(), new TestUtils.EmptyPreferences(getContext()), TOKEN, config, false, null);
     }
 }

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -864,7 +864,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
         class TestMixpanelAPI extends MixpanelAPI {
             public TestMixpanelAPI(Context c, Future<SharedPreferences> prefs, String token) {
-                super(c, prefs, token, false);
+                super(c, prefs, token, false, null);
             }
 
             @Override
@@ -943,7 +943,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
         class TestMixpanelAPI extends MixpanelAPI {
             public TestMixpanelAPI(Context c, Future<SharedPreferences> prefs, String token) {
-                super(c, prefs, token, false);
+                super(c, prefs, token, false, null);
             }
 
             @Override
@@ -1134,7 +1134,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
     }
 
     public void testPersistence() {
-        MixpanelAPI metricsOne = new MixpanelAPI(getContext(), mMockPreferences, "SAME TOKEN", false);
+        MixpanelAPI metricsOne = new MixpanelAPI(getContext(), mMockPreferences, "SAME TOKEN", false, null);
         metricsOne.reset();
 
         JSONObject props;
@@ -1169,7 +1169,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
         class ListeningAPI extends MixpanelAPI {
             public ListeningAPI(Context c, Future<SharedPreferences> prefs, String token) {
-                super(c, prefs, token, false);
+                super(c, prefs, token, false, null);
             }
 
             @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MockMixpanel.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MockMixpanel.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Future;
 @SuppressWarnings("deprecation")
 class MockMixpanel extends MixpanelAPI {
     public MockMixpanel(Context context, Future<SharedPreferences> prefsFuture, String testToken) {
-        super(context, prefsFuture, testToken, false);
+        super(context, prefsFuture, testToken, false, null);
     }
 
     // Not complete- you may need to override track(), registerSuperProperties, etc

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -107,7 +107,7 @@ public class OptOutTest extends AndroidTestCase {
      */
     public void testOptOutDefaultFlag() throws InterruptedException {
         mCleanUpCalls = new CountDownLatch(2); // optOutTrack calls
-        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, true) {
+        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, true, null) {
             @Override
             PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
                 mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
@@ -136,7 +136,7 @@ public class OptOutTest extends AndroidTestCase {
      */
     public void testHasOptOutTrackingOrNot() throws InterruptedException {
         mCleanUpCalls = new CountDownLatch(4); // optOutTrack calls
-        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, true) {
+        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, true, null) {
             @Override
             PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
                 mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
@@ -168,7 +168,7 @@ public class OptOutTest extends AndroidTestCase {
      */
     public void testPeopleUpdates() throws InterruptedException, JSONException {
         mCleanUpCalls = new CountDownLatch(2);
-        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN,false) {
+        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN,false, null) {
             @Override
             PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
                 mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
@@ -285,7 +285,7 @@ public class OptOutTest extends AndroidTestCase {
      * Track calls before and after opting out
      */
     public void testTrackCalls() throws InterruptedException, JSONException {
-        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN,false) {
+        mMixpanelAPI = new MixpanelAPI(getContext(), mMockReferrerPreferences, TOKEN, false, null) {
             @Override
             PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
                 mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
@@ -24,7 +24,7 @@ public class TestUtils {
 
     public static class CleanMixpanelAPI extends MixpanelAPI {
         public CleanMixpanelAPI(final Context context, final Future<SharedPreferences> referrerPreferences, final String token) {
-            super(context, referrerPreferences, token, false);
+            super(context, referrerPreferences, token, false, null);
         }
 
         @Override


### PR DESCRIPTION
Adding a new optional parameter when using `getInstance`. You can now pass super properties as part of the initialization purposes so you don't need to run `registerSuperProperties` right after and they will be part of the `$ae_first_open` event, for instance.

Fixes https://github.com/mixpanel/mixpanel-android/issues/597