### PR TITLE
Refactor HTTP service to use enum for HTTP methods and switch feature flags to GET requests

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -73,6 +73,19 @@ public class AutomaticEventsTest {
                     @Nullable byte[] requestBodyBytes, // If provided, send this as raw body
                     @Nullable SSLSocketFactory socketFactory)
             {
+                return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+            }
+
+            @Override
+            public RemoteService.RequestResult performRequest(
+                    @NonNull RemoteService.HttpMethod method,
+                    @NonNull String endpointUrl,
+                    @Nullable ProxyServerInteractor interactor,
+                    @Nullable Map<String, Object> params,
+                    @Nullable Map<String, String> headers,
+                    @Nullable byte[] requestBodyBytes,
+                    @Nullable SSLSocketFactory socketFactory)
+            {
 
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                 assertTrue(params.containsKey("data"));
@@ -227,6 +240,19 @@ public class AutomaticEventsTest {
                     @Nullable Map<String, Object> params, // Used only if requestBodyBytes is null
                     @Nullable Map<String, String> headers,
                     @Nullable byte[] requestBodyBytes, // If provided, send this as raw body
+                    @Nullable SSLSocketFactory socketFactory)
+            {
+                return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+            }
+
+            @Override
+            public RemoteService.RequestResult performRequest(
+                    @NonNull RemoteService.HttpMethod method,
+                    @NonNull String endpointUrl,
+                    @Nullable ProxyServerInteractor interactor,
+                    @Nullable Map<String, Object> params,
+                    @Nullable Map<String, String> headers,
+                    @Nullable byte[] requestBodyBytes,
                     @Nullable SSLSocketFactory socketFactory)
             {
                 final String jsonData = Base64Coder.decodeString(params.get("data").toString());

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -1059,7 +1059,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testRequestBodyConstruction_performFetchRequest()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Setup with flags enabled and specific context data
     JSONObject contextData = new JSONObject();
     contextData.put("$os", "Android");
@@ -1146,7 +1146,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testRequestBodyConstruction_withNullContext()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Setup with flags enabled but null context
     setupFlagsConfig(true, null);
 
@@ -1199,7 +1199,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testRequestBodyConstruction_withEmptyDistinctId()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Setup with flags enabled
     setupFlagsConfig(true, new JSONObject());
 
@@ -1244,7 +1244,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testFlagsConfigContextUsage_initialContext()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Test that initial context from FlagsConfig is properly used
     JSONObject initialContext = new JSONObject();
     initialContext.put("app_version", "1.0.0");
@@ -1284,7 +1284,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testFlagsConfigContextUsage_contextMerging()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Test that distinct_id doesn't override existing context properties
     JSONObject initialContext = new JSONObject();
     initialContext.put("distinct_id", "should_be_overridden"); // This should be overridden
@@ -1323,7 +1323,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testFlagsConfigContextUsage_emptyContext()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Test behavior with empty context object
     JSONObject emptyContext = new JSONObject();
     setupFlagsConfig(true, emptyContext);
@@ -1356,7 +1356,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testFlagsConfigContextUsage_complexNestedContext()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Test that complex nested objects in context are preserved
     JSONObject nestedObj = new JSONObject();
     nestedObj.put("city", "San Francisco");
@@ -1403,7 +1403,7 @@ public class FeatureFlagManagerTest {
 
   @Test
   public void testFlagsConfigContextUsage_specialCharactersInContext()
-      throws InterruptedException, JSONException {
+      throws InterruptedException, JSONException, UnsupportedEncodingException {
     // Test that special characters and unicode in context are handled properly
     JSONObject initialContext = new JSONObject();
     initialContext.put("emoji", "🚀🎉");

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -13,6 +13,7 @@ import com.mixpanel.android.util.OfflineMode; // Assuming this exists
 import com.mixpanel.android.util.ProxyServerInteractor;
 import com.mixpanel.android.util.RemoteService;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -64,6 +65,32 @@ public class FeatureFlagManagerTest {
     public JSONObject getRequestBodyAsJson() throws JSONException {
       if (requestBodyBytes == null) return null;
       return new JSONObject(new String(requestBodyBytes, StandardCharsets.UTF_8));
+    }
+
+    public Map<String, String> getQueryParameters() throws JSONException, UnsupportedEncodingException {
+      Map<String, String> params = new HashMap<>();
+      if (endpointUrl.contains("?")) {
+        String query = endpointUrl.substring(endpointUrl.indexOf("?") + 1);
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+          String[] keyValue = pair.split("=", 2);
+          if (keyValue.length == 2) {
+            String key = java.net.URLDecoder.decode(keyValue[0], "UTF-8");
+            String value = java.net.URLDecoder.decode(keyValue[1], "UTF-8");
+            params.put(key, value);
+          }
+        }
+      }
+      return params;
+    }
+
+    public JSONObject getContextFromQueryParams() throws JSONException, UnsupportedEncodingException {
+      Map<String, String> params = getQueryParameters();
+      String contextString = params.get("context");
+      if (contextString != null) {
+        return new JSONObject(contextString);
+      }
+      return null;
     }
   }
 
@@ -142,6 +169,20 @@ public class FeatureFlagManagerTest {
 
     @Override
     public RemoteService.RequestResult performRequest(
+        @NonNull String endpointUrl,
+        @Nullable ProxyServerInteractor interactor,
+        @Nullable Map<String, Object> params,
+        @Nullable Map<String, String> headers,
+        @Nullable byte[] requestBodyBytes,
+        @Nullable SSLSocketFactory socketFactory)
+        throws ServiceUnavailableException, IOException {
+      // Delegate to new method with POST as default for backward compatibility
+      return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+    }
+
+    @Override
+    public RemoteService.RequestResult performRequest(
+        @NonNull RemoteService.HttpMethod method,
         @NonNull String endpointUrl,
         @Nullable ProxyServerInteractor interactor,
         @Nullable Map<String, Object> params,
@@ -1046,17 +1087,17 @@ public class FeatureFlagManagerTest {
     assertTrue(
         "URL should contain /flags endpoint", capturedRequest.endpointUrl.contains("/flags"));
 
-    // Parse and verify the request body
-    assertNotNull("Request should have body", capturedRequest.requestBodyBytes);
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    assertNotNull("Request body should be valid JSON", requestBody);
+    // Parse and verify the query parameters (GET request)
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    assertNotNull("Query parameters should be present", queryParams);
 
-    // Log the actual request body for debugging
-    MPLog.v("FeatureFlagManagerTest", "Request body: " + requestBody.toString());
+    // Log the actual URL for debugging
+    MPLog.v("FeatureFlagManagerTest", "Request URL: " + capturedRequest.endpointUrl);
 
-    // Verify context is included
-    assertTrue("Request should contain context", requestBody.has("context"));
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    // Verify context is included in query parameters
+    assertTrue("Request should contain context parameter", queryParams.containsKey("context"));
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
+    assertNotNull("Context should be valid JSON", requestContext);
 
     // Verify distinct_id is in the context
     assertTrue("Context should contain distinct_id", requestContext.has("distinct_id"));
@@ -1081,12 +1122,20 @@ public class FeatureFlagManagerTest {
         "test_value",
         requestContext.getString("custom_property"));
 
+    // Verify the new query parameters are included
+    assertTrue("Request should contain token parameter", queryParams.containsKey("token"));
+    assertEquals("Token should match", TEST_TOKEN, queryParams.get("token"));
+    
+    assertTrue("Request should contain mp_lib parameter", queryParams.containsKey("mp_lib"));
+    assertEquals("mp_lib should be android", "android", queryParams.get("mp_lib"));
+    
+    assertTrue("Request should contain $lib_version parameter", queryParams.containsKey("$lib_version"));
+    assertNotNull("$lib_version should not be null", queryParams.get("$lib_version"));
+
     // Verify headers
     assertNotNull("Request should have headers", capturedRequest.headers);
-    assertEquals(
-        "Content-Type should be application/json with charset",
-        "application/json; charset=utf-8",
-        capturedRequest.headers.get("Content-Type"));
+    assertTrue("Request should have Authorization header", capturedRequest.headers.containsKey("Authorization"));
+    assertFalse("GET request should not have Content-Type header", capturedRequest.headers.containsKey("Content-Type"));
 
     // Wait for flags to be ready
     for (int i = 0; i < 20 && !mFeatureFlagManager.areFlagsReady(); i++) {
@@ -1118,12 +1167,14 @@ public class FeatureFlagManagerTest {
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
     assertNotNull("Request should have been made", capturedRequest);
 
-    // Parse request body
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
+    // Parse query parameters (GET request)
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    assertNotNull("Query parameters should be present", queryParams);
 
-    // Verify context exists
-    assertTrue("Request should contain context", requestBody.has("context"));
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    // Verify context exists in query parameters
+    assertTrue("Request should contain context parameter", queryParams.containsKey("context"));
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
+    assertNotNull("Context should be valid JSON", requestContext);
 
     // Verify distinct_id is in context
     assertEquals(
@@ -1169,12 +1220,14 @@ public class FeatureFlagManagerTest {
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
     assertNotNull("Request should have been made", capturedRequest);
 
-    // Parse request body
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
+    // Parse query parameters (GET request)
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    assertNotNull("Query parameters should be present", queryParams);
 
-    // Verify context exists
-    assertTrue("Request should contain context", requestBody.has("context"));
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    // Verify context exists in query parameters
+    assertTrue("Request should contain context parameter", queryParams.containsKey("context"));
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
+    assertNotNull("Context should be valid JSON", requestContext);
 
     // Verify distinct_id is included in context even when empty
     assertTrue("Context should contain distinct_id field", requestContext.has("distinct_id"));
@@ -1213,8 +1266,8 @@ public class FeatureFlagManagerTest {
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
     assertNotNull("Request should have been made", capturedRequest);
 
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
 
     // Verify all initial context properties are included
     assertEquals(
@@ -1254,8 +1307,8 @@ public class FeatureFlagManagerTest {
 
     // Capture and verify request
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
 
     // Verify distinct_id from delegate overrides the one in initial context
     assertEquals(
@@ -1288,8 +1341,8 @@ public class FeatureFlagManagerTest {
 
     // Capture and verify request
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
 
     // Context should only contain distinct_id and device_id when initial context is empty
     assertEquals(
@@ -1328,8 +1381,8 @@ public class FeatureFlagManagerTest {
 
     // Capture and verify request
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
 
     // Verify complex nested structures are preserved
     JSONObject locationInRequest = requestContext.getJSONObject("location");
@@ -1371,8 +1424,8 @@ public class FeatureFlagManagerTest {
 
     // Capture and verify request
     CapturedRequest capturedRequest = mMockRemoteService.takeRequest(1000, TimeUnit.MILLISECONDS);
-    JSONObject requestBody = capturedRequest.getRequestBodyAsJson();
-    JSONObject requestContext = requestBody.getJSONObject("context");
+    Map<String, String> queryParams = capturedRequest.getQueryParameters();
+    JSONObject requestContext = capturedRequest.getContextFromQueryParams();
 
     // Verify special characters are preserved correctly
     assertEquals("emoji should be preserved", "🚀🎉", requestContext.getString("emoji"));

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -67,6 +67,19 @@ public class HttpTest {
               @Nullable byte[] requestBodyBytes, // If provided, send this as raw body
               @Nullable SSLSocketFactory socketFactory)
               throws ServiceUnavailableException, IOException {
+            return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+          }
+
+          @Override
+          public RemoteService.RequestResult performRequest(
+              @NonNull RemoteService.HttpMethod method,
+              @NonNull String endpointUrl,
+              @Nullable ProxyServerInteractor interactor,
+              @Nullable Map<String, Object> params,
+              @Nullable Map<String, String> headers,
+              @Nullable byte[] requestBodyBytes,
+              @Nullable SSLSocketFactory socketFactory)
+              throws ServiceUnavailableException, IOException {
             try {
               if (mFlushResults.isEmpty()) {
                 mFlushResults.add(TestUtils.bytes("1\n"));

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -1394,6 +1394,20 @@ public class MixpanelBasicTest {
                   byte[] requestBodyBytes,
                   SSLSocketFactory socketFactory)
                   throws ServiceUnavailableException, IOException {
+                // Delegate to the new method signature with POST as default
+                return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+              }
+
+              @Override
+              public RemoteService.RequestResult performRequest(
+                  RemoteService.HttpMethod method,
+                  String endpointUrl,
+                  ProxyServerInteractor interactor,
+                  Map<String, Object> params,
+                  Map<String, String> headers,
+                  byte[] requestBodyBytes,
+                  SSLSocketFactory socketFactory)
+                  throws ServiceUnavailableException, IOException {
                 // Track calls to the flags endpoint
                 if (endpointUrl != null && endpointUrl.contains("/flags/")) {
                   flagsEndpointCalls.add(endpointUrl);

--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/OptOutTest.java
@@ -68,6 +68,19 @@ public class OptOutTest {
                     @Nullable byte[] requestBodyBytes, // If provided, send this as raw body
                     @Nullable SSLSocketFactory socketFactory)
             {
+                return performRequest(RemoteService.HttpMethod.POST, endpointUrl, interactor, params, headers, requestBodyBytes, socketFactory);
+            }
+
+            @Override
+            public RemoteService.RequestResult performRequest(
+                    @NonNull RemoteService.HttpMethod method,
+                    @NonNull String endpointUrl,
+                    @Nullable ProxyServerInteractor interactor,
+                    @Nullable Map<String, Object> params,
+                    @Nullable Map<String, String> headers,
+                    @Nullable byte[] requestBodyBytes,
+                    @Nullable SSLSocketFactory socketFactory)
+            {
                 if (params != null) {
                     final String jsonData = Base64Coder.decodeString(params.get("data").toString());
                     assertTrue(params.containsKey("data"));

--- a/src/main/java/com/mixpanel/android/util/RemoteService.java
+++ b/src/main/java/com/mixpanel/android/util/RemoteService.java
@@ -13,6 +13,10 @@ import javax.net.ssl.SSLSocketFactory;
 
 
 public interface RemoteService {
+    enum HttpMethod {
+        GET, POST
+    }
+
     boolean isOnline(Context context, OfflineMode offlineMode);
 
     void checkIsMixpanelBlocked();
@@ -37,6 +41,31 @@ public interface RemoteService {
             @Nullable Map<String, Object> params, // Used only if requestBodyBytes is null
             @Nullable Map<String, String> headers,
             @Nullable byte[] requestBodyBytes, // If provided, send this as raw body
+            @Nullable SSLSocketFactory socketFactory)
+            throws ServiceUnavailableException, IOException;
+
+    /**
+     * Performs an HTTP request with the specified method. For GET requests, parameters go in query string.
+     * For POST requests, parameters can go in body (URL-encoded or JSON) or query string based on requestBodyBytes.
+     *
+     * @param method           The HTTP method to use (GET or POST).
+     * @param endpointUrl      The target URL.
+     * @param interactor       Optional proxy interactor.
+     * @param params           Parameters (query string for GET, body for POST if requestBodyBytes is null).
+     * @param headers          Optional map of custom headers (e.g., Authorization, Content-Type).
+     * @param requestBodyBytes Optional raw byte array for POST request body. If non-null, params are ignored for body.
+     * @param socketFactory    Optional custom SSLSocketFactory.
+     * @return A RequestResult containing the response body, actual URL used, and success status.
+     * @throws ServiceUnavailableException If the server returned a 5xx error with a Retry-After header.
+     * @throws IOException                For network errors or non-5xx HTTP errors where reading failed.
+     */
+    RequestResult performRequest(
+            @NonNull HttpMethod method,
+            @NonNull String endpointUrl,
+            @Nullable ProxyServerInteractor interactor,
+            @Nullable Map<String, Object> params,
+            @Nullable Map<String, String> headers,
+            @Nullable byte[] requestBodyBytes,
             @Nullable SSLSocketFactory socketFactory)
             throws ServiceUnavailableException, IOException;
 


### PR DESCRIPTION
## Summary

This PR implements the same changes from the JavaScript SDK ([mixpanel/mixpanel-js-private#319](https://github.com/mixpanel/mixpanel-js-private/pull/319)) to align the Android SDK's feature flag implementation with the JS SDK for better CDN caching support.

## Key Changes

### 🔧 HTTP Service Refactoring
- Add `HttpMethod` enum (GET, POST) to `RemoteService` interface
- Consolidate `HttpService` methods to support both GET and POST via enum parameter  
- Maintain backward compatibility with existing `performRequest` method (defaults to POST)
- Remove duplicate code by merging POST and GET request handling

### 🚀 Feature Flag Implementation Updates
- **Switch from POST requests with JSON body to GET requests with query parameters**
- Update parameter names to match JS SDK: `mp_lib` and `$lib_version` instead of `sdk` and `sdk_version`
- Move context, token, and SDK info from request body to URL query parameters
- Remove Content-Type header for GET requests (not needed for GET)

### 🧪 Test Infrastructure Updates
- Update `FeatureFlagManagerTest` to validate GET requests instead of POST
- Add query parameter parsing methods to `CapturedRequest` helper class
- Update all request body construction tests to check query parameters instead
- Update context usage tests to work with new parameter format
- Add validation for new parameters: `token`, `mp_lib`, `$lib_version`

## Benefits

- **🏎️ CDN Caching**: GET requests can be cached by CDNs for improved performance
- **🤝 Consistency**: Aligns Android SDK with JavaScript SDK implementation  
- **🛠️ Maintainability**: Single HTTP method implementation reduces code duplication
- **↩️ Backward Compatibility**: Existing POST usage continues to work unchanged

## Request Format Changes

### Before (POST with JSON body):
```http
POST /flags HTTP/1.1
Content-Type: application/json
Authorization: Basic <token>

{
  "context": {
    "distinct_id": "user123",
    "device_id": "device456",
    "$os": "Android"
  }
}
```

### After (GET with query parameters):
```http
GET /flags?context=%7B%22distinct_id%22%3A%22user123%22%2C%22device_id%22%3A%22device456%22%2C%22%24os%22%3A%22Android%22%7D&token=<token>&mp_lib=android&%24lib_version=8.2.3 HTTP/1.1
Authorization: Basic <token>
```

## Test Plan

- [x] All existing feature flag tests updated and passing
- [x] New query parameter validation added  
- [x] HTTP service enum functionality verified
- [x] Backward compatibility maintained for all existing POST requests
- [x] No breaking changes to public API

## Files Changed

- `src/main/java/com/mixpanel/android/util/RemoteService.java` - Added HttpMethod enum and new method signature
- `src/main/java/com/mixpanel/android/util/HttpService.java` - Consolidated GET/POST handling 
- `src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java` - Switch to GET requests with new parameters
- `src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java` - Updated tests for GET requests
- `src/androidTest/java/com/mixpanel/android/mpmetrics/*Test.java` - Updated mock implementations

🤖 Generated with [Claude Code](https://claude.ai/code)