### PR TITLE
rename PushTapTarget enum to PushTapActionType

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
@@ -211,7 +211,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_cta", "http://mixpanel.com");
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("browser"), "http://mixpanel.com");
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("browser"), "http://mixpanel.com");
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
 
         mpPushSpy.createNotification(intent);
@@ -227,7 +227,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp", "some_extra_data");
         intent.putExtra("mp_cta", "http://mixpanel.com");
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("browser"), "http://mixpanel.com");
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("browser"), "http://mixpanel.com");
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -239,7 +239,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("homescreen"));
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("homescreen"));
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -255,7 +255,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_ontap", onTap);
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("homescreen"));
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("homescreen"));
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -268,7 +268,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapTarget.HOMESCREEN.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget());
     }
 
     public void testOnTapBrowser() {
@@ -277,7 +277,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_ontap", onTap);
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("browser"), "http://mixpanel.com");
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("browser"), "http://mixpanel.com");
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -290,7 +290,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapTarget.URL_IN_BROWSER.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER.getTarget());
     }
 
     public void testOnTapDeeplink() {
@@ -299,7 +299,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_ontap", onTap);
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("deeplink"), "my-app://action2");
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("deeplink"), "my-app://action2");
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -312,7 +312,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapTarget.DEEP_LINK.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.DEEP_LINK.getTarget());
     }
 
     public void testOnTapError() {
@@ -321,7 +321,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         intent.putExtra("mp_message", "MESSAGE");
         intent.putExtra("mp_ontap", onTap);
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("badtype"), "my-app://action2");
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("badtype"), "my-app://action2");
         mpPushSpy.createNotification(intent);
 
         verify(mpPushSpy).buildOnTap(onTap);
@@ -332,7 +332,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         final Intent intent = new Intent();
         intent.putExtra("mp_message", "MESSAGE");
 
-        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString("homescreen"));
+        MixpanelNotificationData.PushTapAction fakeOnTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString("homescreen"));
         PushTapActionMatcher matchesFakeOnTap = new PushTapActionMatcher(fakeOnTap);
         mpPushSpy.createNotification(intent);
 
@@ -345,7 +345,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapTarget.HOMESCREEN.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget());
     }
 
     public void testActionButtons() {
@@ -354,14 +354,14 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
             intent.putExtra("mp_message", "MESSAGE");
             intent.putExtra("mp_buttons", "[{\"id\": \"id1\", \"lbl\": \"Button 1\", \"ontap\": {\"type\": \"homescreen\"}}, {\"id\": \"id2\", \"lbl\": \"Button 2\", \"ontap\": {\"type\": \"deeplink\", \"uri\": \"my-app://action2\"}}, {\"id\": \"id3\", \"lbl\": \"Button 3\", {\"type\": \"browser\", \"uri\": \"http://mixpanel.com\"}}]");
 
-            MixpanelNotificationData.PushTapAction fakeOnTap1 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.HOMESCREEN);
-            MixpanelNotificationData.PushTapAction fakeOnTap2 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.DEEP_LINK, "my-app://action2");
-            MixpanelNotificationData.PushTapAction fakeOnTap3 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.URL_IN_BROWSER, "http://mixpanel.com");
+            MixpanelNotificationData.PushTapAction fakeOnTap1 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.HOMESCREEN);
+            MixpanelNotificationData.PushTapAction fakeOnTap2 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.DEEP_LINK, "my-app://action2");
+            MixpanelNotificationData.PushTapAction fakeOnTap3 = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER, "http://mixpanel.com");
 
             List<MixpanelNotificationData.MixpanelNotificationButtonData> fakeButtonList = new ArrayList<>();
-            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 1", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.HOMESCREEN, null), "id1"));
-            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 2", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.DEEP_LINK, "my-app://action2"), "id2"));
-            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 3", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.URL_IN_BROWSER, "http://mixpanel.com"), "id3"));
+            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 1", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.HOMESCREEN, null), "id1"));
+            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 2", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.DEEP_LINK, "my-app://action2"), "id2"));
+            fakeButtonList.add(new MixpanelNotificationData.MixpanelNotificationButtonData("Button 3", new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER, "http://mixpanel.com"), "id3"));
 
             when(mpPushSpy.buildButtons(intent.getStringExtra("mp_buttons"))).thenReturn(fakeButtonList);
             mpPushSpy.createNotification(intent);

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
@@ -268,7 +268,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.toString());
     }
 
     public void testOnTapBrowser() {
@@ -290,7 +290,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER.toString());
     }
 
     public void testOnTapDeeplink() {
@@ -312,7 +312,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.DEEP_LINK.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.DEEP_LINK.toString());
     }
 
     public void testOnTapError() {
@@ -345,7 +345,7 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
 
         Bundle options = mpPushSpy.buildBundle(fakeOnTap);
         assertEquals(options.getString("tapTarget"), "notification");
-        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget());
+        assertEquals(options.getString("actionType"), MixpanelNotificationData.PushTapActionType.HOMESCREEN.toString());
     }
 
     public void testActionButtons() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationData.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationData.java
@@ -251,19 +251,19 @@ import java.util.List;
         DEEP_LINK("deeplink"),
         ERROR("error");
 
-        private String target;
+        private String stringVal;
 
         PushTapActionType(String envTarget) {
-            this.target = envTarget;
+            this.stringVal = envTarget;
         }
 
-        public String getTarget() {
-            return target;
+        public String toString() {
+            return stringVal;
         }
 
         public static PushTapActionType fromString(String target) {
             for (PushTapActionType entry : PushTapActionType.values()) {
-                if (entry.getTarget().equals(target)) {
+                if (entry.toString().equals(target)) {
                     return entry;
                 }
             }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationData.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationData.java
@@ -228,24 +228,24 @@ import java.util.List;
     }
 
     protected static class PushTapAction {
-        public PushTapAction(PushTapTarget type, String aUri) {
+        public PushTapAction(PushTapActionType type, String aUri) {
             mActionType = type;
             mUri = aUri;
         }
 
-        public PushTapAction(PushTapTarget type) {
+        public PushTapAction(PushTapActionType type) {
             this(type, null);
         }
 
-        public PushTapTarget getActionType() { return mActionType; };
+        public PushTapActionType getActionType() { return mActionType; };
 
         public String getUri() { return mUri; };
 
-        private final PushTapTarget mActionType;
+        private final PushTapActionType mActionType;
         private final String mUri;
     }
 
-    protected enum PushTapTarget {
+    protected enum PushTapActionType {
         HOMESCREEN("homescreen"),
         URL_IN_BROWSER("browser"),
         DEEP_LINK("deeplink"),
@@ -253,7 +253,7 @@ import java.util.List;
 
         private String target;
 
-        PushTapTarget(String envTarget) {
+        PushTapActionType(String envTarget) {
             this.target = envTarget;
         }
 
@@ -261,8 +261,8 @@ import java.util.List;
             return target;
         }
 
-        public static PushTapTarget fromString(String target) {
-            for (PushTapTarget entry : PushTapTarget.values()) {
+        public static PushTapActionType fromString(String target) {
+            for (PushTapActionType entry : PushTapActionType.values()) {
                 if (entry.getTarget().equals(target)) {
                     return entry;
                 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import android.webkit.URLUtil;
 
 import com.mixpanel.android.util.MPLog;
-import com.mixpanel.android.mpmetrics.MixpanelNotificationData.PushTapTarget;
+import com.mixpanel.android.mpmetrics.MixpanelNotificationData.PushTapActionType;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -43,12 +43,12 @@ public class MixpanelNotificationRouteActivity extends Activity {
 
     protected Intent handleRouteIntent(Intent routeIntent) {
         CharSequence actionTypeChars = routeIntent.getExtras().getCharSequence("actionType");
-        PushTapTarget target;
+        PushTapActionType target;
         if (null == actionTypeChars) {
             MPLog.d(LOGTAG, "Notification action click logged with no action type");
-            target = PushTapTarget.HOMESCREEN;
+            target = PushTapActionType.HOMESCREEN;
         } else {
-            target = PushTapTarget.fromString(actionTypeChars.toString());
+            target = PushTapActionType.fromString(actionTypeChars.toString());
         }
 
         CharSequence uri = routeIntent.getExtras().getCharSequence("uri");

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -373,14 +373,14 @@ public class MixpanelPushNotification {
                 final JSONObject onTapJSON = new JSONObject(onTapStr);
                 final String typeFromJSON = onTapJSON.getString("type");
 
-                if (!typeFromJSON.equals(MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget())) {
+                if (!typeFromJSON.equals(MixpanelNotificationData.PushTapActionType.HOMESCREEN.toString())) {
                     final String uriFromJSON = onTapJSON.getString("uri");
                     onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString(typeFromJSON), uriFromJSON);
                 } else {
                     onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString(typeFromJSON));
                 }
 
-                if (onTap.getActionType().getTarget().equals(MixpanelNotificationData.PushTapActionType.ERROR.getTarget())) {
+                if (onTap.getActionType().toString().equals(MixpanelNotificationData.PushTapActionType.ERROR.toString())) {
                     hasOnTapError = true;
                     onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.HOMESCREEN);
                 }
@@ -454,7 +454,7 @@ public class MixpanelPushNotification {
     protected Bundle buildBundle(MixpanelNotificationData.PushTapAction onTap) {
         Bundle options = new Bundle();
         options.putCharSequence("tapTarget", TAP_TARGET_NOTIFICATION);
-        options.putCharSequence("actionType", onTap.getActionType().getTarget());
+        options.putCharSequence("actionType", onTap.getActionType().toString());
         options.putCharSequence("uri", onTap.getUri());
         options.putCharSequence("messageId", mData.getMessageId());
         options.putCharSequence("campaignId", mData.getCampaignId());

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -373,16 +373,16 @@ public class MixpanelPushNotification {
                 final JSONObject onTapJSON = new JSONObject(onTapStr);
                 final String typeFromJSON = onTapJSON.getString("type");
 
-                if (!typeFromJSON.equals(MixpanelNotificationData.PushTapTarget.HOMESCREEN.getTarget())) {
+                if (!typeFromJSON.equals(MixpanelNotificationData.PushTapActionType.HOMESCREEN.getTarget())) {
                     final String uriFromJSON = onTapJSON.getString("uri");
-                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString(typeFromJSON), uriFromJSON);
+                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString(typeFromJSON), uriFromJSON);
                 } else {
-                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.fromString(typeFromJSON));
+                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.fromString(typeFromJSON));
                 }
 
-                if (onTap.getActionType().getTarget().equals(MixpanelNotificationData.PushTapTarget.ERROR.getTarget())) {
+                if (onTap.getActionType().getTarget().equals(MixpanelNotificationData.PushTapActionType.ERROR.getTarget())) {
                     hasOnTapError = true;
-                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.HOMESCREEN);
+                    onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.HOMESCREEN);
                 }
             } catch (JSONException e){
                 MPLog.d(LOGTAG, "Exception occurred while parsing ontap");
@@ -397,14 +397,14 @@ public class MixpanelPushNotification {
         MixpanelNotificationData.PushTapAction onTap = null;
 
         if (null != uriString) {
-            onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.URL_IN_BROWSER, uriString);
+            onTap = new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.URL_IN_BROWSER, uriString);
         }
 
         return onTap;
     }
 
     protected MixpanelNotificationData.PushTapAction getDefaultOnTap() {
-        return new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapTarget.HOMESCREEN);
+        return new MixpanelNotificationData.PushTapAction(MixpanelNotificationData.PushTapActionType.HOMESCREEN);
     }
 
     @TargetApi(20)


### PR DESCRIPTION
PushTapTarget is ambiguous and the terminology is also used for what was tapped on the notification so I renamed this to be more semantically useful.