### PR TITLE
fix routing activity bug

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
@@ -38,8 +38,8 @@ public class MixpanelNotificationRouteActivity extends Activity {
             NotificationManager notificationManager = (NotificationManager) getApplicationContext().getSystemService(getApplicationContext().NOTIFICATION_SERVICE);
             fcmMessagingService.cancelNotification(extras, notificationManager);
         }
-        startActivity(notificationIntent);
         finish();
+        startActivity(notificationIntent);
     }
 
     protected Intent handleRouteIntent(Intent routeIntent) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelNotificationRouteActivity.java
@@ -39,6 +39,7 @@ public class MixpanelNotificationRouteActivity extends Activity {
             fcmMessagingService.cancelNotification(extras, notificationManager);
         }
         startActivity(notificationIntent);
+        finish();
     }
 
     protected Intent handleRouteIntent(Intent routeIntent) {


### PR DESCRIPTION
context: When a user receives a notification that launches the browser or another app while the main app has no activities running, the routing activity becomes the sole activity in the task causing it to never finish and continue to appear in the recents screen for the app. When the user navigates back to the activity using the recents screen the routing activity executes again and launches the ontap behavior. This will continue to happen until the user manually kills the task or the app is launched.

To fix this I added a call to Activity.finish() so that once executed this activity will finish and not exist in the back stack nor as a task to navigate to in the recents screen irregardless of whether the main activity is running.