### PR TITLE
Add explicit exported flag to activities

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -65,12 +65,12 @@
             </intent-filter>
         </service>
         -->
-        
-        <!-- This activity will allow your application to make tracking calls to the MixpanelAPI for notification interactions-->
-        <activity android:name="com.mixpanel.android.mpmetrics.MixpanelNotificationRouteActivity">
-        </activity>
 
-        <receiver android:name="com.mixpanel.android.mpmetrics.MixpanelPushNotificationDismissedReceiver">
-        </receiver>
+        <!-- This activity will allow your application to make tracking calls to the MixpanelAPI for notification interactions-->
+        <activity
+            android:name="com.mixpanel.android.mpmetrics.MixpanelNotificationRouteActivity"
+            android:exported="false" />
+
+        <receiver android:name="com.mixpanel.android.mpmetrics.MixpanelPushNotificationDismissedReceiver" />
     </application>
 </manifest>


### PR DESCRIPTION
Hi, we updated our app to target Android 12 and get the following error when running connected tests:

> android:exported needs to be explicitly specified for <activity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.


I looked into merged manifests and found out it was Mixpanel causing this issue so I opened this pull request 🙂 