### PR TITLE
feat: add headers support for mixpanel proxy api calls

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -12,7 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -63,7 +63,7 @@ public class AutomaticEventsTest {
     private void setUpInstance(boolean trackAutomaticEvents) {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
 
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
@@ -212,7 +212,7 @@ public class AutomaticEventsTest {
 
         final HttpService mpSecondPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
                 try {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -63,7 +63,7 @@ public class AutomaticEventsTest {
     private void setUpInstance(boolean trackAutomaticEvents) {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) {
 
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
@@ -212,7 +212,7 @@ public class AutomaticEventsTest {
 
         final HttpService mpSecondPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
                 try {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
+import com.mixpanel.android.util.MixpanelServerCallback;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -62,7 +63,7 @@ public class AutomaticEventsTest {
     private void setUpInstance(boolean trackAutomaticEvents) {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
 
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
@@ -211,7 +212,7 @@ public class AutomaticEventsTest {
 
         final HttpService mpSecondPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
                 try {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -9,6 +9,7 @@ import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
+import com.mixpanel.android.util.MixpanelServerCallback;
 import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 
@@ -61,7 +62,7 @@ public class HttpTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory)
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory)
                     throws ServiceUnavailableException, IOException {
                 try {
                     if (mFlushResults.isEmpty()) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -61,7 +61,7 @@ public class HttpTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory)
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory)
                     throws ServiceUnavailableException, IOException {
                 try {
                     if (mFlushResults.isEmpty()) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -5,11 +5,10 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.RemoteService;
 import com.mixpanel.android.util.HttpService;
 
@@ -62,7 +61,7 @@ public class HttpTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory)
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory)
                     throws ServiceUnavailableException, IOException {
                 try {
                     if (mFlushResults.isEmpty()) {

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -703,7 +703,7 @@ public class MixpanelBasicTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final boolean isIdentified = isIdentifiedRef.get();
                 assertTrue(params.containsKey("data"));
                 final String decoded = Base64Coder.decodeString(params.get("data").toString());
@@ -1398,7 +1398,7 @@ public class MixpanelBasicTest {
     public void testAlias() {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 try {
                     assertTrue(params.containsKey("data"));
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.mixpanel.android.BuildConfig;
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
+import com.mixpanel.android.util.MixpanelServerCallback;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -702,7 +703,7 @@ public class MixpanelBasicTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final boolean isIdentified = isIdentifiedRef.get();
                 assertTrue(params.containsKey("data"));
                 final String decoded = Base64Coder.decodeString(params.get("data").toString());
@@ -1397,7 +1398,7 @@ public class MixpanelBasicTest {
     public void testAlias() {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 try {
                     assertTrue(params.containsKey("data"));
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -12,7 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.mixpanel.android.BuildConfig;
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -703,7 +703,7 @@ public class MixpanelBasicTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 final boolean isIdentified = isIdentifiedRef.get();
                 assertTrue(params.containsKey("data"));
                 final String decoded = Base64Coder.decodeString(params.get("data").toString());
@@ -1398,7 +1398,7 @@ public class MixpanelBasicTest {
     public void testAlias() {
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 try {
                     assertTrue(params.containsKey("data"));
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -8,7 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -58,7 +58,7 @@ public class OptOutTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 if (params != null) {
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                     assertTrue(params.containsKey("data"));

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -58,7 +58,7 @@ public class OptOutTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 if (params != null) {
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                     assertTrue(params.containsKey("data"));

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.mixpanel.android.util.Base64Coder;
 import com.mixpanel.android.util.HttpService;
+import com.mixpanel.android.util.MixpanelServerCallback;
 import com.mixpanel.android.util.RemoteService;
 
 import org.json.JSONArray;
@@ -57,7 +58,7 @@ public class OptOutTest {
 
         final RemoteService mockPoster = new HttpService() {
             @Override
-            public byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory) {
+            public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) {
                 if (params != null) {
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                     assertTrue(params.containsKey("data"));

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -514,7 +514,7 @@ import javax.net.ssl.SSLSocketFactory;
                     byte[] response;
                     try {
                         final SSLSocketFactory socketFactory = mConfig.getSSLSocketFactory();
-                        response = poster.performRequest(url, mConfig.getMixpanelServerCallback(), params, socketFactory);
+                        response = poster.performRequest(url, mConfig.getProxyServerInteractor(), params, socketFactory);
                         if (null == response) {
                             deleteEvents = false;
                             logAboutMessageToMixpanel("Response was null, unexpected failure posting to " + url + ".");

--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -514,7 +514,7 @@ import javax.net.ssl.SSLSocketFactory;
                     byte[] response;
                     try {
                         final SSLSocketFactory socketFactory = mConfig.getSSLSocketFactory();
-                        response = poster.performRequest(url, params, socketFactory);
+                        response = poster.performRequest(url, mConfig.getMixpanelServerCallback(), params, socketFactory);
                         if (null == response) {
                             deleteEvents = false;
                             logAboutMessageToMixpanel("Response was null, unexpected failure posting to " + url + ".");

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -10,7 +10,7 @@ import androidx.annotation.Nullable;
 import com.mixpanel.android.BuildConfig;
 import com.mixpanel.android.util.MPConstants;
 import com.mixpanel.android.util.MPLog;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.OfflineMode;
 
 import java.security.GeneralSecurityException;
@@ -304,9 +304,9 @@ public class MPConfig {
 
     public boolean getTrackAutomaticEvents() { return mTrackAutomaticEvents; }
 
-    public void setServerURL(String serverURL, MixpanelServerCallback callback) {
+    public void setServerURL(String serverURL, ProxyServerInteractor callback) {
         setServerURL(serverURL);
-        setMixpanelServerCallback(callback);
+        setProxyServerInteractor(callback);
     }
 
     // In parity with iOS SDK
@@ -419,11 +419,11 @@ public class MPConfig {
 
     ///////////////////////////////////////////////
 
-    public MixpanelServerCallback getMixpanelServerCallback() {
+    public ProxyServerInteractor getMixpanelServerCallback() {
         return this.serverCallbacks;
     }
 
-    public void setMixpanelServerCallback(MixpanelServerCallback callback) {
+    public void setProxyServerInteractor(ProxyServerInteractor callback) {
         this.serverCallbacks = callback;
     }
 
@@ -486,6 +486,6 @@ public class MPConfig {
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;
     private OfflineMode mOfflineMode;
-    private MixpanelServerCallback serverCallbacks = null;
+    private ProxyServerInteractor serverCallbacks = null;
     private static final String LOGTAG = "MixpanelAPI.Conf";
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import com.mixpanel.android.BuildConfig;
 import com.mixpanel.android.util.MPConstants;
 import com.mixpanel.android.util.MPLog;
+import com.mixpanel.android.util.MixpanelServerCallback;
 import com.mixpanel.android.util.OfflineMode;
 
 import java.security.GeneralSecurityException;
@@ -303,6 +304,11 @@ public class MPConfig {
 
     public boolean getTrackAutomaticEvents() { return mTrackAutomaticEvents; }
 
+    public void setServerURL(String serverURL, MixpanelServerCallback callback) {
+        setServerURL(serverURL);
+        setMixpanelServerCallback(callback);
+    }
+
     // In parity with iOS SDK
     public void setServerURL(String serverURL) {
         setEventsEndpointWithBaseURL(serverURL);
@@ -413,6 +419,14 @@ public class MPConfig {
 
     ///////////////////////////////////////////////
 
+    public MixpanelServerCallback getMixpanelServerCallback() {
+        return this.serverCallbacks;
+    }
+
+    public void setMixpanelServerCallback(MixpanelServerCallback callback) {
+        this.serverCallbacks = callback;
+    }
+
     // Package access for testing only- do not call directly in library code
     /* package */ static MPConfig readConfig(Context appContext, String instanceName) {
         final String packageName = appContext.getPackageName();
@@ -472,5 +486,6 @@ public class MPConfig {
     // Mutable, with synchronized accessor and mutator
     private SSLSocketFactory mSSLSocketFactory;
     private OfflineMode mOfflineMode;
+    private MixpanelServerCallback serverCallbacks = null;
     private static final String LOGTAG = "MixpanelAPI.Conf";
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -304,9 +304,9 @@ public class MPConfig {
 
     public boolean getTrackAutomaticEvents() { return mTrackAutomaticEvents; }
 
-    public void setServerURL(String serverURL, ProxyServerInteractor callback) {
+    public void setServerURL(String serverURL, ProxyServerInteractor interactor) {
         setServerURL(serverURL);
-        setProxyServerInteractor(callback);
+        setProxyServerInteractor(interactor);
     }
 
     // In parity with iOS SDK
@@ -423,8 +423,8 @@ public class MPConfig {
         return this.serverCallbacks;
     }
 
-    public void setProxyServerInteractor(ProxyServerInteractor callback) {
-        this.serverCallbacks = callback;
+    public void setProxyServerInteractor(ProxyServerInteractor interactor) {
+        this.serverCallbacks = interactor;
     }
 
     // Package access for testing only- do not call directly in library code

--- a/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -419,7 +419,7 @@ public class MPConfig {
 
     ///////////////////////////////////////////////
 
-    public ProxyServerInteractor getMixpanelServerCallback() {
+    public ProxyServerInteractor getProxyServerInteractor() {
         return this.serverCallbacks;
     }
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.os.Bundle;
 
 import com.mixpanel.android.util.MPLog;
+import com.mixpanel.android.util.MixpanelServerCallback;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -580,6 +581,17 @@ public class MixpanelAPI {
         mConfig.setServerURL(serverURL);
     }
 
+    /**
+     * Set the base URL used for Mixpanel API requests.
+     * Useful if you need to proxy Mixpanel requests. Defaults to https://api.mixpanel.com.
+     * To route data to Mixpanel's EU servers, set to https://api-eu.mixpanel.com
+     *
+     * @param serverURL the base URL used for Mixpanel API requests
+     * @param callback the callback for mixpanel proxy server api headers and status
+     */
+    public void setServerURL(String serverURL, MixpanelServerCallback callback) {
+        mConfig.setServerURL(serverURL, callback);
+    }
 
     public Boolean getTrackAutomaticEvents() { return mTrackAutomaticEvents; }
     /**

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -14,7 +14,7 @@ import android.os.Build;
 import android.os.Bundle;
 
 import com.mixpanel.android.util.MPLog;
-import com.mixpanel.android.util.MixpanelServerCallback;
+import com.mixpanel.android.util.ProxyServerInteractor;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -589,7 +589,7 @@ public class MixpanelAPI {
      * @param serverURL the base URL used for Mixpanel API requests
      * @param callback the callback for mixpanel proxy server api headers and status
      */
-    public void setServerURL(String serverURL, MixpanelServerCallback callback) {
+    public void setServerURL(String serverURL, ProxyServerInteractor callback) {
         mConfig.setServerURL(serverURL, callback);
     }
 

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -90,7 +90,7 @@ public class HttpService implements RemoteService {
     }
 
     @Override
-    public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) throws ServiceUnavailableException, IOException {
+    public byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory) throws ServiceUnavailableException, IOException {
         MPLog.v(LOGTAG, "Attempting request to " + endpointUrl);
 
         byte[] response = null;
@@ -114,8 +114,8 @@ public class HttpService implements RemoteService {
                     ((HttpsURLConnection) connection).setSSLSocketFactory(socketFactory);
                 }
 
-                if (callback != null && isProxyRequest(endpointUrl)) {
-                    Map<String,String> headers = callback.getProxyRequestHeaders();
+                if (interactor != null && isProxyRequest(endpointUrl)) {
+                    Map<String,String> headers = interactor.getProxyRequestHeaders();
                     if (headers != null) {
                         for (Map.Entry<String, String> entry : headers.entrySet()) {
                             connection.setRequestProperty(entry.getKey(), entry.getValue());
@@ -144,8 +144,8 @@ public class HttpService implements RemoteService {
                     out.close();
                     out = null;
                 }
-                if (callback != null && isProxyRequest(endpointUrl)) {
-                    callback.onProxyResponse(endpointUrl, connection.getResponseCode());
+                if (interactor != null && isProxyRequest(endpointUrl)) {
+                    interactor.onProxyResponse(endpointUrl, connection.getResponseCode());
                 }
                 in = connection.getInputStream();
                 response = slurp(in);

--- a/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -90,7 +90,7 @@ public class HttpService implements RemoteService {
     }
 
     @Override
-    public byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory) throws ServiceUnavailableException, IOException {
+    public byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory) throws ServiceUnavailableException, IOException {
         MPLog.v(LOGTAG, "Attempting request to " + endpointUrl);
 
         byte[] response = null;
@@ -114,8 +114,8 @@ public class HttpService implements RemoteService {
                     ((HttpsURLConnection) connection).setSSLSocketFactory(socketFactory);
                 }
 
-                if (shouldProcessMixpanelCallback(endpointUrl) && callback != null) {
-                    Map<String,String> headers = callback.getHeaders();
+                if (callback != null && isProxyRequest(endpointUrl)) {
+                    Map<String,String> headers = callback.getProxyRequestHeaders();
                     if (headers != null) {
                         for (Map.Entry<String, String> entry : headers.entrySet()) {
                             connection.setRequestProperty(entry.getKey(), entry.getValue());
@@ -144,8 +144,8 @@ public class HttpService implements RemoteService {
                     out.close();
                     out = null;
                 }
-                if (shouldProcessMixpanelCallback(endpointUrl) && callback != null) {
-                    callback.onResponse(endpointUrl, connection.getResponseCode());
+                if (callback != null && isProxyRequest(endpointUrl)) {
+                    callback.onProxyResponse(endpointUrl, connection.getResponseCode());
                 }
                 in = connection.getInputStream();
                 response = slurp(in);
@@ -179,7 +179,7 @@ public class HttpService implements RemoteService {
         return response;
     }
 
-    private static boolean shouldProcessMixpanelCallback(String endpointUrl) {
+    private static boolean isProxyRequest(String endpointUrl) {
         return !endpointUrl.toLowerCase().contains(MIXPANEL_API.toLowerCase());
     }
 

--- a/src/main/java/com/mixpanel/android/util/MixpanelServerCallback.java
+++ b/src/main/java/com/mixpanel/android/util/MixpanelServerCallback.java
@@ -1,0 +1,9 @@
+package com.mixpanel.android.util;
+
+import java.util.Map;
+
+public interface MixpanelServerCallback {
+    Map<String, String> getHeaders();
+
+    void onResponse(String apiPath, int responseCode);
+}

--- a/src/main/java/com/mixpanel/android/util/MixpanelServerCallback.java
+++ b/src/main/java/com/mixpanel/android/util/MixpanelServerCallback.java
@@ -1,9 +1,0 @@
-package com.mixpanel.android.util;
-
-import java.util.Map;
-
-public interface MixpanelServerCallback {
-    Map<String, String> getHeaders();
-
-    void onResponse(String apiPath, int responseCode);
-}

--- a/src/main/java/com/mixpanel/android/util/ProxyServerInteractor.java
+++ b/src/main/java/com/mixpanel/android/util/ProxyServerInteractor.java
@@ -1,0 +1,9 @@
+package com.mixpanel.android.util;
+
+import java.util.Map;
+
+public interface ProxyServerInteractor {
+    Map<String, String> getProxyRequestHeaders();
+
+    void onProxyResponse(String apiPath, int responseCode);
+}

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -14,7 +14,7 @@ public interface RemoteService {
 
     void checkIsMixpanelBlocked();
 
-    byte[] performRequest(String endpointUrl, Map<String, Object> params, SSLSocketFactory socketFactory)
+    byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory)
             throws ServiceUnavailableException, IOException;
 
     class ServiceUnavailableException extends Exception {

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -14,7 +14,7 @@ public interface RemoteService {
 
     void checkIsMixpanelBlocked();
 
-    byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory)
+    byte[] performRequest(String endpointUrl, ProxyServerInteractor interactor, Map<String, Object> params, SSLSocketFactory socketFactory)
             throws ServiceUnavailableException, IOException;
 
     class ServiceUnavailableException extends Exception {

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -14,7 +14,7 @@ public interface RemoteService {
 
     void checkIsMixpanelBlocked();
 
-    byte[] performRequest(String endpointUrl, MixpanelServerCallback callback, Map<String, Object> params, SSLSocketFactory socketFactory)
+    byte[] performRequest(String endpointUrl, ProxyServerInteractor callback, Map<String, Object> params, SSLSocketFactory socketFactory)
             throws ServiceUnavailableException, IOException;
 
     class ServiceUnavailableException extends Exception {


### PR DESCRIPTION
### Introducing Header Support for Mixpanel Proxy Servers

This pull request introduces a feature enabling proxy servers to request custom headers from the application.

### Problem:

Currently, when the proxy server URL is set, it makes API calls in a standard manner. However, if the application wishes to include certain headers, such as authentication tokens or device IDs, this isn't possible.

### Solution:

This pull request implements a callback mechanism. Before making an API call, the system requests headers and returns the API endpoint and status code. This information can be utilized by the application for tracking or other purposes.

### Implementation:

This implementation introduces a new property in the config class called "MixpanelServerCallback". It contains a method named "getHeaders()" which requests any headers to be passed just before the proxy server API call. Once the API call is complete, it returns the API endpoint and status code via "onResponse()".

### Benefits:

Enhanced Proxy API Control:
This solution grants the proxy API full control during Mixpanel proxy API calls.