### PR TITLE
Fix integration event when opted out

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -176,7 +176,7 @@ public class MixpanelAPI {
             track("$app_open", null);
         }
 
-        if (!mPersistentIdentity.isFirstIntegration(mToken)) {
+        if (!mPersistentIdentity.isFirstIntegration(mToken) && !optOutTrackingDefault && !hasOptedOutTracking()) {
             try {
                 sendHttpEvent("Integration", "85053bf24bba75239b16a601d9387e17", token, null, false);
                 mPersistentIdentity.setIsIntegrated(mToken);


### PR DESCRIPTION
Add a check for the integration event to only be sent when the library has not been initialized in the opted out state or the user has already opted out