### PR TITLE
track using application context

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelPushNotification.java
@@ -624,7 +624,7 @@ public class MixpanelPushNotification {
                     new JSONObject()
             );
 
-            MixpanelAPI instance = MixpanelAPI.getInstanceFromMpPayload(mContext, mpPayloadStr);
+            MixpanelAPI instance = MixpanelAPI.getInstanceFromMpPayload(mContext.getApplicationContext(), mpPayloadStr);
             if (instance != null && instance.isAppInForeground()) {
                 JSONObject additionalProperties = new JSONObject();
                 try {


### PR DESCRIPTION
Use application context instead of activity context so that when checking isAppInForeground we are doing so on the main app context, not the current activity which will always be in the foreground while running this section of code.