### PR TITLE
Change Android mixpanel default properties ($app_release, $app_build_number) from number to string

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -688,8 +688,9 @@ import javax.net.ssl.SSLSocketFactory;
 
                  final Integer applicationVersionCode = mSystemInformation.getAppVersionCode();
                  if (null != applicationVersionCode) {
-                    ret.put("$app_release", applicationVersionCode);
-                    ret.put("$app_build_number", applicationVersionCode);
+                    final String applicationVersion = String.valueOf(applicationVersionCode);
+                    ret.put("$app_release", applicationVersion);
+                    ret.put("$app_build_number", applicationVersion);
                 }
 
                 final Boolean hasNFC = mSystemInformation.hasNFC();


### PR DESCRIPTION
iOS's $app_build_number is string with XX.XX.XX format, and Android sdk sends number.

Although Mixpanel is designed to handle mixed types, unfortunately it's not free. our query engine needs to slow down when it encounters different types. especially for Mixpanel default properties, this impacts most of our clients. this PR matches the types of two default properties with iOS expecting overall performance improvements for properties query.