### PR TITLE
Add experiment properties to feature flag exposure tracking

### DIFF
--- a/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -1743,8 +1743,8 @@ public class FeatureFlagManagerTest {
 
     // Verify tracking properties include optional parameters
     MockFeatureFlagDelegate.TrackCall call = mMockDelegate.trackCalls.get(0);
-    assertEquals("ExperimentID should be included", "exp_789", call.properties.getString("experimentID"));
-    assertTrue("IsExperimentActive should be included", call.properties.getBoolean("isExperimentActive"));
-    assertTrue("IsQATester should be included", call.properties.getBoolean("isQATester"));
+    assertEquals("ExperimentID should be included", "exp_789", call.properties.getString("$experiment_id"));
+    assertTrue("IsExperimentActive should be included", call.properties.getBoolean("$is_experiment_active"));
+    assertTrue("IsQATester should be included", call.properties.getBoolean("$is_qa_tester"));
   }
 }

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -713,13 +713,13 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
       }
 
       if (variant.experimentID != null) {
-        properties.put("experimentID", variant.experimentID);
+        properties.put("$experiment_id", variant.experimentID);
       }
       if (variant.isExperimentActive != null) {
-        properties.put("isExperimentActive", variant.isExperimentActive);
+        properties.put("$is_experiment_active", variant.isExperimentActive);
       }
       if (variant.isQATester != null) {
-        properties.put("isQATester", variant.isQATester);
+        properties.put("$is_qa_tester", variant.isQATester);
       }
     } catch (JSONException e) {
       MPLog.e(LOGTAG, "Failed to create JSON properties for $experiment_started event", e);

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -711,6 +711,16 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
         properties.put("timeLastFetched", timing.timeLastFetched);
         properties.put("fetchLatencyMs", timing.fetchLatencyMs);
       }
+
+      if (variant.experimentID != null) {
+        properties.put("experimentID", variant.experimentID);
+      }
+      if (variant.isExperimentActive != null) {
+        properties.put("isExperimentActive", variant.isExperimentActive);
+      }
+      if (variant.isQATester != null) {
+        properties.put("isQATester", variant.isQATester);
+      }
     } catch (JSONException e) {
       MPLog.e(LOGTAG, "Failed to create JSON properties for $experiment_started event", e);
       return; // Don't track if properties failed

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -44,7 +44,7 @@ public class MixpanelFlagVariant {
     public final Boolean isQATester;
 
     /**
-     * Constructs a {@code FeatureFlagData} object when parsing an API response.
+     * Constructs a {@code MixpanelFlagVariant} object when parsing an API response.
      *
      * @param key The key of the feature flag variant. Corresponds to 'variant_key' from the API. Cannot be null.
      * @param value The value of the feature flag variant. Corresponds to 'variant_value' from the API.
@@ -59,7 +59,7 @@ public class MixpanelFlagVariant {
     }
 
     /**
-     * Constructs a {@code FeatureFlagData} object when parsing an API response with optional experiment fields.
+     * Constructs a {@code MixpanelFlagVariant} object when parsing an API response with optional experiment fields.
      *
      * @param key The key of the feature flag variant. Corresponds to 'variant_key' from the API. Cannot be null.
      * @param value The value of the feature flag variant. Corresponds to 'variant_value' from the API.
@@ -77,7 +77,7 @@ public class MixpanelFlagVariant {
     }
 
     /**
-     * Constructs a {@code FeatureFlagData} object for creating fallback instances.
+     * Constructs a {@code MixpanelFlagVariant} object for creating fallback instances.
      * In this case, the provided {@code keyAndValue} is used as both the key and the value
      * for the feature flag data. This is typically used when a flag is not found
      * and a default string value needs to be returned.
@@ -93,7 +93,7 @@ public class MixpanelFlagVariant {
     }
 
     /**
-     * Constructs a {@code FeatureFlagData} object for creating fallback instances.
+     * Constructs a {@code MixpanelFlagVariant} object for creating fallback instances.
      * In this version, the key is set to an empty string (""), and the provided {@code value}
      * is used as the value for the feature flag data. This is typically used when a
      * flag is not found or an error occurs, and a default value needs to be provided.
@@ -110,7 +110,7 @@ public class MixpanelFlagVariant {
     }
 
     /**
-     * Default constructor that initializes an empty {@code FeatureFlagData} object.
+     * Default constructor that initializes an empty {@code MixpanelFlagVariant} object.
      * The key is set to an empty string ("") and the value is set to null.
      * This constructor might be used internally or for specific default cases.
      */

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -26,6 +26,24 @@ public class MixpanelFlagVariant {
     public final Object value;
 
     /**
+     * The value of experimentID. This corresponds to the optional 'experiment_id' field in the Mixpanel API response.
+     */
+    @Nullable
+    public final String experimentID;
+
+    /**
+     * The value of isExperimentActive. This corresponds to the optional 'is_experiment_active' field in the Mixpanel API response.
+     */
+    @Nullable
+    public final Boolean isExperimentActive;
+
+    /**
+     * The value of isQATester. This corresponds to the optional 'is_qa_tester' field in the Mixpanel API response.
+     */
+    @Nullable
+    public final Boolean isQATester;
+
+    /**
      * Constructs a {@code FeatureFlagData} object when parsing an API response.
      *
      * @param key The key of the feature flag variant. Corresponds to 'variant_key' from the API. Cannot be null.
@@ -35,6 +53,27 @@ public class MixpanelFlagVariant {
     public MixpanelFlagVariant(@NonNull String key, @Nullable Object value) {
         this.key = key;
         this.value = value;
+        this.experimentID = null;
+        this.isExperimentActive = null;
+        this.isQATester = null;
+    }
+
+    /**
+     * Constructs a {@code FeatureFlagData} object when parsing an API response with optional experiment fields.
+     *
+     * @param key The key of the feature flag variant. Corresponds to 'variant_key' from the API. Cannot be null.
+     * @param value The value of the feature flag variant. Corresponds to 'variant_value' from the API.
+     * Can be Boolean, String, Number, JSONArray, JSONObject, or null.
+     * @param experimentID The experiment ID. Corresponds to 'experiment_id' from the API. Can be null.
+     * @param isExperimentActive Whether the experiment is active. Corresponds to 'is_experiment_active' from the API. Can be null.
+     * @param isQATester Whether the user is a QA tester. Corresponds to 'is_qa_tester' from the API. Can be null.
+     */
+    public MixpanelFlagVariant(@NonNull String key, @Nullable Object value, @Nullable String experimentID, @Nullable Boolean isExperimentActive, @Nullable Boolean isQATester) {
+        this.key = key;
+        this.value = value;
+        this.experimentID = experimentID;
+        this.isExperimentActive = isExperimentActive;
+        this.isQATester = isQATester;
     }
 
     /**
@@ -48,6 +87,9 @@ public class MixpanelFlagVariant {
     public MixpanelFlagVariant(@NonNull String keyAndValue) {
         this.key = keyAndValue; // Default key to the value itself
         this.value = keyAndValue;
+        this.experimentID = null;
+        this.isExperimentActive = null;
+        this.isQATester = null;
     }
 
     /**
@@ -62,6 +104,9 @@ public class MixpanelFlagVariant {
     public MixpanelFlagVariant(@NonNull Object value) {
         this.key = "";
         this.value = value;
+        this.experimentID = null;
+        this.isExperimentActive = null;
+        this.isQATester = null;
     }
 
     /**
@@ -72,5 +117,8 @@ public class MixpanelFlagVariant {
     MixpanelFlagVariant() {
         this.key = "";
         this.value = null;
+        this.experimentID = null;
+        this.isExperimentActive = null;
+        this.isQATester = null;
     }
 }

--- a/src/main/java/com/mixpanel/android/util/JsonUtils.java
+++ b/src/main/java/com/mixpanel/android/util/JsonUtils.java
@@ -153,7 +153,23 @@ public class JsonUtils {
                         MPLog.w(LOGTAG, "Flag definition missing 'variant_value' for key: " + featureName + ". Assuming null value.");
                     }
 
-                    MixpanelFlagVariant flagData = new MixpanelFlagVariant(variantKey, variantValue);
+                    // Parse optional experiment tracking fields
+                    String experimentID = null;
+                    if (flagDefinition.has(MPConstants.Flags.EXPERIMENT_ID) && !flagDefinition.isNull(MPConstants.Flags.EXPERIMENT_ID)) {
+                        experimentID = flagDefinition.getString(MPConstants.Flags.EXPERIMENT_ID);
+                    }
+
+                    Boolean isExperimentActive = null;
+                    if (flagDefinition.has(MPConstants.Flags.IS_EXPERIMENT_ACTIVE) && !flagDefinition.isNull(MPConstants.Flags.IS_EXPERIMENT_ACTIVE)) {
+                        isExperimentActive = flagDefinition.getBoolean(MPConstants.Flags.IS_EXPERIMENT_ACTIVE);
+                    }
+
+                    Boolean isQATester = null;
+                    if (flagDefinition.has(MPConstants.Flags.IS_QA_TESTER) && !flagDefinition.isNull(MPConstants.Flags.IS_QA_TESTER)) {
+                        isQATester = flagDefinition.getBoolean(MPConstants.Flags.IS_QA_TESTER);
+                    }
+
+                    MixpanelFlagVariant flagData = new MixpanelFlagVariant(variantKey, variantValue, experimentID, isExperimentActive, isQATester);
                     flagsMap.put(featureName, flagData);
 
                 } catch (JSONException e) {

--- a/src/main/java/com/mixpanel/android/util/MPConstants.java
+++ b/src/main/java/com/mixpanel/android/util/MPConstants.java
@@ -21,5 +21,8 @@ public class MPConstants {
         public static final String FLAGS_KEY = "flags";
         public static final String VARIANT_KEY = "variant_key";
         public static final String VARIANT_VALUE = "variant_value";
+        public static final String EXPERIMENT_ID = "experiment_id";
+        public static final String IS_EXPERIMENT_ACTIVE = "is_experiment_active";
+        public static final String IS_QA_TESTER = "is_qa_tester";
     }
 }


### PR DESCRIPTION
Plumbs ExperimentID, isExperimentActive, and isQATester, optional properties that may be present in the /flags API response, through to the tracked $experiment_started event.

## GitHub Copilot Summary

This pull request adds support for optional experiment tracking parameters to feature flag variants in the Mixpanel Android SDK. The changes ensure that experiment-related fields (`experiment_id`, `is_experiment_active`, and `is_qa_tester`) are parsed from API responses, stored in the `MixpanelFlagVariant` class, and included in tracking event properties. A new test verifies that these fields are correctly handled end-to-end.

**Feature flag experiment tracking enhancements:**

* Added new fields (`experimentID`, `isExperimentActive`, `isQATester`) to the `MixpanelFlagVariant` class, updated constructors to initialize them, and documented their purpose. [[1]](diffhunk://#diff-19c77a86269a04942a2c6d81260eba1ede733de506f711d087996da14cd904e7R28-R45) [[2]](diffhunk://#diff-19c77a86269a04942a2c6d81260eba1ede733de506f711d087996da14cd904e7R56-R76) [[3]](diffhunk://#diff-19c77a86269a04942a2c6d81260eba1ede733de506f711d087996da14cd904e7R90-R92) [[4]](diffhunk://#diff-19c77a86269a04942a2c6d81260eba1ede733de506f711d087996da14cd904e7R107-R109) [[5]](diffhunk://#diff-19c77a86269a04942a2c6d81260eba1ede733de506f711d087996da14cd904e7R120-R122)
* Updated the constants in `MPConstants.Flags` for the new experiment tracking fields.

**Parsing and serialization improvements:**

* Modified `JsonUtils.parseFlagsResponse` to extract the new experiment tracking fields from the API response and pass them to the `MixpanelFlagVariant` constructor.
* Updated the test helper method `createFlagsResponseJson` to include the optional experiment parameters when present.

**Tracking event property updates:**

* Enhanced `_performTrackingDelegateCall` in `FeatureFlagManager` to include the new experiment parameters in tracking event properties if available.

**Testing:**

* Added a new test to `FeatureFlagManagerTest` to verify that all optional experiment parameters are included in tracking event properties when present.