### PR TITLE
Use DisplayManager directly instead of using WindowManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,12 @@ allprojects {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22"

--- a/mixpaneldemo/build.gradle.kts
+++ b/mixpaneldemo/build.gradle.kts
@@ -49,6 +49,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+}
+
 include ":"
 rootProject.name = "mixpanel-android"
 include ':mixpanel-android'

--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -88,13 +88,13 @@ import com.mixpanel.android.util.MPLog;
         mHasTelephony = foundTelephony;
         mDisplayMetrics = new DisplayMetrics();
 
-        DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        DisplayManager displayManager = (DisplayManager) mContext.getSystemService(Context.DISPLAY_SERVICE);
         Display display = (displayManager != null) ? displayManager.getDisplay(Display.DEFAULT_DISPLAY) : null;
 
         if (display != null) {
             display.getMetrics(mDisplayMetrics);
         } else {
-            DisplayMetrics defaultMetrics = context.getResources().getDisplayMetrics();
+            DisplayMetrics defaultMetrics = mContext.getResources().getDisplayMetrics();
             mDisplayMetrics.setTo(defaultMetrics);
         }
     }

--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -88,8 +88,15 @@ import com.mixpanel.android.util.MPLog;
         mHasTelephony = foundTelephony;
         mDisplayMetrics = new DisplayMetrics();
 
-        Display display = ((DisplayManager) mContext.getSystemService(Context.DISPLAY_SERVICE)).getDisplay(Display.DEFAULT_DISPLAY);
-        display.getMetrics(mDisplayMetrics);
+        DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        Display display = (displayManager != null) ? displayManager.getDisplay(Display.DEFAULT_DISPLAY) : null;
+
+        if (display != null) {
+            display.getMetrics(mDisplayMetrics);
+        } else {
+            DisplayMetrics defaultMetrics = context.getResources().getDisplayMetrics();
+            mDisplayMetrics.setTo(defaultMetrics);
+        }
     }
 
     public String getAppVersionName() { return mAppVersionName; }

--- a/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/SystemInformation.java
@@ -11,13 +11,13 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.hardware.display.DisplayManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
 import android.view.Display;
-import android.view.WindowManager;
 
 import com.mixpanel.android.util.MPLog;
 
@@ -88,7 +88,7 @@ import com.mixpanel.android.util.MPLog;
         mHasTelephony = foundTelephony;
         mDisplayMetrics = new DisplayMetrics();
 
-        Display display = ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+        Display display = ((DisplayManager) mContext.getSystemService(Context.DISPLAY_SERVICE)).getDisplay(Display.DEFAULT_DISPLAY);
         display.getMetrics(mDisplayMetrics);
     }
 


### PR DESCRIPTION
Fixes #850

Also took the oportunity to add org.gradle.toolchains.foojay-resolver-convention so that we can build project even though only having java 23 on the developer machine