### PR TITLE
Changes method signature for React Native

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -683,7 +683,7 @@ public class MixpanelAPI {
      *
      * @return The device id associated with event tracking
      */
-    protected String getAnonymousId() {
+    public String getAnonymousId() {
         return mPersistentIdentity.getAnonymousId();
     }
 


### PR DESCRIPTION
This is needed to allow RN to access the Device ID