### PR TITLE
Replace deprecated view drawing cache api

### DIFF
--- a/src/main/java/com/mixpanel/android/util/ActivityImageUtils.java
+++ b/src/main/java/com/mixpanel/android/util/ActivityImageUtils.java
@@ -2,7 +2,9 @@ package com.mixpanel.android.util;
 
 import android.app.Activity;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 
 public class ActivityImageUtils {
@@ -10,14 +12,21 @@ public class ActivityImageUtils {
     public static Bitmap getScaledScreenshot(final Activity activity, int scaleWidth, int scaleHeight, boolean relativeScaleIfTrue) {
         final View someView = activity.findViewById(android.R.id.content);
         final View rootView = someView.getRootView();
-        final boolean originalCacheState = rootView.isDrawingCacheEnabled();
-        rootView.setDrawingCacheEnabled(true);
-        rootView.buildDrawingCache(true);
+
+        final Bitmap original = Bitmap.createBitmap(rootView.getWidth() , rootView.getHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(original);
+
+        Drawable backgroundDrawable = rootView.getBackground();
+        if (backgroundDrawable != null) {
+            backgroundDrawable.draw(canvas);
+        } else {
+            canvas.drawColor(Color.WHITE);
+        }
+        rootView.draw(canvas);
 
         // We could get a null or zero px bitmap if the rootView hasn't been measured
         // appropriately, or we grab it before layout.
         // This is ok, and we should handle it gracefully.
-        final Bitmap original = rootView.getDrawingCache();
         Bitmap scaled = null;
         if (null != original && original.getWidth() > 0 && original.getHeight() > 0) {
             if (relativeScaleIfTrue) {
@@ -31,9 +40,6 @@ public class ActivityImageUtils {
                     MPLog.i(LOGTAG, "Not enough memory to produce scaled image, returning a null screenshot");
                 }
             }
-        }
-        if (!originalCacheState) {
-            rootView.setDrawingCacheEnabled(false);
         }
         return scaled;
     }


### PR DESCRIPTION
Replace deprecated  "buildDrawingCache" API, this will lead to "Software rendering doesn't support hardware bitmaps" crashes.
This is to address https://github.com/mixpanel/mixpanel-android/issues/711
