### PR TITLE
add APIs 'setFlushBatchSize' and 'setMaximumDatabaseLimit'

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -138,11 +138,11 @@ public class HttpTest {
             }
 
             @Override
-            protected boolean belowMemThreshold() {
+            protected boolean aboveMemThreshold() {
                 if (mForceOverMemThreshold) {
-                    return false;
+                    return true;
                 } else {
-                    return super.belowMemThreshold();
+                    return super.aboveMemThreshold();
                 }
             }
         };

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -19,24 +19,6 @@ public class MPConfigTest {
     public static final String DISABLE_VIEW_CRAWLER_METADATA_KEY = "com.mixpanel.android.MPConfig.DisableViewCrawler";
 
     @Test
-    public void testSetServerURL() throws Exception {
-        final Bundle metaData = new Bundle();
-        MPConfig config = mpConfig(metaData);
-        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
-        // default Mixpanel endpoint
-        assertEquals("https://api.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
-        assertEquals("https://api.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
-        assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
-        assertEquals("https://api.mixpanel.com/decide", config.getDecideEndpoint());
-
-        mixpanelAPI.setServerURL("https://api-eu.mixpanel.com");
-        assertEquals("https://api-eu.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
-        assertEquals("https://api-eu.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
-        assertEquals("https://api-eu.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
-        assertEquals("https://api-eu.mixpanel.com/decide", config.getDecideEndpoint());
-    }
-
-    @Test
     public void testSetUseIpAddressForGeolocation() {
         final Bundle metaData = new Bundle();
         metaData.putString("com.mixpanel.android.MPConfig.EventsEndpoint", "https://api.mixpanel.com/track/?ip=1");
@@ -102,6 +84,23 @@ public class MPConfigTest {
         assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
     }
 
+    public void testSetServerURL() throws Exception {
+        final Bundle metaData = new Bundle();
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        // default Mixpanel endpoint
+        assertEquals("https://api.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
+        assertEquals("https://api.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
+        assertEquals("https://api.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
+        assertEquals("https://api.mixpanel.com/decide", config.getDecideEndpoint());
+
+        mixpanelAPI.setServerURL("https://api-eu.mixpanel.com");
+        assertEquals("https://api-eu.mixpanel.com/track/?ip=1", config.getEventsEndpoint());
+        assertEquals("https://api-eu.mixpanel.com/engage/?ip=1", config.getPeopleEndpoint());
+        assertEquals("https://api-eu.mixpanel.com/groups/?ip=1", config.getGroupsEndpoint());
+        assertEquals("https://api-eu.mixpanel.com/decide", config.getDecideEndpoint());
+    }
+
     @Test
     public void testEndPointAndGeoSettingBothReadFromConfigFalse() {
         final Bundle metaData = new Bundle();
@@ -141,6 +140,46 @@ public class MPConfigTest {
         assertTrue(config.DEBUG);
         mixpanelAPI.setEnableLogging(false);
         assertFalse(config.DEBUG);
+    }
+
+
+
+    @Test
+    public void testSetFlushBatchSize() {
+        final Bundle metaData = new Bundle();
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        mixpanelAPI.setFlushBatchSize(10);
+        assertEquals(10, config.getFlushBatchSize());
+        mixpanelAPI.setFlushBatchSize(100);
+        assertEquals(100, config.getFlushBatchSize());
+    }
+
+    @Test
+    public void testSetFlushBatchSize2() {
+        final Bundle metaData = new Bundle();
+        metaData.putInt("com.mixpanel.android.MPConfig.FlushBatchSize", 5);
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        assertEquals(5, mixpanelAPI.getFlushBatchSize());
+    }
+
+    @Test
+    public void testSetMaximumDatabaseLimit() {
+        final Bundle metaData = new Bundle();
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        mixpanelAPI.setMaximumDatabaseLimit(10000);
+        assertEquals(10000, config.getMaximumDatabaseLimit());
+    }
+
+    @Test
+    public void testSetMaximumDatabaseLimit2() {
+        final Bundle metaData = new Bundle();
+        metaData.putInt("com.mixpanel.android.MPConfig.MaximumDatabaseLimit", 100000000);
+        MPConfig config = mpConfig(metaData);
+        final MixpanelAPI mixpanelAPI = mixpanelApi(config);
+        assertEquals(100000000, mixpanelAPI.getMaximumDatabaseLimit());
     }
 
     private MPConfig mpConfig(final Bundle metaData) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -35,6 +35,9 @@ import javax.net.ssl.SSLSocketFactory;
  *     <dt>com.mixpanel.android.MPConfig.FlushInterval</dt>
  *     <dd>An integer number of milliseconds, the maximum time to wait before an upload if the bulk upload limit isn't reached.</dd>
  *
+ *     <dt>com.mixpanel.android.MPConfig.FlushBatchSize</dt>
+ *     <dd>Maximum number of events/updates to send in a single network request</dd>
+ *
  *     <dt>com.mixpanel.android.MPConfig.FlushOnBackground</dt>
  *     <dd>A boolean value. If false, the library will not flush the event and people queues when the app goes into the background. Defaults to true.</dd>
  *
@@ -48,6 +51,9 @@ import javax.net.ssl.SSLSocketFactory;
  *     <dd>An integer number of bytes. Mixpanel attempts to limit the size of its persistent data
  *          queue based on the storage capacity of the device, but will always allow queuing below this limit. Higher values
  *          will take up more storage even when user storage is very full.</dd>
+ *
+ *     <dt>com.mixpanel.android.MPConfig.MaximumDatabaseLimit</dt>
+ *     <dd>An integer number of bytes, the maximum size limit to the Mixpanel database. </dd>
  *
  *     <dt>com.mixpanel.android.MPConfig.ResourcePackageName</dt>
  *     <dd>A string java package name. Defaults to the package name of the Application. Users should set if the package name of their R class is different from the application package name due to application id settings.</dd>
@@ -183,8 +189,10 @@ public class MPConfig {
 
         mBulkUploadLimit = metaData.getInt("com.mixpanel.android.MPConfig.BulkUploadLimit", 40); // 40 records default
         mFlushInterval = metaData.getInt("com.mixpanel.android.MPConfig.FlushInterval", 60 * 1000); // one minute default
+        mFlushBatchSize = metaData.getInt("com.mixpanel.android.MPConfig.FlushBatchSize", 50); // flush 50 events at a time by default
         mFlushOnBackground = metaData.getBoolean("com.mixpanel.android.MPConfig.FlushOnBackground", true);
         mMinimumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MinimumDatabaseLimit", 20 * 1024 * 1024); // 20 Mb
+        mMaximumDatabaseLimit = metaData.getInt("com.mixpanel.android.MPConfig.MaximumDatabaseLimit", Integer.MAX_VALUE); // 2 Gb
         mResourcePackageName = metaData.getString("com.mixpanel.android.MPConfig.ResourcePackageName"); // default is null
         mDisableDecideChecker = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableDecideChecker", false);
         mDisableAppOpenEvent = metaData.getBoolean("com.mixpanel.android.MPConfig.DisableAppOpenEvent", true);
@@ -258,12 +266,28 @@ public class MPConfig {
         return mFlushOnBackground;
     }
 
+    // Maximum number of events/updates to send in a single network request
+    public int getFlushBatchSize() {
+        return mFlushBatchSize;
+    }
+
+
+    public void setFlushBatchSize(int flushBatchSize) {
+        mFlushBatchSize = flushBatchSize;
+    }
+
     // Throw away records that are older than this in milliseconds. Should be below the server side age limit for events.
     public long getDataExpiration() {
         return mDataExpiration;
     }
 
     public int getMinimumDatabaseLimit() { return mMinimumDatabaseLimit; }
+
+    public int getMaximumDatabaseLimit() { return mMaximumDatabaseLimit; }
+
+    public void setMaximumDatabaseLimit(int maximumDatabaseLimit) {
+        mMaximumDatabaseLimit = maximumDatabaseLimit;
+    }
 
     public boolean getDisableAppOpenEvent() {
         return mDisableAppOpenEvent;
@@ -417,8 +441,10 @@ public class MPConfig {
         return "Mixpanel (" + VERSION + ") configured with:\n" +
                 "    BulkUploadLimit " + getBulkUploadLimit() + "\n" +
                 "    FlushInterval " + getFlushInterval() + "\n" +
+                "    FlushInterval " + getFlushBatchSize() + "\n" +
                 "    DataExpiration " + getDataExpiration() + "\n" +
                 "    MinimumDatabaseLimit " + getMinimumDatabaseLimit() + "\n" +
+                "    MaximumDatabaseLimit " + getMaximumDatabaseLimit() + "\n" +
                 "    DisableAppOpenEvent " + getDisableAppOpenEvent() + "\n" +
                 "    EnableDebugLogging " + DEBUG + "\n" +
                 "    EventsEndpoint " + getEventsEndpoint() + "\n" +
@@ -436,6 +462,7 @@ public class MPConfig {
     private final boolean mFlushOnBackground;
     private final long mDataExpiration;
     private final int mMinimumDatabaseLimit;
+    private int mMaximumDatabaseLimit;
     private final boolean mDisableDecideChecker;
     private final boolean mDisableAppOpenEvent;
     private final boolean mDisableExceptionHandler;
@@ -443,6 +470,7 @@ public class MPConfig {
     private String mPeopleEndpoint;
     private String mGroupsEndpoint;
     private String mDecideEndpoint;
+    private int mFlushBatchSize;
 
     private final String mResourcePackageName;
     private final int mMinSessionDuration;

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -584,6 +584,38 @@ public class MixpanelAPI {
     }
 
     /**
+     * Set maximum number of events/updates to send in a single network request
+     *
+     * @param flushBatchSize  int, the number of events to be flushed at a time, defaults to 50
+     */
+    public void setFlushBatchSize(int flushBatchSize) {
+        mConfig.setFlushBatchSize(flushBatchSize);
+    }
+
+    /**
+     * Get maximum number of events/updates to send in a single network request
+     */
+    public int getFlushBatchSize() {
+        return mConfig.getFlushBatchSize();
+    }
+
+    /**
+     * Set an integer number of bytes, the maximum size limit to the Mixpanel database.
+     *
+     * @param maximumDatabaseLimit an integer number of bytes, the maximum size limit to the Mixpanel database.
+     */
+    public void setMaximumDatabaseLimit(int maximumDatabaseLimit) {
+        mConfig.setMaximumDatabaseLimit(maximumDatabaseLimit);
+    }
+
+    /**
+     * Get  the maximum size limit to the Mixpanel database.
+     */
+    public int getMaximumDatabaseLimit() {
+        return mConfig.getMaximumDatabaseLimit();
+    }
+
+    /**
      * Set the base URL used for Mixpanel API requests.
      * Useful if you need to proxy Mixpanel requests. Defaults to https://api.mixpanel.com.
      * To route data to Mixpanel's EU servers, set to https://api-eu.mixpanel.com
@@ -593,6 +625,7 @@ public class MixpanelAPI {
     public void setServerURL(String serverURL) {
         mConfig.setServerURL(serverURL);
     }
+
 
     /**
      * This function creates a distinct_id alias from alias to original. If original is null, then it will create an alias


### PR DESCRIPTION
This PR adds the following new configs for you to optimize the Mixpanel tracking:

```   /**
     * Set maximum number of events/updates to send in a single network request
     *
     * @param flushBatchSize  int, the number of events to be flushed at a time, defaults to 50
     */
    public void setFlushBatchSize(int flushBatchSize);

    /**
     * Set an integer number of bytes, the maximum size limit to the Mixpanel database.
     *
     * @param maximumDatabaseLimit an integer number of bytes, the maximum size limit to the Mixpanel database.
     */
    public void setMaximumDatabaseLimit(int maximumDatabaseLimit);
```

You can also set them in `AndroidManifest.xml`, i.e.
```
        <meta-data android:name="com.mixpanel.android.MPConfig.FlushBatchSize"
            android:value="5" />

        <meta-data android:name="com.mixpanel.android.MPConfig.MaximumDatabaseLimit"
            android:value="100000000" />
```
