### PR TITLE
Messaged received tracking fix

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelActivityLifecycleCallbacks.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 /* package */ class MixpanelActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
     private Handler mHandler = new Handler(Looper.getMainLooper());
     private Runnable check;
-    private boolean mIsForeground = true;
+    private boolean mIsForeground = false;
     private boolean mPaused = true;
     private static Double sStartSessionTime;
     public static final int CHECK_DELAY = 500;


### PR DESCRIPTION
State of MixpanelActivityLifecycleCallbacks does not persist when the app is in killed in Android causing isForeground to be reinitialized to true again when a message is received. Init isForeground to false instead.