### PR TITLE
bump target API level to 33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ group = GROUP
 version = VERSION_NAME
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -30,11 +30,10 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 31
+        targetSdkVersion 33
         multiDexEnabled true
         testApplicationId "com.mixpanel.android.mpmetrics"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
         consumerProguardFiles 'proguard.txt'
 
         buildConfigField "String", "MIXPANEL_VERSION", "\"${version}\""
@@ -50,6 +49,8 @@ android {
         testOptions {
             execution 'ANDROIDX_TEST_ORCHESTRATOR'
         }
+
+
     }
     buildTypes {
         debug{
@@ -91,7 +92,6 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:2.25.1"
     androidTestUtil 'androidx.test:orchestrator:1.4.0'
     testImplementation "org.mockito:mockito-core:2.25.1"
-    
 }
 
 apply from: rootProject.file('maven.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=7.3.3
+VERSION_NAME=7.3.4-SNAPSHOT
 
 POM_PACKAGING=aar
 GROUP=com.mixpanel.android


### PR DESCRIPTION
This is to meet Google Play’s [target API level requirements](https://support.google.com/googleplay/android-developer/answer/11926878).

https://developer.android.com/google/play/requirements/target-sdk