### PR TITLE
Convert feature flag requests from POST to GET for CDN compatibility

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -459,6 +459,18 @@ public class FeatureFlagManagerTest {
         assertEquals("$experiment_started", call.eventName);
         assertEquals("track_flag_sync", call.properties.getString("Experiment name"));
         assertEquals("v_track_sync", call.properties.getString("Variant name"));
+        assertEquals("feature_flag", call.properties.getString("$experiment_type"));
+
+        // Verify that timing properties are included
+        assertTrue("timeLastFetched should be present", call.properties.has("timeLastFetched"));
+        assertTrue("fetchLatencyMs should be present", call.properties.has("fetchLatencyMs"));
+
+        // Verify that timing values are reasonable
+        long timeLastFetched = call.properties.getLong("timeLastFetched");
+        long fetchLatencyMs = call.properties.getLong("fetchLatencyMs");
+        assertTrue("timeLastFetched should be positive", timeLastFetched > 0);
+        assertTrue("fetchLatencyMs should be non-negative", fetchLatencyMs >= 0);
+        assertTrue("fetchLatencyMs should be reasonable (< 5 seconds)", fetchLatencyMs < 5000);
     }
 
     @Test

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagDelegate.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagDelegate.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 interface FeatureFlagDelegate {
     MPConfig getMPConfig();
     String getDistinctId();
+    String getAnonymousId();
     void track(String eventName, JSONObject properties);
     String getToken();
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -444,6 +444,7 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
 
         final MPConfig config = delegate.getMPConfig();
         final String distinctId = delegate.getDistinctId();
+        final String deviceId = delegate.getAnonymousId();
 
         if (distinctId == null) {
             MPLog.w(LOGTAG, "Distinct ID is null. Cannot fetch flags.");
@@ -456,6 +457,7 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
             // 1. Build Request Body JSON
             JSONObject contextJson = new JSONObject(mFlagsConfig.context.toString());
             contextJson.put("distinct_id", distinctId);
+            contextJson.put("device_id", deviceId);
             JSONObject requestJson = new JSONObject();
             requestJson.put("context", contextJson);
             String requestJsonString = requestJson.toString();

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -457,7 +457,9 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
             // 1. Build Request Body JSON
             JSONObject contextJson = new JSONObject(mFlagsConfig.context.toString());
             contextJson.put("distinct_id", distinctId);
-            contextJson.put("device_id", deviceId);
+            if (deviceId != null) {
+                contextJson.put("device_id", deviceId);
+            }
             JSONObject requestJson = new JSONObject();
             requestJson.put("context", contextJson);
             String requestJsonString = requestJson.toString();

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -40,6 +40,26 @@ public interface RemoteService {
             @Nullable SSLSocketFactory socketFactory)
             throws ServiceUnavailableException, IOException;
 
+    /**
+     * Performs an HTTP GET request with query parameters.
+     *
+     * @param endpointUrl      The target URL.
+     * @param interactor       Optional proxy interactor.
+     * @param queryParams      Query parameters to be URL-encoded and appended to the URL.
+     * @param headers          Optional map of custom headers (e.g., Authorization).
+     * @param socketFactory    Optional custom SSLSocketFactory.
+     * @return The response body as a byte array, or null if the request failed with a non-retriable HTTP error code.
+     * @throws ServiceUnavailableException If the server returned a 5xx error with a Retry-After header.
+     * @throws IOException                For network errors or non-5xx HTTP errors where reading failed.
+     */
+    byte[] performRequestGet(
+            @NonNull String endpointUrl,
+            @Nullable ProxyServerInteractor interactor,
+            @Nullable Map<String, Object> queryParams,
+            @Nullable Map<String, String> headers,
+            @Nullable SSLSocketFactory socketFactory)
+            throws ServiceUnavailableException, IOException;
+
     class ServiceUnavailableException extends Exception {
         public ServiceUnavailableException(String message, String strRetryAfter) {
             super(message);


### PR DESCRIPTION
## Summary
Converts feature flag requests from POST to GET method to enable CDN usage, following the same changes made in the JavaScript SDK.

### Changes Made
- Modified `FeatureFlagManager` to use GET requests with query parameters instead of POST with JSON body
- Added `performRequestGet` method to `RemoteService` interface and `HttpService` implementation
- Added SDK name ("android") and SDK version to all feature flag requests
- Removed Content-Type header for GET requests (Authorization header maintained)
- Added comprehensive test coverage for GET request functionality

### Technical Details
- Query parameters now include: `context`, `token`, `sdk`, `sdk_version`
- Context parameter contains JSON with `distinct_id`, `device_id`, and other context data
- Maintains backward compatibility with existing feature flag behavior
- All error handling and retry logic preserved

### Test Coverage
- Added tests for GET request method verification
- Added tests for query parameter construction and encoding
- Added tests for header validation (Authorization present, Content-Type absent)
- Added tests for URL encoding of special characters and Unicode
- Added tests for null device ID handling

🤖 Generated with [Claude Code](https://claude.ai/code)