### PR TITLE
Fix `MPConfig.UseIpAddressForGeolocation` gets ignored 

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -26,18 +26,18 @@ public class MPConfigTest {
         // default Mixpanel endpoint
         assertEquals("https://api.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
         assertEquals("https://api.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
-        assertEquals("https://api.mixpanel.com/groups/", config.getGroupsEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
         assertEquals("https://api.mixpanel.com/decide", config.getDecideEndpoint());
 
         mixpanelAPI.setServerURL("https://api-eu.mixpanel.com");
         assertEquals("https://api-eu.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
         assertEquals("https://api-eu.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
-        assertEquals("https://api-eu.mixpanel.com/groups/", config.getGroupsEndpoint());
+        assertEquals("https://api-eu.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
         assertEquals("https://api-eu.mixpanel.com/decide", config.getDecideEndpoint());
     }
 
     @Test
-    public void testSetUseIpAddressForGeolocation() throws Exception {
+    public void testSetUseIpAddressForGeolocation() {
         final Bundle metaData = new Bundle();
         metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/?ip=1");
         metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/?ip=1");
@@ -48,19 +48,18 @@ public class MPConfigTest {
         mixpanelAPI.setUseIpAddressForGeolocation(false);
         assertEquals("https://api.mixpanel.com/track/?ip=0", config.getEventsEndpoint());
         assertEquals("https://api.mixpanel.com/engage/?ip=0", config.getPeopleEndpoint());
-        assertEquals("https://api.mixpanel.com/groups/", config.getGroupsEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=0", config.getGroupsEndpoint());
         assertEquals("https://api.mixpanel.com/decide", config.getDecideEndpoint());
 
         mixpanelAPI.setUseIpAddressForGeolocation(true);
-
         assertEquals("https://api.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
         assertEquals("https://api.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
-        assertEquals("https://api.mixpanel.com/groups/", config.getGroupsEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
         assertEquals("https://api.mixpanel.com/decide", config.getDecideEndpoint());
     }
 
     @Test
-    public void testSetUseIpAddressForGeolocationOverwrite() throws Exception {
+    public void testSetUseIpAddressForGeolocationOverwrite() {
         final Bundle metaData = new Bundle();
         metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/?ip=1");
         metaData.putString("com.mixpanel.android.MPConfig.PeopleEndpoint", "https://api.mixpanel.com/engage/?ip=1");
@@ -86,6 +85,51 @@ public class MPConfigTest {
         mixpanelAPI2.setUseIpAddressForGeolocation(true);
         assertEquals("https://api.mixpanel.com/track/?ip=1", config2.getEventsEndpoint());
         assertEquals("https://api.mixpanel.com/engage/?ip=1", config2.getPeopleEndpoint());
+    }
+
+    @Test
+    public void testEndPointAndGeoSettingBothReadFromConfigTrue() {
+        final Bundle metaData = new Bundle();
+        metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/");
+        metaData.putString("com.mixpanel.android.MPConfig.PeopleEndpoint", "https://api.mixpanel.com/engage/");
+        metaData.putString("com.mixpanel.android.MPConfig.GroupsEndpoint", "https://api.mixpanel.com/groups/");
+        metaData.putBoolean("com.mixpanel.android.MPConfig.UseIpAddressForGeolocation", true);
+
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        assertEquals("https://api.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
+        assertEquals("https://api.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
+    }
+
+    @Test
+    public void testEndPointAndGeoSettingBothReadFromConfigFalse() {
+        final Bundle metaData = new Bundle();
+        metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/");
+        metaData.putString("com.mixpanel.android.MPConfig.PeopleEndpoint", "https://api.mixpanel.com/engage/");
+        metaData.putString("com.mixpanel.android.MPConfig.GroupsEndpoint", "https://api.mixpanel.com/groups/");
+        metaData.putBoolean("com.mixpanel.android.MPConfig.UseIpAddressForGeolocation", false);
+
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        assertEquals("https://api.mixpanel.com/track/?ip=0", config.getEventsEndpoint());
+        assertEquals("https://api.mixpanel.com/engage/?ip=0", config.getPeopleEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=0", config.getGroupsEndpoint());
+    }
+
+    @Test
+    public void testEndPointAndGeoSettingBothReadFromConfigFalseOverwrite() {
+        final Bundle metaData = new Bundle();
+        metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/?ip=1");
+        metaData.putString("com.mixpanel.android.MPConfig.PeopleEndpoint", "https://api.mixpanel.com/engage/?ip=1");
+        metaData.putString("com.mixpanel.android.MPConfig.GroupsEndpoint", "https://api.mixpanel.com/groups/?ip=1");
+        metaData.putBoolean("com.mixpanel.android.MPConfig.UseIpAddressForGeolocation", false);
+
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        assertEquals("https://api.mixpanel.com/track/?ip=0", config.getEventsEndpoint());
+        assertEquals("https://api.mixpanel.com/engage/?ip=0", config.getPeopleEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=0", config.getGroupsEndpoint());
     }
 
     @Test

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -210,24 +210,25 @@ public class MPConfig {
             }
         }
         mDataExpiration = dataExpirationLong;
+        boolean noUseIpAddressForGeolocationSetting = !metaData.containsKey("com.mixpanel.android.MPConfig.UseIpAddressForGeolocation");
 
         String eventsEndpoint = metaData.getString("com.mixpanel.android.MPConfig.EventsEndpoint");
         if (eventsEndpoint != null) {
-            setEventsEndpoint(eventsEndpoint);
+            setEventsEndpoint(noUseIpAddressForGeolocationSetting ? eventsEndpoint : getEndPointWithIpTrackingParam(eventsEndpoint, getUseIpAddressForGeolocation()));
         } else {
             setEventsEndpointWithBaseURL(MPConstants.URL.MIXPANEL_API);
         }
 
         String peopleEndpoint = metaData.getString("com.mixpanel.android.MPConfig.PeopleEndpoint");
         if (peopleEndpoint != null) {
-            setPeopleEndpoint(peopleEndpoint);
+            setPeopleEndpoint(noUseIpAddressForGeolocationSetting ? peopleEndpoint : getEndPointWithIpTrackingParam(peopleEndpoint, getUseIpAddressForGeolocation()));
         } else {
             setPeopleEndpointWithBaseURL(MPConstants.URL.MIXPANEL_API);
         }
 
         String groupsEndpoint = metaData.getString("com.mixpanel.android.MPConfig.GroupsEndpoint");
         if (groupsEndpoint != null) {
-            setGroupsEndpoint(groupsEndpoint);
+            setGroupsEndpoint(noUseIpAddressForGeolocationSetting ? groupsEndpoint : getEndPointWithIpTrackingParam(groupsEndpoint, getUseIpAddressForGeolocation()));
         } else {
             setGroupsEndpointWithBaseURL(MPConstants.URL.MIXPANEL_API);
         }
@@ -316,7 +317,7 @@ public class MPConfig {
     }
 
     private void setGroupsEndpointWithBaseURL(String baseURL) {
-        setGroupsEndpoint(baseURL + MPConstants.URL.GROUPS);
+        setGroupsEndpoint(getEndPointWithIpTrackingParam(baseURL + MPConstants.URL.GROUPS, getUseIpAddressForGeolocation()));
     }
 
     private void setGroupsEndpoint(String groupsEndpoint) {
@@ -360,6 +361,7 @@ public class MPConfig {
         mUseIpAddressForGeolocation = useIpAddressForGeolocation;
         setEventsEndpoint(getEndPointWithIpTrackingParam(getEventsEndpoint(), useIpAddressForGeolocation));
         setPeopleEndpoint(getEndPointWithIpTrackingParam(getPeopleEndpoint(), useIpAddressForGeolocation));
+        setGroupsEndpoint(getEndPointWithIpTrackingParam(getGroupsEndpoint(), useIpAddressForGeolocation));
     }
 
     public void setEnableLogging(boolean enableLogging) {


### PR DESCRIPTION
addresses #772 