### PR TITLE
Fix IllegalArgumentException when closing connection

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/InstallReferrerPlay.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/InstallReferrerPlay.java
@@ -148,8 +148,12 @@ import java.util.regex.Pattern;
     }
 
     public void disconnect() {
-        if (mReferrerClient != null) {
-            mReferrerClient.endConnection();
+        if (mReferrerClient != null && mReferrerClient.isReady()) {
+            try {
+                mReferrerClient.endConnection();
+            } catch (Exception e) {
+                MPLog.e(TAG, "Error closing referrer connection", e);
+            }
         }
     }
 


### PR DESCRIPTION
On installreferrer 1.0, `endConnection` will try to unbind a service that might not be registered. Adding `isReady()` to avoid ending the connection if it wasn't successfully connected before. FIxes https://github.com/mixpanel/mixpanel-android/issues/678