### PR TITLE
Only register Broadcast receiver on API Level 33+ and non-Instant Apps

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -14,7 +14,6 @@ import android.os.Build;
 import android.os.Bundle;
 import androidx.core.content.ContextCompat;
 
-import com.mixpanel.android.util.MPConstants.SessionReplay;
 import com.mixpanel.android.util.MPLog;
 import com.mixpanel.android.util.ProxyServerInteractor;
 

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -195,13 +195,17 @@ public class MixpanelAPI {
             mMessages.removeResidualImageFiles(new File(mContext.getApplicationInfo().dataDir));
         }
 
-        BroadcastReceiver sessionReplayReceiver = new SessionReplayBroadcastReceiver(this);
-        ContextCompat.registerReceiver(
-                mContext.getApplicationContext(),
-                sessionReplayReceiver,
-                SessionReplayBroadcastReceiver.INTENT_FILTER,
-                ContextCompat.RECEIVER_NOT_EXPORTED
-        );
+        // Event tracking integration w/ Session Replay SDK requires Android 13 or higher.
+        // It is also NOT supported in "Instant" apps
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !context.getPackageManager().isInstantApp()) {
+            BroadcastReceiver sessionReplayReceiver = new SessionReplayBroadcastReceiver(this);
+            ContextCompat.registerReceiver(
+                    mContext.getApplicationContext(),
+                    sessionReplayReceiver,
+                    SessionReplayBroadcastReceiver.INTENT_FILTER,
+                    ContextCompat.RECEIVER_NOT_EXPORTED
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/mixpanel/mixpanel-android/issues/846