### PR TITLE
migrate to Airship 12.x for the integration

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/ConnectIntegrations.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/ConnectIntegrations.java
@@ -42,8 +42,8 @@ import java.util.Set;
         try {
             Class urbanAirshipClass = Class.forName(urbanAirshipClassName);
             Object sharedUAirship = urbanAirshipClass.getMethod("shared").invoke(null);
-            Object pushManager = sharedUAirship.getClass().getMethod("getPushManager").invoke(sharedUAirship);
-            String channelID = (String)pushManager.getClass().getMethod("getChannelId").invoke(pushManager);
+            Object channel = sharedUAirship.getClass().getMethod("getChannel").invoke(sharedUAirship);
+            String channelID = (String)channel.getClass().getMethod("getId").invoke(channel);
             if (channelID != null && !channelID.isEmpty()) {
                 mUrbanAirshipRetries = 0;
                 if (mSavedUrbanAirshipChannelID == null || !mSavedUrbanAirshipChannelID.equals(channelID)) {


### PR DESCRIPTION
Fix crash when integrating with urban airship 12.0+ due to the following change: 

`UAirship.shared().getPushManager(). getChannelId() -> UAirship.shared().getChannel().getId())`

For more details:
https://github.com/urbanairship/android-library/blob/main/documentation/migration/migration-guide-11-12.md

