### PR TITLE
Never crash when checking isBluetoothEnabled

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -150,7 +150,6 @@ import com.mixpanel.android.util.MPLog;
         } catch (Exception e) {
             // something went wrong, don't crash, we can live without it
         }
-
         return isBluetoothEnabled;
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -147,11 +147,10 @@ import com.mixpanel.android.util.MPLog;
                     isBluetoothEnabled = bluetoothAdapter.isEnabled();
                 }
             }
-        } catch (SecurityException e) {
-            // do nothing since we don't have permissions
-        } catch (NoClassDefFoundError e) {
-            // Some phones doesn't have this class. Just ignore it
+        } catch (Exception e) {
+            // something went wrong, don't crash, we can live without it
         }
+
         return isBluetoothEnabled;
     }
 


### PR DESCRIPTION
Customer was seeing crashes due to unhandled exception when we checked if bluetooth was enabled. This is non-critical, we should never crash. We can live without it.