### PR TITLE
feat: Enable data separation for each MixPanel API instance

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -82,7 +82,7 @@ public class AutomaticEventsTest {
         };
 
         InstrumentationRegistry.getInstrumentation().getContext().deleteDatabase("mixpanel");
-        mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void cleanupEvents(String last_id, Table table, String token) {
                 if (token.equalsIgnoreCase(TOKEN)) {
@@ -102,7 +102,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final AnalyticsMessages automaticAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages automaticAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
 
             @Override
             protected RemoteService getPoster() {
@@ -228,7 +228,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final MPDbAdapter mpSecondDbAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mpSecondDbAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void cleanupEvents(String last_id, Table table, String token) {
                 if (token.equalsIgnoreCase(SECOND_TOKEN)) {
@@ -247,7 +247,7 @@ public class AutomaticEventsTest {
             }
         };
 
-        final AnalyticsMessages mpSecondAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages mpSecondAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             protected RemoteService getPoster() {
                 return mpSecondPoster;
@@ -281,8 +281,8 @@ public class AutomaticEventsTest {
         };
         assertTrue(mLatch.await(MAX_TIMEOUT_POLL, TimeUnit.MILLISECONDS));
         assertEquals(initialCalls, mTrackedEvents);
-        mLatch = new CountDownLatch(MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()).getBulkUploadLimit() - initialCalls);
-        for (int i = 0; i < MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()).getBulkUploadLimit() - initialCalls; i++) {
+        mLatch = new CountDownLatch(MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null).getBulkUploadLimit() - initialCalls);
+        for (int i = 0; i < MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null).getBulkUploadLimit() - initialCalls; i++) {
             mCleanMixpanelAPI.track("Track event " + i);
         }
 
@@ -291,7 +291,7 @@ public class AutomaticEventsTest {
 
         assertEquals(AutomaticEvents.FIRST_OPEN, mPerformRequestEvents.poll(MAX_TIMEOUT_POLL, TimeUnit.MILLISECONDS));
         assertEquals(AutomaticEvents.APP_UPDATED, mPerformRequestEvents.poll(MAX_TIMEOUT_POLL, TimeUnit.MILLISECONDS));
-        for (int i = 0; i < MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()).getBulkUploadLimit() - initialCalls; i++) {
+        for (int i = 0; i < MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null).getBulkUploadLimit() - initialCalls; i++) {
             assertEquals("Track event " + i, mPerformRequestEvents.poll(MAX_TIMEOUT_POLL, TimeUnit.MILLISECONDS));
         }
 

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -94,7 +94,7 @@ public class HttpTest {
             }
         };
 
-        final MPConfig config = new MPConfig(new Bundle(), InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPConfig config = new MPConfig(new Bundle(), InstrumentationRegistry.getInstrumentation().getContext(), null) {
 
             @Override
             public String getEventsEndpoint() {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MPConfigTest.java
@@ -196,7 +196,7 @@ public class MPConfigTest {
     }
 
     private MPConfig mpConfig(final Bundle metaData) {
-        return new MPConfig(metaData, InstrumentationRegistry.getInstrumentation().getContext());
+        return new MPConfig(metaData, InstrumentationRegistry.getInstrumentation().getContext(), null);
     }
 
     private MixpanelAPI mixpanelApi(final MPConfig config) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -52,7 +52,7 @@ public class MixpanelBasicTest {
     @Before
     public void setUp() throws Exception {
         mMockPreferences = new TestUtils.EmptyPreferences(InstrumentationRegistry.getInstrumentation().getContext());
-        AnalyticsMessages messages = AnalyticsMessages.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()));
+        AnalyticsMessages messages = AnalyticsMessages.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null));
         messages.hardKill();
         Thread.sleep(2000);
 
@@ -102,7 +102,7 @@ public class MixpanelBasicTest {
         afterMap.put("added", "after");
         JSONObject after = new JSONObject(afterMap);
 
-        MPDbAdapter adapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), "DeleteTestDB", MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext()));
+        MPDbAdapter adapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), "DeleteTestDB", MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null));
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.EVENTS);
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.PEOPLE);
         adapter.addJSON(before, "ATOKEN", MPDbAdapter.Table.GROUPS);
@@ -142,7 +142,7 @@ public class MixpanelBasicTest {
     public void testLooperDestruction() {
         final BlockingQueue<JSONObject> messages = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter explodingDb = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter explodingDb = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 messages.add(message);
@@ -150,7 +150,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages explodingMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages explodingMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             // This will throw inside of our worker thread.
             @Override
             public MPDbAdapter makeDbAdapter(Context context) {
@@ -188,7 +188,7 @@ public class MixpanelBasicTest {
     public void testEventOperations() throws JSONException {
         final BlockingQueue<JSONObject> messages = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter eventOperationsAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter eventOperationsAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 messages.add(message);
@@ -197,7 +197,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages eventOperationsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages eventOperationsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             // This will throw inside of our worker thread.
             @Override
             public MPDbAdapter makeDbAdapter(Context context) {
@@ -309,7 +309,7 @@ public class MixpanelBasicTest {
     public void testPeopleMessageOperations() throws JSONException {
         final List<AnalyticsMessages.PeopleDescription> messages = new ArrayList<AnalyticsMessages.PeopleDescription>();
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -384,7 +384,7 @@ public class MixpanelBasicTest {
     public void testGroupOperations() throws JSONException {
         final List<AnalyticsMessages.GroupDescription> messages = new ArrayList<AnalyticsMessages.GroupDescription>();
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void groupMessage(GroupDescription heard) {
                 messages.add(heard);
@@ -465,7 +465,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue();
         final BlockingQueue<JSONObject> peopleUpdates = new LinkedBlockingQueue();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -476,7 +476,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -545,7 +545,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue();
         final BlockingQueue<JSONObject> peopleUpdates = new LinkedBlockingQueue();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -556,7 +556,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void peopleMessage(PeopleDescription heard) {
                 messages.add(heard);
@@ -684,7 +684,7 @@ public class MixpanelBasicTest {
         final SynchronizedReference<Boolean> isIdentifiedRef = new SynchronizedReference<Boolean>();
         isIdentifiedRef.set(false);
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                 try {
@@ -719,7 +719,7 @@ public class MixpanelBasicTest {
         };
 
 
-        final MPConfig mockConfig = new MPConfig(new Bundle(), InstrumentationRegistry.getInstrumentation().getContext()) {
+        final MPConfig mockConfig = new MPConfig(new Bundle(), InstrumentationRegistry.getInstrumentation().getContext(), null) {
             @Override
             public int getFlushInterval() {
                 return -1;
@@ -883,7 +883,7 @@ public class MixpanelBasicTest {
     @Test
     public void testTrackCharge() {
         final List<AnalyticsMessages.PeopleDescription> messages = new ArrayList<>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -938,7 +938,7 @@ public class MixpanelBasicTest {
     public void testTrackWithSavedDistinctId(){
         final String savedDistinctID = "saved_distinct_id";
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                   if (!heard.isAutomatic() && !heard.getEventName().equals("$identify")) {
@@ -1016,7 +1016,7 @@ public class MixpanelBasicTest {
     @Test
     public void testSetAddRemoveGroup(){
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic() &&
@@ -1152,7 +1152,7 @@ public class MixpanelBasicTest {
     public void testIdentifyCall() throws JSONException {
         String newDistinctId = "New distinct ID";
         final List<AnalyticsMessages.EventDescription> messages = new ArrayList<AnalyticsMessages.EventDescription>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1187,7 +1187,7 @@ public class MixpanelBasicTest {
     public void testIdentifyResetCall() throws JSONException {
         String newDistinctId = "New distinct ID";
         final List<AnalyticsMessages.EventDescription> messages = new ArrayList<AnalyticsMessages.EventDescription>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1248,7 +1248,7 @@ public class MixpanelBasicTest {
         // will get their values from the same persistent store.
 
         final List<Object> messages = new ArrayList<Object>();
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription heard) {
                 if (!heard.isAutomatic()) {
@@ -1355,7 +1355,7 @@ public class MixpanelBasicTest {
             @Override
             public void run() {
 
-                final MPDbAdapter dbMock = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+                final MPDbAdapter dbMock = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
                     @Override
                     public int addJSON(JSONObject message, String token, MPDbAdapter.Table table) {
                         mMessages.add(message);
@@ -1364,7 +1364,7 @@ public class MixpanelBasicTest {
                     }
                 };
 
-                final AnalyticsMessages analyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+                final AnalyticsMessages analyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
                     @Override
                     public MPDbAdapter makeDbAdapter(Context context) {
                         return dbMock;
@@ -1415,7 +1415,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             protected RemoteService getPoster() {
                 return mockPoster;
@@ -1439,7 +1439,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue<JSONObject>();
         final BlockingQueue<JSONObject> identifiedUpdates = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -1451,7 +1451,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
@@ -1460,13 +1460,13 @@ public class MixpanelBasicTest {
 
         MixpanelAPI mixpanel1 = new TestUtils.CleanMixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockPreferences, "testAnonymousPeopleUpdates", "instance1") {
             @Override
-            AnalyticsMessages getAnalyticsMessages() {
+            protected AnalyticsMessages getAnalyticsMessages() {
                 return listener;
             }
         };
         MixpanelAPI mixpanel2 = new TestUtils.CleanMixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockPreferences, "testAnonymousPeopleUpdates", "instance2") {
             @Override
-            AnalyticsMessages getAnalyticsMessages() {
+            protected AnalyticsMessages getAnalyticsMessages() {
                 return listener;
             }
         };
@@ -1496,7 +1496,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> anonymousUpdates = new LinkedBlockingQueue<JSONObject>();
         final BlockingQueue<JSONObject> identifiedUpdates = new LinkedBlockingQueue<JSONObject>();
 
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
                 if (table == Table.ANONYMOUS_PEOPLE) {
@@ -1508,7 +1508,7 @@ public class MixpanelBasicTest {
             }
         };
 
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             protected MPDbAdapter makeDbAdapter(Context context) {
                 return mockAdapter;
@@ -1517,7 +1517,7 @@ public class MixpanelBasicTest {
 
         MixpanelAPI mixpanel = new TestUtils.CleanMixpanelAPI(InstrumentationRegistry.getInstrumentation().getContext(), mMockPreferences, "testAnonymousPeopleUpdates") {
             @Override
-            AnalyticsMessages getAnalyticsMessages() {
+            protected AnalyticsMessages getAnalyticsMessages() {
                 return listener;
             }
         };
@@ -1585,7 +1585,7 @@ public class MixpanelBasicTest {
         final BlockingQueue<JSONObject> storedJsons = new LinkedBlockingQueue<>();
         final BlockingQueue<AnalyticsMessages.EventDescription> eventsMessages = new LinkedBlockingQueue<>();
         final BlockingQueue<AnalyticsMessages.PeopleDescription> peopleMessages = new LinkedBlockingQueue<>();
-        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final MPDbAdapter mockAdapter = new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
 
             @Override
             public int addJSON(JSONObject j, String token, Table table) {
@@ -1593,7 +1593,7 @@ public class MixpanelBasicTest {
                 return super.addJSON(j, token, table);
             }
         };
-        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        final AnalyticsMessages listener = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             public void eventsMessage(EventDescription eventDescription) {
                 if (!eventDescription.isAutomatic()) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -81,7 +81,7 @@ public class OptOutTest {
         };
 
         mMockAdapter = getMockDBAdapter();
-        mAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        mAnalyticsMessages = new AnalyticsMessages(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
             @Override
             protected RemoteService getPoster() {
                 return mockPoster;
@@ -356,7 +356,7 @@ public class OptOutTest {
     }
 
     private MPDbAdapter getMockDBAdapter() {
-        return new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext())) {
+        return new MPDbAdapter(InstrumentationRegistry.getInstrumentation().getContext(), MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null)) {
 
             @Override
             public void cleanupAllEvents(Table table, String token) {

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -43,6 +43,7 @@ import javax.net.ssl.SSLSocketFactory;
     /* package */ AnalyticsMessages(final Context context, MPConfig config) {
         mContext = context;
         mConfig = config;
+        mInstanceName = config.getInstanceName();
         mWorker = createWorker();
         getPoster().checkIsMixpanelBlocked();
     }
@@ -65,11 +66,12 @@ import javax.net.ssl.SSLSocketFactory;
         synchronized (sInstances) {
             final Context appContext = messageContext.getApplicationContext();
             AnalyticsMessages ret;
-            if (! sInstances.containsKey(appContext)) {
+            String instanceName = config.getInstanceName();
+            if (!sInstances.containsKey(instanceName)) {
                 ret = new AnalyticsMessages(appContext, config);
-                sInstances.put(appContext, ret);
+                sInstances.put(instanceName, ret);
             } else {
-                ret = sInstances.get(appContext);
+                ret = sInstances.get(instanceName);
             }
             return ret;
         }
@@ -686,6 +688,7 @@ import javax.net.ssl.SSLSocketFactory;
 
     // Used across thread boundaries
     private final Worker mWorker;
+    private final String mInstanceName;
     protected final Context mContext;
     protected final MPConfig mConfig;
 
@@ -703,6 +706,6 @@ import javax.net.ssl.SSLSocketFactory;
 
     private static final String LOGTAG = "MixpanelAPI.Messages";
 
-    private static final Map<Context, AnalyticsMessages> sInstances = new HashMap<Context, AnalyticsMessages>();
+    private static final Map<String, AnalyticsMessages> sInstances = new HashMap<>();
 
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPDbAdapter.java
@@ -5,6 +5,7 @@ import java.io.FilenameFilter;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -28,7 +29,7 @@ import com.mixpanel.android.util.MPLog;
  */
 /* package */ class MPDbAdapter {
     private static final String LOGTAG = "MixpanelAPI.Database";
-    private static final Map<Context, MPDbAdapter> sInstances = new HashMap<>();
+    private static final Map<String, MPDbAdapter> sInstances = new HashMap<>();
 
     public enum Table {
         EVENTS ("events"),
@@ -284,7 +285,11 @@ import com.mixpanel.android.util.MPLog;
     }
 
     public MPDbAdapter(Context context, MPConfig config) {
-        this(context, DATABASE_NAME, config);
+        this(context, getDbName(config.getInstanceName()), config);
+    }
+
+    private static String getDbName(String instanceName) {
+        return (instanceName == null || instanceName.trim().isEmpty()) ? DATABASE_NAME : (DATABASE_NAME + "_" + instanceName);
     }
 
     public MPDbAdapter(Context context, String dbName, MPConfig config) {
@@ -295,11 +300,12 @@ import com.mixpanel.android.util.MPLog;
         synchronized (sInstances) {
             final Context appContext = context.getApplicationContext();
             MPDbAdapter ret;
-            if (! sInstances.containsKey(appContext)) {
+            String instanceName = config.getInstanceName();
+            if (!sInstances.containsKey(instanceName)) {
                 ret = new MPDbAdapter(appContext, config);
-                sInstances.put(appContext, ret);
+                sInstances.put(instanceName, ret);
             } else {
-                ret = sInstances.get(appContext);
+                ret = sInstances.get(instanceName);
             }
             return ret;
         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -110,7 +110,7 @@ public class MixpanelAPI {
      * Use MixpanelAPI.getInstance to get an instance.
      */
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token, boolean optOutTrackingDefault, JSONObject superProperties, boolean trackAutomaticEvents) {
-        this(context, referrerPreferences, token, MPConfig.getInstance(context), optOutTrackingDefault, superProperties, null, trackAutomaticEvents);
+        this(context, referrerPreferences, token, MPConfig.getInstance(context, null), optOutTrackingDefault, superProperties, null, trackAutomaticEvents);
     }
 
     /**
@@ -118,7 +118,7 @@ public class MixpanelAPI {
      * Use MixpanelAPI.getInstance to get an instance.
      */
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token, boolean optOutTrackingDefault, JSONObject superProperties, String instanceName, boolean trackAutomaticEvents) {
-        this(context, referrerPreferences, token, MPConfig.getInstance(context), optOutTrackingDefault, superProperties, instanceName, trackAutomaticEvents);
+        this(context, referrerPreferences, token, MPConfig.getInstance(context, instanceName), optOutTrackingDefault, superProperties, instanceName, trackAutomaticEvents);
     }
 
     /**
@@ -128,6 +128,7 @@ public class MixpanelAPI {
     MixpanelAPI(Context context, Future<SharedPreferences> referrerPreferences, String token, MPConfig config, boolean optOutTrackingDefault, JSONObject superProperties, String instanceName, boolean trackAutomaticEvents) {
         mContext = context;
         mToken = token;
+        mInstanceName = instanceName;
         mPeople = new PeopleImpl();
         mGroups = new HashMap<String, GroupImpl>();
         mConfig = config;
@@ -2343,6 +2344,7 @@ public class MixpanelAPI {
     private final MPConfig mConfig;
     private final Boolean mTrackAutomaticEvents;
     private final String mToken;
+    private final String mInstanceName;
     private final PeopleImpl mPeople;
     private final Map<String, GroupImpl> mGroups;
     private final PersistentIdentity mPersistentIdentity;


### PR DESCRIPTION
## Introducing Database Separation for Streamlined Event Routing

This pull request addresses the challenge of event data being directed to both Mixpanel and the proxy server due to a single database setup. 

**Problem:**

Currently, all events are stored in a centralized database, regardless of their intended destination (Mixpanel or proxy server). This makes it impossible to control which events flow to each server.

**Solution:**

This pull request implements separate databases for each server, named according to their unique `instanceName`. This ensures events are routed to the appropriate server based on their origin.

**Implementation:**

* The creation process for databases and `AnalyticsMessage` objects has been modified to utilize the `instanceName` instead of a context-based key.
* This change guarantees the creation of distinct databases for each server, enabling proper event segregation.

**Benefits:**

* **Improved Data Control:** This solution allows for precise control over event routing, eliminating the unintended duplication of data across servers.
* **Enhanced Efficiency:** Separating data streams can potentially enhance performance and resource utilization for both Mixpanel and the proxy server.