### PR TITLE
Passing down the 'MPConfig' instance from the MixpanelAPI instance

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -82,7 +82,7 @@ public class AutomaticEventsTest {
         };
 
         InstrumentationRegistry.getInstrumentation().getContext().deleteDatabase("mixpanel");
-        mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void cleanupEvents(String last_id, Table table, String token) {
                 if (token.equalsIgnoreCase(TOKEN)) {
@@ -102,7 +102,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final AnalyticsMessages automaticAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages automaticAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
 
             @Override
             protected RemoteService getPoster() {
@@ -228,7 +228,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final MPDbAdapter mpSecondDbAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mpSecondDbAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void cleanupEvents(String last_id, Table table, String token) {
                 if (token.equalsIgnoreCase(SECOND_TOKEN)) {
@@ -247,7 +247,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final AnalyticsMessages mpSecondAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages mpSecondAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             protected RemoteService getPoster() {
                 return mpSecondPoster;

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -107,7 +107,7 @@ public class HttpTest {
             }
         };
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), config) {
             @Override
             public void cleanupEvents(String last_id, Table table, String token) {
                 mCleanupCalls.add("called");
@@ -124,7 +124,7 @@ public class HttpTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), config) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
@@ -135,10 +135,6 @@ public class HttpTest {
                 return mockPoster;
             }
 
-            @Override
-            protected MPConfig getConfig(Context context) {
-                return config;
-            }
         };
 
         mMetrics = new TestUtils.CleanMixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockPreferences, "Test Message Queuing") {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -52,7 +52,7 @@ public class MixpanelBasicTest {
     @Before
     public void setUp() throws Exception {
         mMockPreferences = new TestUtils.EmptyPreferences(InstrumentationRegistry.getInstrumentation().getContext());
-        AnalyticsMessages messages = AnalyticsMessages.getInstance(InstrumentationRegistry.getInstrumentation().getContext());
+        AnalyticsMessages messages = AnalyticsMessages.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()));
         messages.hardKill();
         Thread.sleep(2000);
 
@@ -102,7 +102,7 @@ public class MixpanelBasicTest {
         afterMap.put("added", "after");
         JSONObject after = new JSONObject(afterMap);
 
-        MPDbAdapter adapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), "DeleteTestDB");
+        MPDbAdapter adapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), "DeleteTestDB", MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()));
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.EVENTS);
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.PEOPLE);
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.GROUPS);
@@ -142,7 +142,7 @@ public class MixpanelBasicTest {
     public void testLooperDestruction() {
         final BlockingQueue<JSONObject> messages = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter explodingDb = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter explodingDb = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 messages.add(message);
@@ -150,7 +150,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages explodingMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages explodingMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             // This will throw inside of our worker thread.
             @Override
             public MPDbAdapter makeDbAdapter(Context context) {
@@ -188,7 +188,7 @@ public class MixpanelBasicTest {
     public void testEventOperations() throws JSONException {
         final BlockingQueue<JSONObject> messages = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter eventOperationsAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter eventOperationsAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 messages.add(message);
@@ -197,7 +197,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages eventOperationsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages eventOperationsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             // This will throw inside of our worker thread.
             @Override
             public MPDbAdapter makeDbAdapter(Context context) {
@@ -309,7 +309,7 @@ public class MixpanelBasicTest {
     public void testPeopleMessageOperations() throws JSONException {
         final List<AnalyticsMessages.PeopleDescription> messages = new ArrayList<AnalyticsMessages.PeopleDescription>();
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -384,7 +384,7 @@ public class MixpanelBasicTest {
     public void testGroupOperations() throws JSONException {
         final List<AnalyticsMessages.GroupDescription> messages = new ArrayList<AnalyticsMessages.GroupDescription>();
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void groupMessage(GroupDescription heard) {
                 messages.add(heard);
@@ -465,7 +465,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue();
         final BlockingQueue<JSONObject> peopleUpdates = new LinkedBlockingQueue();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -476,7 +476,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -545,7 +545,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue();
         final BlockingQueue<JSONObject> peopleUpdates = new LinkedBlockingQueue();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -556,7 +556,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -684,7 +684,7 @@ public class MixpanelBasicTest {
         final SynchronizedReference<Boolean> isIdentifiedRef = new SynchronizedReference<Boolean>();
         isIdentifiedRef.set(false);
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 try {
@@ -749,16 +749,12 @@ public class MixpanelBasicTest {
             public boolean getDisableAppOpenEvent() { return true; }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), mockConfig) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
             }
 
-            @Override
-            protected MPConfig getConfig(Context context) {
-                return mockConfig;
-            }
 
             @Override
             protected RemoteService getPoster() {
@@ -887,7 +883,7 @@ public class MixpanelBasicTest {
     @Test
     public void testTrackCharge() {
         final List<AnalyticsMessages.PeopleDescription> messages = new ArrayList<>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -942,7 +938,7 @@ public class MixpanelBasicTest {
     public void testTrackWithSavedDistinctId(){
         final String savedDistinctID = "saved_distinct_id";
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                   if (!heard.isAutomatic() && !heard.getEventName().equals("$identify")) {
@@ -1020,7 +1016,7 @@ public class MixpanelBasicTest {
     @Test
     public void testSetAddRemoveGroup(){
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic() &&
@@ -1156,7 +1152,7 @@ public class MixpanelBasicTest {
     public void testIdentifyCall() throws JSONException {
         String newDistinctId = "New distinct ID";
         final List<AnalyticsMessages.EventDescription> messages = new ArrayList<AnalyticsMessages.EventDescription>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1191,7 +1187,7 @@ public class MixpanelBasicTest {
     public void testIdentifyResetCall() throws JSONException {
         String newDistinctId = "New distinct ID";
         final List<AnalyticsMessages.EventDescription> messages = new ArrayList<AnalyticsMessages.EventDescription>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1252,7 +1248,7 @@ public class MixpanelBasicTest {
         // will get their values from the same persistent store.
 
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1359,7 +1355,7 @@ public class MixpanelBasicTest {
             @Override
             public void run() {
 
-                final MPDbAdapter dbMock = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+                final MPDbAdapter dbMock = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
                     @Override
                     public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                         mMessages.add(message);
@@ -1368,7 +1364,7 @@ public class MixpanelBasicTest {
                     }
                 };
 
-                final AnalyticsMessages analyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+                final AnalyticsMessages analyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
                     @Override
                     public MPDbAdapter makeDbAdapter(Context context) {
                         return dbMock;
@@ -1419,7 +1415,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             protected RemoteService getPoster() {
                 return mockPoster;
@@ -1443,7 +1439,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue<JSONObject>();
         final BlockingQueue<JSONObject> identifiedUpdates = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -1455,7 +1451,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
@@ -1500,7 +1496,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue<JSONObject>();
         final BlockingQueue<JSONObject> identifiedUpdates = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -1512,7 +1508,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
@@ -1589,7 +1585,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> storedJsons = new LinkedBlockingQueue<>();
         final BlockingQueue<AnalyticsMessages.EventDescription> eventsMessages = new LinkedBlockingQueue<>();
         final BlockingQueue<AnalyticsMessages.PeopleDescription> peopleMessages = new LinkedBlockingQueue<>();
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
 
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
@@ -1597,7 +1593,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             public void eventsMessage(EventDescription eventDescription) {
                 if (!eventDescription.isAutomatic()) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -81,7 +81,7 @@ public class OptOutTest {
         };
 
         mMockAdapter = getMockDBAdapter();
-        mAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext()) {
+        mAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
             @Override
             protected RemoteService getPoster() {
                 return mockPoster;
@@ -356,7 +356,7 @@ public class OptOutTest {
     }
 
     private MPDbAdapter getMockDBAdapter() {
-        return new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext()) {
+        return new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
 
             @Override
             public void cleanupAllEvents(Table table, String token) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -40,9 +40,9 @@ import javax.net.ssl.SSLSocketFactory;
     /**
      * Do not call directly. You should call AnalyticsMessages.getInstance()
      */
-    /* package */ AnalyticsMessages(final Context context) {
+    /* package */ AnalyticsMessages(final Context context, MPConfig config) {
         mContext = context;
-        mConfig = getConfig(context);
+        mConfig = config;
         mWorker = createWorker();
         getPoster().checkIsMixpanelBlocked();
     }
@@ -57,13 +57,16 @@ import javax.net.ssl.SSLSocketFactory;
      *
      * @param messageContext should be the Main Activity of the application
      *     associated with these messages.
+     *
+     * @param config The MPConfig configuration settings for the AnalyticsMessages instance.
+     *               
      */
-    public static AnalyticsMessages getInstance(final Context messageContext) {
+    public static AnalyticsMessages getInstance(final Context messageContext, MPConfig config) {
         synchronized (sInstances) {
             final Context appContext = messageContext.getApplicationContext();
             AnalyticsMessages ret;
             if (! sInstances.containsKey(appContext)) {
-                ret = new AnalyticsMessages(appContext);
+                ret = new AnalyticsMessages(appContext, config);
                 sInstances.put(appContext, ret);
             } else {
                 ret = sInstances.get(appContext);
@@ -162,11 +165,7 @@ import javax.net.ssl.SSLSocketFactory;
     }
 
     protected MPDbAdapter makeDbAdapter(Context context) {
-        return MPDbAdapter.getInstance(context);
-    }
-
-    protected MPConfig getConfig(Context context) {
-        return MPConfig.getInstance(context);
+        return MPDbAdapter.getInstance(context, mConfig);
     }
 
     protected RemoteService getPoster() {

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
@@ -110,10 +110,10 @@ import com.mixpanel.android.util.MPLog;
     private final MPDatabaseHelper mDb;
 
     private static class MPDatabaseHelper extends SQLiteOpenHelper {
-        MPDatabaseHelper(Context context, String dbName) {
+        MPDatabaseHelper(Context context, String dbName, MPConfig config) {
             super(context, dbName, null, DATABASE_VERSION);
             mDatabaseFile = context.getDatabasePath(dbName);
-            mConfig = MPConfig.getInstance(context);
+            mConfig = config;
             mContext = context;
         }
 
@@ -283,20 +283,20 @@ import com.mixpanel.android.util.MPLog;
         private final Context mContext;
     }
 
-    public MPDbAdapter(Context context) {
-        this(context, DATABASE_NAME);
+    public MPDbAdapter(Context context, MPConfig config) {
+        this(context, DATABASE_NAME, config);
     }
 
-    public MPDbAdapter(Context context, String dbName) {
-        mDb = new MPDatabaseHelper(context, dbName);
+    public MPDbAdapter(Context context, String dbName, MPConfig config) {
+        mDb = new MPDatabaseHelper(context, dbName, config);
     }
 
-    public static MPDbAdapter getInstance(Context context) {
+    public static MPDbAdapter getInstance(Context context, MPConfig config) {
         synchronized (sInstances) {
             final Context appContext = context.getApplicationContext();
             MPDbAdapter ret;
             if (! sInstances.containsKey(appContext)) {
-                ret = new MPDbAdapter(appContext);
+                ret = new MPDbAdapter(appContext, config);
                 sInstances.put(appContext, ret);
             } else {
                 ret = sInstances.get(appContext);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -163,7 +163,7 @@ public class MixpanelAPI {
             registerSuperProperties(superProperties);
         }
 
-        final boolean dbExists = MPDbAdapter.getInstance(mContext).getDatabaseFile().exists();
+        final boolean dbExists = MPDbAdapter.getInstance(mContext, mConfig).getDatabaseFile().exists();
 
         registerMixpanelActivityLifecycleCallbacks();
 
@@ -1729,7 +1729,7 @@ public class MixpanelAPI {
     // non-test client code.
 
     /* package */ AnalyticsMessages getAnalyticsMessages() {
-        return AnalyticsMessages.getInstance(mContext);
+        return AnalyticsMessages.getInstance(mContext, mConfig);
     }
 
 


### PR DESCRIPTION
Fix the issue: MPConfig instances created through MixpanelAPI are not being utilized when making API calls from AnalyticsMessages