### PR TITLE
Support defining multiple instances by specifying `instanceName` in `getInstance()`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=6.3.0
+VERSION_NAME=6.4.0-SNAPSHOT
 
 POM_PACKAGING=aar
 GROUP=com.mixpanel.android

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -153,12 +152,13 @@ public class AutomaticEventsTest {
         mCleanMixpanelAPI = new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, TOKEN, false, null) {
 
             @Override
-                /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token) {
-                final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + token;
+                /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token, final String instanceName) {
+                String instanceKey = instanceName != null ? instanceName : token;
+                final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
                 final SharedPreferences ret = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
                 ret.edit().clear().commit();
 
-                final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimeEvents_" + token;
+                final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimeEvents_" + instanceKey;
                 final SharedPreferences timeSharedPrefs = context.getSharedPreferences(timeEventsPrefsName, Context.MODE_PRIVATE);
                 timeSharedPrefs.edit().clear().commit();
 
@@ -166,7 +166,7 @@ public class AutomaticEventsTest {
                 final SharedPreferences mpSharedPrefs = context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);
                 mpSharedPrefs.edit().clear().putInt("latest_version_code", -2).commit(); // -1 is the default value
 
-                return super.getPersistentIdentity(context, referrerPreferences, token);
+                return super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
             }
 
             @Override

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -148,6 +148,6 @@ public class MPConfigTest {
     }
 
     private MixpanelAPI mixpanelApi(final MPConfig config) {
-        return new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), new TestUtils.EmptyPreferences(InstrumentationRegistry.getInstrumentation().getContext()), TOKEN, config, false, null);
+        return new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), new TestUtils.EmptyPreferences(InstrumentationRegistry.getInstrumentation().getContext()), TOKEN, config, false, null,null);
     }
 }

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -18,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -119,8 +118,8 @@ public class OptOutTest {
         mCleanUpCalls = new CountDownLatch(2); // optOutTrack calls
         mMixpanelAPI = new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, TOKEN, true, null) {
             @Override
-            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
-                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
+            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token, String instanceName) {
+                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
                 return mPersistentIdentity;
             }
 
@@ -149,8 +148,8 @@ public class OptOutTest {
         mCleanUpCalls = new CountDownLatch(4); // optOutTrack calls
         MixpanelAPI mixpanel = new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, "TOKEN", true, null) {
             @Override
-            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
-                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
+            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token, String instanceName) {
+                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
                 return mPersistentIdentity;
             }
 
@@ -180,8 +179,8 @@ public class OptOutTest {
         mCleanUpCalls = new CountDownLatch(2);
         mMixpanelAPI = new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, TOKEN,false, null) {
             @Override
-            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
-                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
+            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token, String instanceName) {
+                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
                 return mPersistentIdentity;
             }
 
@@ -259,8 +258,8 @@ public class OptOutTest {
     public void testDropEventsAndOptInEvent() throws InterruptedException {
         mMixpanelAPI = new TestUtils.CleanMixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, TOKEN) {
             @Override
-            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
-                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
+            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token, String instanceName) {
+                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
                 return mPersistentIdentity;
             }
 
@@ -297,8 +296,8 @@ public class OptOutTest {
     public void testTrackCalls() throws InterruptedException, JSONException {
         mMixpanelAPI = new MixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockReferrerPreferences, TOKEN, false, null) {
             @Override
-            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token) {
-                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token);
+            PersistentIdentity getPersistentIdentity(Context context, Future<SharedPreferences> referrerPreferences, String token, String instanceName) {
+                mPersistentIdentity = super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
                 return mPersistentIdentity;
             }
 

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
@@ -7,10 +7,8 @@ import android.os.Message;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class TestUtils {
     public static byte[] bytes(String s) {
@@ -26,13 +24,18 @@ public class TestUtils {
             super(context, referrerPreferences, token, false, null);
         }
 
+        public CleanMixpanelAPI(final Context context, final Future<SharedPreferences> referrerPreferences, final String token, final String instanceName) {
+            super(context, referrerPreferences, token, false, null, instanceName);
+        }
+
         @Override
-            /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token) {
-            final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + token;
+            /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token, final String instanceName) {
+            String instanceKey = instanceName != null ? instanceName : token;
+            final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
             final SharedPreferences ret = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
             ret.edit().clear().commit();
 
-            final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimeEvents_" + token;
+            final String timeEventsPrefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI.TimeEvents_" + instanceKey;
             final SharedPreferences timeSharedPrefs = context.getSharedPreferences(timeEventsPrefsName, Context.MODE_PRIVATE);
             timeSharedPrefs.edit().clear().commit();
 
@@ -40,7 +43,7 @@ public class TestUtils {
             final SharedPreferences mpSharedPrefs = context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);
             mpSharedPrefs.edit().clear().putBoolean(token, true).putBoolean("has_launched", true).apply();
 
-            return super.getPersistentIdentity(context, referrerPreferences, token);
+            return super.getPersistentIdentity(context, referrerPreferences, token, instanceName);
         }
 
         @Override


### PR DESCRIPTION
addresses #703. This will add the following APIs to MixpanelAPI:
```
/**
...
 * @param instanceName The name you want to uniquely identify the Mixpanel Instance.
   It is useful when you want more than one Mixpanel instance under the same project token.
...
**/
```
`getInstance(Context context, String token, String instanceName)`
`getInstance(Context context, String token, boolean optOutTrackingDefault, String instanceName)`
`getInstance(Context context, String token, JSONObject superProperties, String instanceName)`
`getInstance(Context context, String token, boolean optOutTrackingDefault, JSONObject superProperties, String instanceName)`

Please note: If you are going to add `instanceName` to `getInstance` on your existing implementation. `getInstance` will start using `instanceName` as the instance identifier rather than `token`, so you might lose some of the stored properties including the distinct Id under the `token`. We'd recommend using it when you need to create more than one instance under the same project token. You won't lose any events and user profile updates.