### PR TITLE
Add IP flag to engage call

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -379,7 +379,7 @@ public class MPConfig {
     }
 
     public void setMixpanelPeopleEndpoint() {
-        setPeopleEndpoint(MPConstants.URL.PEOPLE);
+        setPeopleEndpoint(MPConstants.URL.PEOPLE + (getUseIpAddressForGeolocation() ? "1" : "0"));
     }
 
     public void setPeopleEndpoint(String peopleEndpoint) {

--- a/src/main/java/com/mixpanel/android/util/MPConstants.java
+++ b/src/main/java/com/mixpanel/android/util/MPConstants.java
@@ -8,7 +8,7 @@ public class MPConstants {
     public static class URL {
         public static final String DECIDE = "https://decide.mixpanel.com/decide";
         public static final String EVENT = "https://api.mixpanel.com/track?ip=";
-        public static final String PEOPLE = "https://api.mixpanel.com/engage";
+        public static final String PEOPLE = "https://api.mixpanel.com/engage?ip=";
         public static final String GROUPS = "https://api.mixpanel.com/groups";
         public static final String SWITCHBOARD = "wss://switchboard.mixpanel.com/connect/";
     }


### PR DESCRIPTION
I noticed that setting `<meta-data android:name="com.mixpanel.android.MPConfig.UseIpAddressForGeolocation" android:value="false" />` prevents IP geolocation data from being added to events, but it's still added to user profile data.

In the Mixpanel iOS library, setting `useIPAddressForGeoLocation = NO` prevents IP geolocation data from being added to events AND user profile. It seems that the `ip` parameter [is added to all outgoing network calls](https://github.com/mixpanel/mixpanel-iphone/blob/5ddcc639620f296023bed91b11a767ccbda9f3f7/Mixpanel/MPNetwork.m#L112).

This PR adds the IP flag to the `engage` call on Android as well which seems to prevent geolocation data from being added to new user profiles in my tests.