### PR TITLE
fix release script and bump snapshot version manually

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.1.0
+VERSION_NAME=8.1.1-SNAPSHOT
 
 POM_PACKAGING=aar
 GROUP=com.mixpanel.android

--- a/release.sh
+++ b/release.sh
@@ -155,6 +155,10 @@ git add .
 git commit -m "Update documentation for $releaseVersion"
 git push origin gh-pages
 
+printf "\n${YELLOW}Checking out $releaseBranch to update snapshot version...${NC}\n"
+git checkout $releaseBranch
+git pull origin $releaseBranch
+
 # update next snapshot version
 printf "\n${YELLOW}Updating next snapshot version...${NC}\n"
 sed -i.bak 's,^\(VERSION_NAME=\).*,\1'$nextSnapshotVersion',' gradle.properties


### PR DESCRIPTION
The release script wasn't checking out the release branch prior to attempting to set the new snapshot version. It was was still on the docs branch gh-pages so the sed command would fail to find gradle.properties. This PR fixes the script and manually bumps the snapshot version from the last release.