### PR TITLE
add mipmap type to checks for resources

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelNotificationBuilderTest.java
@@ -42,7 +42,6 @@ public class MixpanelNotificationBuilderTest extends AndroidTestCase {
         now = System.currentTimeMillis();
         builderSpy = spy(new Notification.Builder(getContext()));
         mpPushSpy = spy(new MixpanelPushNotification(context, builderSpy, now) {
-            @Override
             protected ResourceIds getResourceIds(Context context) {
                 return getTestResources();
             }

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/ResourceReaderTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/ResourceReaderTest.java
@@ -5,14 +5,14 @@ import android.test.AndroidTestCase;
 
 public class ResourceReaderTest extends AndroidTestCase {
     public void setUp() {
-        mDrawables = new ResourceReader.Drawables(TEST_PACKAGE_NAME, getContext());
+        mImages = new ResourceReader.Images(TEST_PACKAGE_NAME, getContext());
         mIds = new ResourceReader.Ids(TEST_PACKAGE_NAME, getContext());
     }
 
     public void testLocalIdExists() {
-        assertTrue(mDrawables.knownIdName("TEST_DRAW_ZERO"));
-        assertEquals(mDrawables.idFromName("TEST_DRAW_ZERO"), TEST_DRAW_ZERO);
-        assertEquals(mDrawables.nameForId(TEST_DRAW_ZERO), "TEST_DRAW_ZERO");
+        assertTrue(mImages.knownIdName("TEST_DRAW_ZERO"));
+        assertEquals(mImages.idFromName("TEST_DRAW_ZERO"), TEST_DRAW_ZERO);
+        assertEquals(mImages.nameForId(TEST_DRAW_ZERO), "TEST_DRAW_ZERO");
 
         assertTrue(mIds.knownIdName("TEST_ID_ZERO"));
         assertEquals(mIds.idFromName("TEST_ID_ZERO"), TEST_ID_ZERO);
@@ -20,9 +20,9 @@ public class ResourceReaderTest extends AndroidTestCase {
     }
 
     public void testSystemIdExists() {
-        assertTrue(mDrawables.knownIdName("android:ic_lock_idle_alarm"));
-        assertEquals(mDrawables.idFromName("android:ic_lock_idle_alarm"), android.R.drawable.ic_lock_idle_alarm);
-        assertEquals(mDrawables.nameForId(android.R.drawable.ic_lock_idle_alarm), "android:ic_lock_idle_alarm");
+        assertTrue(mImages.knownIdName("android:ic_lock_idle_alarm"));
+        assertEquals(mImages.idFromName("android:ic_lock_idle_alarm"), android.R.drawable.ic_lock_idle_alarm);
+        assertEquals(mImages.nameForId(android.R.drawable.ic_lock_idle_alarm), "android:ic_lock_idle_alarm");
 
         assertTrue(mIds.knownIdName("android:primary"));
         assertEquals(mIds.idFromName("android:primary"), android.R.id.primary);
@@ -30,14 +30,14 @@ public class ResourceReaderTest extends AndroidTestCase {
     }
 
     public void testIdDoesntExist() {
-        assertFalse(mDrawables.knownIdName("NO_SUCH_ID"));
-        assertNull(mDrawables.nameForId(0x7f098888));
+        assertFalse(mImages.knownIdName("NO_SUCH_ID"));
+        assertNull(mImages.nameForId(0x7f098888));
 
         assertFalse(mIds.knownIdName("NO_SUCH_ID"));
         assertNull(mIds.nameForId(0x7f098888));
     }
 
-    private ResourceReader.Drawables mDrawables;
+    private ResourceReader.Images mImages;
     private ResourceReader.Ids mIds;
 
     private static final String TEST_PACKAGE_NAME = "com.mixpanel.android.mpmetrics.test_r_package";

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -206,6 +206,7 @@ public class MixpanelPushNotification {
                 notificationIcon = resource.idFromName(iconName);
             } else if ((resource = getResourceIds(ResourceReader.MIPMAP_TYPE, mContext)).knownIdName(iconName)) {
                 notificationIcon = resource.idFromName(iconName);
+                resource = mDrawableIds;
             }
         }
         if (notificationIcon == MixpanelNotificationData.NOT_SET) {
@@ -213,7 +214,6 @@ public class MixpanelPushNotification {
         }
         mData.setIcon(notificationIcon);
 
-        resource = mDrawableIds;
         int whiteNotificationIcon = MixpanelNotificationData.NOT_SET;
         if (whiteIconName != null) {
             if (mDrawableIds.knownIdName(whiteIconName)) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -687,6 +687,8 @@ public class MixpanelPushNotification {
         }
 
         switch (resourceType) {
+            case ResourceReader.ID_TYPE:
+                return new ResourceReader.Ids(resourcePackage, context);
             case ResourceReader.MIPMAP_TYPE:
                 return new ResourceReader.Mipmap(resourcePackage, context);
             case ResourceReader.DRAWABLE_TYPE:

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -63,7 +63,7 @@ public class MixpanelPushNotification {
     public MixpanelPushNotification(Context context, Notification.Builder builder, long now) {
         this.mContext = context;
         this.mBuilder = builder;
-        this.mDrawableIds = getResourceIds(context);
+        this.mDrawableIds = getResourceIds(ResourceReader.DRAWABLE_TYPE, context);
         this.mNow = now;
         this.ROUTING_REQUEST_CODE = (int) now;
         this.notificationId = (int) now;
@@ -199,9 +199,13 @@ public class MixpanelPushNotification {
         mData.setSticky(sticky);
 
         int notificationIcon = MixpanelNotificationData.NOT_SET;
+
+        ResourceIds resource = mDrawableIds;
         if (iconName != null) {
             if (mDrawableIds.knownIdName(iconName)) {
-                notificationIcon = mDrawableIds.idFromName(iconName);
+                notificationIcon = resource.idFromName(iconName);
+            } else if ((resource = getResourceIds(ResourceReader.MIPMAP_TYPE, mContext)).knownIdName(iconName)) {
+                notificationIcon = resource.idFromName(iconName);
             }
         }
         if (notificationIcon == MixpanelNotificationData.NOT_SET) {
@@ -209,10 +213,13 @@ public class MixpanelPushNotification {
         }
         mData.setIcon(notificationIcon);
 
+        resource = mDrawableIds;
         int whiteNotificationIcon = MixpanelNotificationData.NOT_SET;
         if (whiteIconName != null) {
             if (mDrawableIds.knownIdName(whiteIconName)) {
-                whiteNotificationIcon = mDrawableIds.idFromName(whiteIconName);
+                whiteNotificationIcon = resource.idFromName(whiteIconName);
+            } else if ((resource = getResourceIds(ResourceReader.MIPMAP_TYPE, mContext)).knownIdName(iconName)) {
+                whiteNotificationIcon = resource.idFromName(iconName);
             }
         }
         mData.setWhiteIcon(whiteNotificationIcon);
@@ -672,12 +679,20 @@ public class MixpanelPushNotification {
         }
     }
 
-    /* package */ ResourceIds getResourceIds(Context context) {
+    /* package */ ResourceIds getResourceIds(String resourceType, Context context) {
         final MPConfig config = MPConfig.getInstance(context);
         String resourcePackage = config.getResourcePackageName();
         if (null == resourcePackage) {
             resourcePackage = context.getPackageName();
         }
-        return new ResourceReader.Drawables(resourcePackage, context);
+
+        switch (resourceType) {
+            case ResourceReader.MIPMAP_TYPE:
+                return new ResourceReader.Mipmap(resourcePackage, context);
+            case ResourceReader.DRAWABLE_TYPE:
+            default:
+                return new ResourceReader.Drawables(resourcePackage, context);
+        }
+
     }
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -63,7 +63,7 @@ public class MixpanelPushNotification {
     public MixpanelPushNotification(Context context, Notification.Builder builder, long now) {
         this.mContext = context;
         this.mBuilder = builder;
-        this.mDrawableIds = getResourceIds(ResourceReader.DRAWABLE_TYPE, context);
+        this.mDrawableIds = getResourceIds(ResourceReader.IMAGE_TYPE, context);
         this.mNow = now;
         this.ROUTING_REQUEST_CODE = (int) now;
         this.notificationId = (int) now;
@@ -108,7 +108,6 @@ public class MixpanelPushNotification {
     }
 
     /* package */ void parseIntent(Intent inboundIntent) {
-        List<MixpanelNotificationData.MixpanelNotificationButtonData> buttons = new ArrayList<>();
         final String message = inboundIntent.getStringExtra("mp_message");
         final String iconName = inboundIntent.getStringExtra("mp_icnm");
         final String largeIconName = inboundIntent.getStringExtra("mp_icnm_l");
@@ -204,7 +203,7 @@ public class MixpanelPushNotification {
         if (iconName != null) {
             if (mDrawableIds.knownIdName(iconName)) {
                 notificationIcon = resource.idFromName(iconName);
-            } else if ((resource = getResourceIds(ResourceReader.MIPMAP_TYPE, mContext)).knownIdName(iconName)) {
+            } else if ((resource = getResourceIds(ResourceReader.IMAGE_TYPE, mContext)).knownIdName(iconName)) {
                 notificationIcon = resource.idFromName(iconName);
                 resource = mDrawableIds;
             }
@@ -218,7 +217,7 @@ public class MixpanelPushNotification {
         if (whiteIconName != null) {
             if (mDrawableIds.knownIdName(whiteIconName)) {
                 whiteNotificationIcon = resource.idFromName(whiteIconName);
-            } else if ((resource = getResourceIds(ResourceReader.MIPMAP_TYPE, mContext)).knownIdName(iconName)) {
+            } else if ((resource = getResourceIds(ResourceReader.IMAGE_TYPE, mContext)).knownIdName(iconName)) {
                 whiteNotificationIcon = resource.idFromName(iconName);
             }
         }
@@ -689,11 +688,10 @@ public class MixpanelPushNotification {
         switch (resourceType) {
             case ResourceReader.ID_TYPE:
                 return new ResourceReader.Ids(resourcePackage, context);
-            case ResourceReader.MIPMAP_TYPE:
-                return new ResourceReader.Mipmap(resourcePackage, context);
-            case ResourceReader.DRAWABLE_TYPE:
+            case ResourceReader.IMAGE_TYPE:
             default:
-                return new ResourceReader.Drawables(resourcePackage, context);
+                return new ResourceReader.Images(resourcePackage, context);
+
         }
 
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/ResourceReader.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ResourceReader.java
@@ -56,6 +56,26 @@ public abstract class ResourceReader implements ResourceIds {
         private final String mResourcePackageName;
     }
 
+    public static class Mipmap extends ResourceReader {
+        public Mipmap(String resourcePackageName, Context context) {
+            super(context);
+            mResourcePackageName = resourcePackageName;
+            initialize();
+        }
+
+        @Override
+        protected Class<?> getSystemClass() {
+            return android.R.mipmap.class;
+        }
+
+        @Override
+        protected String getLocalClassName(Context context) {
+            return mResourcePackageName + ".R$mipmap";
+        }
+
+        private final String mResourcePackageName;
+    }
+
     protected ResourceReader(Context context) {
         mContext = context;
         mIdNameToId = new HashMap<String, Integer>();
@@ -151,4 +171,7 @@ public abstract class ResourceReader implements ResourceIds {
 
     @SuppressWarnings("unused")
     private static final String LOGTAG = "MixpanelAPI.RsrcReader";
+
+    public static final String DRAWABLE_TYPE = "Drawables";
+    public static final String MIPMAP_TYPE = "Mipmap";
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/ResourceReader.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ResourceReader.java
@@ -172,6 +172,7 @@ public abstract class ResourceReader implements ResourceIds {
     @SuppressWarnings("unused")
     private static final String LOGTAG = "MixpanelAPI.RsrcReader";
 
+    public static final String ID_TYPE = "Ids";
     public static final String DRAWABLE_TYPE = "Drawables";
     public static final String MIPMAP_TYPE = "Mipmap";
 }


### PR DESCRIPTION
Adds mipmap types to ReasourceReader so that if a check for an icon resource in Drawables fails when building a push notification, Mipmap resources are checked for that resource name before setting the icon to the default.