### PR TITLE
Add README for OpenFeature provider

### DIFF
--- a/openfeature-provider/README.md
+++ b/openfeature-provider/README.md
@@ -1,0 +1,365 @@
+# Mixpanel OpenFeature Provider for Android
+
+[![OpenFeature](https://img.shields.io/badge/OpenFeature-compatible-green)](https://openfeature.dev/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/mixpanel/mixpanel-android/blob/master/LICENSE)
+
+An [OpenFeature](https://openfeature.dev/) provider that wraps Mixpanel's feature flags for use with the OpenFeature Kotlin (Android) SDK. This allows you to use Mixpanel's feature flagging capabilities through OpenFeature's standardized, vendor-agnostic API.
+
+## Overview
+
+This package provides a bridge between Mixpanel's native feature flags implementation and the OpenFeature specification. By using this provider, you can:
+
+- Leverage Mixpanel's powerful feature flag and experimentation platform
+- Use OpenFeature's standardized API for flag evaluation
+- Easily switch between feature flag providers without changing your application code
+- Integrate with OpenFeature's ecosystem of tools and frameworks
+
+## Installation
+
+Add the following dependencies to your app's `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.mixpanel.android:mixpanel-android-openfeature:<version>")
+    implementation("dev.openfeature:kotlin-sdk-android:0.7.2")
+}
+```
+
+Or with Groovy (`build.gradle`):
+
+```groovy
+dependencies {
+    implementation 'com.mixpanel.android:mixpanel-android-openfeature:<version>'
+    implementation 'dev.openfeature:kotlin-sdk-android:0.7.2'
+}
+```
+
+## Quick Start
+
+```kotlin
+import com.mixpanel.android.openfeature.MixpanelProvider
+import com.mixpanel.android.mpmetrics.MixpanelOptions
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+
+// 1. Create the provider using the convenience constructor
+val options = MixpanelOptions.Builder()
+    .featureFlags()
+    .build()
+val provider = MixpanelProvider(context, "YOUR_PROJECT_TOKEN", options)
+
+// 2. Register the provider with OpenFeature
+OpenFeatureAPI.setProviderAndWait(provider)
+
+// 3. Get a client and evaluate flags
+val client = OpenFeatureAPI.getClient()
+val showNewFeature = client.getBooleanValue("new-feature-flag", false)
+
+if (showNewFeature) {
+    // New feature is enabled!
+}
+```
+
+### Alternative: Use an Existing MixpanelAPI Instance
+
+If you already have a `MixpanelAPI` instance, you can pass its `Flags` object directly:
+
+```kotlin
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import com.mixpanel.android.openfeature.MixpanelProvider
+
+val mixpanel = MixpanelAPI.getInstance(context, "YOUR_PROJECT_TOKEN", false, options)
+val provider = MixpanelProvider(mixpanel.getFlags())
+
+OpenFeatureAPI.setProviderAndWait(provider)
+```
+
+> **Important:** If you need to call `mixpanel.identify()` to update the logged-in user or `mixpanel.track()` to use [Runtime Events](https://docs.mixpanel.com/docs/feature-flags/runtime-events) for targeting, you must call these methods on the **same `MixpanelAPI` instance** whose `Flags` object was passed to the provider. Using a different instance will not affect the provider's flag evaluation.
+
+When using the convenience constructor, the underlying instance is accessible via `provider.mixpanel`:
+
+```kotlin
+val provider = MixpanelProvider(context, "YOUR_PROJECT_TOKEN", options)
+
+// Use the same instance for identity and tracking
+provider.mixpanel?.identify("user-123")
+provider.mixpanel?.track("Purchase Completed")
+```
+
+## Usage Examples
+
+### Basic Boolean Flag
+
+```kotlin
+val client = OpenFeatureAPI.getClient()
+
+// Get a boolean flag with a default value
+val isFeatureEnabled = client.getBooleanValue("my-feature", false)
+
+if (isFeatureEnabled) {
+    // Show the new feature
+}
+```
+
+### Mixpanel Flag Types and OpenFeature Evaluation Methods
+
+Mixpanel feature flags support three flag types. Use the corresponding OpenFeature evaluation method based on your flag's variant values:
+
+| Mixpanel Flag Type | Variant Values | OpenFeature Method |
+|---|---|---|
+| Feature Gate | `true` / `false` | `getBooleanValue()` |
+| Experiment | boolean, string, number, or JSON object | `getBooleanValue()`, `getStringValue()`, `getIntegerValue()`, `getDoubleValue()`, or `getObjectValue()` |
+| Dynamic Config | JSON object | `getObjectValue()` |
+
+```kotlin
+val client = OpenFeatureAPI.getClient()
+
+// Feature Gate - boolean variants
+val isFeatureOn = client.getBooleanValue("new-checkout", false)
+
+// Experiment with string variants
+val buttonColor = client.getStringValue("button-color-test", "blue")
+
+// Experiment with integer variants
+val maxItems = client.getIntegerValue("max-items", 10)
+
+// Experiment with double variants
+val threshold = client.getDoubleValue("score-threshold", 0.5)
+
+// Dynamic Config - JSON object variants
+val featureConfig = client.getObjectValue("homepage-layout", Value.Structure(mapOf(
+    "layout" to Value.String("grid"),
+    "itemsPerRow" to Value.Integer(3)
+)))
+```
+
+### Getting Full Resolution Details
+
+If you need additional metadata about the flag evaluation:
+
+```kotlin
+val client = OpenFeatureAPI.getClient()
+
+val details = client.getBooleanDetails("my-feature", false)
+
+println(details.value)        // The resolved value
+println(details.variant)      // The variant key from Mixpanel
+println(details.reason)       // Why this value was returned
+println(details.errorCode)    // Error code if evaluation failed
+```
+
+### Setting Context
+
+You can pass evaluation context that will be sent to Mixpanel for flag evaluation using `OpenFeatureAPI.setContext()`:
+
+```kotlin
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.Value
+
+OpenFeatureAPI.setContext(ImmutableContext(
+    attributes = mutableMapOf(
+        "email" to Value.String("user@example.com"),
+        "plan" to Value.String("premium")
+    )
+))
+```
+
+> **Note:** Per-evaluation context (the optional `context` parameter on evaluation methods) is **not supported** by this provider. Context must be set globally via `OpenFeatureAPI.setContext()`, which triggers a re-fetch of flag values from Mixpanel.
+
+### Using custom_properties for Runtime Properties
+
+You can pass `custom_properties` in the evaluation context for use with Mixpanel's [Runtime Properties](https://docs.mixpanel.com/docs/feature-flags/runtime-properties) targeting rules. Values must be flat key-value pairs (no nested objects):
+
+```kotlin
+OpenFeatureAPI.setContext(ImmutableContext(
+    attributes = mutableMapOf(
+        "custom_properties" to Value.Structure(mapOf(
+            "tier" to Value.String("enterprise"),
+            "seats" to Value.Integer(50),
+            "industry" to Value.String("technology")
+        ))
+    )
+))
+```
+
+## Context Mapping
+
+Understanding how OpenFeature context maps to Mixpanel:
+
+### All Properties Passed Directly
+
+All properties in the OpenFeature `EvaluationContext` are passed directly to Mixpanel's feature flag evaluation. There is no transformation or filtering of properties.
+
+```kotlin
+// This OpenFeature context...
+OpenFeatureAPI.setContext(ImmutableContext(
+    targetingKey = "user-123",
+    attributes = mutableMapOf(
+        "email" to Value.String("user@example.com"),
+        "plan" to Value.String("premium"),
+        "beta_tester" to Value.Boolean(true)
+    )
+))
+
+// ...is passed to Mixpanel as-is for flag evaluation
+```
+
+### targetingKey is Not Special
+
+Unlike some feature flag providers, `targetingKey` is **not** used as a special bucketing key in Mixpanel. It is simply passed as another context property. Mixpanel's server-side configuration determines which properties are used for:
+
+- **Targeting rules**: Which users see which variants
+- **Bucketing**: How users are consistently assigned to variants
+
+### User Identity is Managed Separately
+
+**Important**: This provider does **not** call `mixpanel.identify()`. User identity should be managed separately through the same Mixpanel instance that backs this provider:
+
+```kotlin
+// Manage identity through the same Mixpanel instance
+provider.mixpanel?.identify("user-123")
+
+// The provider will use Mixpanel's current distinct_id automatically
+val client = OpenFeatureAPI.getClient()
+val value = client.getBooleanValue("my-flag", false)
+```
+
+## API Reference
+
+### MixpanelProvider
+
+The main provider class that implements the OpenFeature `FeatureProvider` interface.
+
+#### Constructors
+
+```kotlin
+// Primary constructor - pass a Flags instance directly
+MixpanelProvider(flags: MixpanelAPI.Flags)
+
+// Convenience constructor - creates a MixpanelAPI instance internally
+MixpanelProvider(context: Context, token: String, options: MixpanelOptions)
+```
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `metadata` | `ProviderMetadata` | Provider metadata with the name "mixpanel-provider" |
+| `mixpanel` | `MixpanelAPI?` | The underlying Mixpanel instance (only available when using the convenience constructor) |
+
+#### Methods
+
+| Method | Description |
+|--------|-------------|
+| `initialize(initialContext?)` | Called when the provider is registered. Applies initial context if provided. |
+| `onContextSet(oldContext, newContext)` | Called when the global evaluation context changes. Sends updated context to Mixpanel. |
+| `shutdown()` | Called when the provider is shut down. No-op since Mixpanel manages its own lifecycle. |
+| `getBooleanEvaluation(key, defaultValue, context)` | Evaluates a boolean flag |
+| `getStringEvaluation(key, defaultValue, context)` | Evaluates a string flag |
+| `getIntegerEvaluation(key, defaultValue, context)` | Evaluates an integer flag |
+| `getDoubleEvaluation(key, defaultValue, context)` | Evaluates a double flag |
+| `getObjectEvaluation(key, defaultValue, context)` | Evaluates an object flag |
+
+## Error Handling
+
+The provider uses OpenFeature's standard error codes to indicate issues during flag evaluation:
+
+### PROVIDER_NOT_READY
+
+Returned when flags are evaluated before the provider has finished initializing.
+
+```kotlin
+// To avoid this error, use setProviderAndWait
+OpenFeatureAPI.setProviderAndWait(provider)
+
+// Or listen for the READY event
+OpenFeatureAPI.observe<OpenFeatureEvents.ProviderReady> {
+    // Now safe to evaluate flags
+}
+```
+
+### FLAG_NOT_FOUND
+
+Returned when the requested flag does not exist in Mixpanel.
+
+```kotlin
+val details = client.getBooleanDetails("nonexistent-flag", false)
+
+if (details.errorCode == ErrorCode.FLAG_NOT_FOUND) {
+    println("Flag does not exist, using default value")
+}
+```
+
+### TYPE_MISMATCH
+
+Returned when the flag value type does not match the requested type.
+
+```kotlin
+// If 'my-flag' is configured as a string in Mixpanel...
+val details = client.getBooleanDetails("my-flag", false)
+
+if (details.errorCode == ErrorCode.TYPE_MISMATCH) {
+    println("Flag is not a boolean, using default value")
+}
+```
+
+## Troubleshooting
+
+### Flags Always Return Default Values
+
+**Possible causes:**
+
+1. **Feature flags not enabled**: Ensure you configured Mixpanel with feature flags enabled:
+   ```kotlin
+   val options = MixpanelOptions.Builder()
+       .featureFlags()
+       .build()
+   ```
+
+2. **Provider not ready**: Make sure to wait for the provider to initialize:
+   ```kotlin
+   OpenFeatureAPI.setProviderAndWait(provider)
+   ```
+
+3. **Network issues**: Check Logcat for failed requests to Mixpanel's flags API.
+
+4. **Flag not configured**: Verify the flag exists in your Mixpanel project and is enabled.
+
+### Type Mismatch Errors
+
+If you are getting `TYPE_MISMATCH` errors:
+
+1. **Check flag configuration**: Verify the flag's value type in Mixpanel matches how you are evaluating it:
+   ```kotlin
+   // If flag value is a string like "true", use getStringValue, not getBooleanValue
+   val value = client.getStringValue("my-flag", "default")
+   ```
+
+2. **Use getObjectValue for complex types**: For JSON objects or arrays, use `getObjectValue`.
+
+### Exposure Events Not Tracking
+
+If `$experiment_started` events are not appearing in Mixpanel:
+
+1. **Verify Mixpanel tracking is working**: Test that other Mixpanel events are being tracked successfully.
+
+2. **Check for duplicate evaluations**: Mixpanel only tracks the first exposure per flag per session to avoid duplicate events.
+
+### Flags Not Updating After Context Change
+
+When you update the OpenFeature context, the provider needs to fetch new flag values:
+
+```kotlin
+// Update context and wait for new flags
+OpenFeatureAPI.setContext(ImmutableContext(
+    attributes = mutableMapOf("plan" to Value.String("premium"))
+))
+
+// Now evaluate with new context
+val value = client.getBooleanValue("premium-feature", false)
+```
+
+If flags still are not updating, check that your targeting rules in Mixpanel are configured to use the context properties you are setting.
+
+## License
+
+Apache-2.0

--- a/openfeature-provider/build.gradle.kts
+++ b/openfeature-provider/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.mixpanel.android.openfeature"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencies {
+    implementation(project(":"))
+    implementation("dev.openfeature:kotlin-sdk-android:0.7.2")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+}

--- a/openfeature-provider/build.gradle.kts
+++ b/openfeature-provider/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("maven-publish")
 }
 
 android {
@@ -25,11 +26,28 @@ android {
             isIncludeAndroidResources = true
         }
     }
+
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId = property("GROUP") as String
+                artifactId = "mixpanel-android-openfeature"
+                version = property("VERSION_NAME") as String
+            }
+        }
     }
 }
 

--- a/openfeature-provider/src/main/AndroidManifest.xml
+++ b/openfeature-provider/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -58,7 +58,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         try {
             variant = flags.getVariantSync(key, fallback)
         } catch (e: Exception) {
-            return generalError(defaultValue)
+            return generalError(defaultValue, e.message)
         }
 
         if (variant === fallback) {
@@ -87,7 +87,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         try {
             variant = flags.getVariantSync(key, fallback)
         } catch (e: Exception) {
-            return generalError(defaultValue)
+            return generalError(defaultValue, e.message)
         }
 
         if (variant === fallback) {
@@ -116,7 +116,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         try {
             variant = flags.getVariantSync(key, fallback)
         } catch (e: Exception) {
-            return generalError(defaultValue)
+            return generalError(defaultValue, e.message)
         }
 
         if (variant === fallback) {
@@ -158,7 +158,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         try {
             variant = flags.getVariantSync(key, fallback)
         } catch (e: Exception) {
-            return generalError(defaultValue)
+            return generalError(defaultValue, e.message)
         }
 
         if (variant === fallback) {
@@ -187,7 +187,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         try {
             variant = flags.getVariantSync(key, fallback)
         } catch (e: Exception) {
-            return generalError(defaultValue)
+            return generalError(defaultValue, e.message)
         }
 
         if (variant === fallback) {
@@ -240,10 +240,11 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         )
     }
 
-    private fun <T> generalError(defaultValue: T): ProviderEvaluation<T> {
+    private fun <T> generalError(defaultValue: T, message: String? = null): ProviderEvaluation<T> {
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.GENERAL,
+            errorMessage = message ?: "Unexpected error during flag evaluation",
             reason = Reason.ERROR.toString()
         )
     }
@@ -270,7 +271,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         val map = mutableMapOf<String, Any?>()
         val targetingKey = ctx.getTargetingKey()
         if (targetingKey.isNotEmpty()) {
-            map["targeting_key"] = targetingKey
+            map["targetingKey"] = targetingKey
         }
         for (key in ctx.keySet()) {
             map[key] = valueToAny(ctx.getValue(key))

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -10,6 +10,8 @@ import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.Reason
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * An OpenFeature provider backed by the Mixpanel Android SDK's feature flags.
@@ -23,11 +25,19 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
     override val metadata: ProviderMetadata = MixpanelProviderMetadata()
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        // No-op: the Mixpanel SDK manages its own initialization.
+        if (initialContext != null) {
+            val contextMap = evaluationContextToMap(initialContext)
+            suspendCoroutine<Unit> { continuation ->
+                flags.setContext(contextMap) { continuation.resume(Unit) }
+            }
+        }
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        // No-op: context is managed by the Mixpanel SDK via mixpanel.identify().
+        val contextMap = evaluationContextToMap(newContext)
+        suspendCoroutine<Unit> { continuation ->
+            flags.setContext(contextMap) { continuation.resume(Unit) }
+        }
     }
 
     override fun shutdown() {
@@ -52,7 +62,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         if (variant === fallback) {
-            return flagNotFound(defaultValue)
+            return flagNotFound(key, defaultValue)
         }
 
         val value = variant.value
@@ -60,7 +70,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             return success(value, variant.key)
         }
 
-        return typeMismatch(defaultValue)
+        return typeMismatch(key, "Boolean", value, defaultValue)
     }
 
     override fun getStringEvaluation(
@@ -81,7 +91,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         if (variant === fallback) {
-            return flagNotFound(defaultValue)
+            return flagNotFound(key, defaultValue)
         }
 
         val value = variant.value
@@ -89,7 +99,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             return success(value, variant.key)
         }
 
-        return typeMismatch(defaultValue)
+        return typeMismatch(key, "String", value, defaultValue)
     }
 
     override fun getIntegerEvaluation(
@@ -110,7 +120,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         if (variant === fallback) {
-            return flagNotFound(defaultValue)
+            return flagNotFound(key, defaultValue)
         }
 
         val value = variant.value
@@ -131,7 +141,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             }
         }
 
-        return typeMismatch(defaultValue)
+        return typeMismatch(key, "Int", value, defaultValue)
     }
 
     override fun getDoubleEvaluation(
@@ -152,7 +162,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         if (variant === fallback) {
-            return flagNotFound(defaultValue)
+            return flagNotFound(key, defaultValue)
         }
 
         val value = variant.value
@@ -160,7 +170,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             return success(value.toDouble(), variant.key)
         }
 
-        return typeMismatch(defaultValue)
+        return typeMismatch(key, "Double", value, defaultValue)
     }
 
     override fun getObjectEvaluation(
@@ -181,7 +191,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         if (variant === fallback) {
-            return flagNotFound(defaultValue)
+            return flagNotFound(key, defaultValue)
         }
 
         return success(toValue(variant.value), variant.key)
@@ -201,23 +211,32 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.PROVIDER_NOT_READY,
-            reason = Reason.ERROR.toString()
+            reason = Reason.ERROR.toString(),
+            errorMessage = "Flags not ready"
         )
     }
 
-    private fun <T> flagNotFound(defaultValue: T): ProviderEvaluation<T> {
+    private fun <T> flagNotFound(flagKey: String, defaultValue: T): ProviderEvaluation<T> {
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.FLAG_NOT_FOUND,
-            reason = Reason.ERROR.toString()
+            reason = Reason.ERROR.toString(),
+            errorMessage = "Flag \"$flagKey\" not found"
         )
     }
 
-    private fun <T> typeMismatch(defaultValue: T): ProviderEvaluation<T> {
+    private fun <T> typeMismatch(
+        flagKey: String,
+        expectedType: String,
+        actualValue: Any?,
+        defaultValue: T
+    ): ProviderEvaluation<T> {
+        val actualType = actualValue?.let { it::class.simpleName } ?: "null"
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.TYPE_MISMATCH,
-            reason = Reason.ERROR.toString()
+            reason = Reason.ERROR.toString(),
+            errorMessage = "Flag \"$flagKey\" value is not a $expectedType: $actualType"
         )
     }
 
@@ -238,7 +257,38 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             is Long -> Value.Integer(obj.toInt())
             is Double -> Value.Double(obj)
             is Float -> Value.Double(obj.toDouble())
+            is Map<*, *> -> Value.Structure(
+                obj.entries.associate { (k, v) -> k.toString() to toValue(v) }
+            )
+            is List<*> -> Value.List(obj.map { toValue(it) })
+            is Iterable<*> -> Value.List(obj.map { toValue(it) })
             else -> Value.String(obj.toString())
+        }
+    }
+
+    private fun evaluationContextToMap(ctx: EvaluationContext): Map<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        val targetingKey = ctx.getTargetingKey()
+        if (targetingKey.isNotEmpty()) {
+            map["targeting_key"] = targetingKey
+        }
+        for (key in ctx.keySet()) {
+            map[key] = valueToAny(ctx.getValue(key))
+        }
+        return map
+    }
+
+    private fun valueToAny(value: Value?): Any? {
+        if (value == null || value.isNull()) return null
+        return when (value) {
+            is Value.Boolean -> value.asBoolean()
+            is Value.String -> value.asString()
+            is Value.Integer -> value.asInteger()
+            is Value.Double -> value.asDouble()
+            is Value.List -> value.asList()?.map { valueToAny(it) }
+            is Value.Structure -> value.asStructure()?.mapValues { (_, v) -> valueToAny(v) }
+            is Value.Instant -> value.asString()
+            else -> value.asString()
         }
     }
 

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -34,6 +34,9 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
      * Convenience constructor that creates a [MixpanelAPI] instance internally and
      * extracts its [MixpanelAPI.Flags] for use as the backing flag source.
      *
+     * The created instance is accessible via the [mixpanel] property for calling
+     * [MixpanelAPI.identify] and [MixpanelAPI.track].
+     *
      * @param context The application context.
      * @param token Your Mixpanel project token.
      * @param options A [MixpanelOptions] instance to configure the Mixpanel SDK.

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -44,7 +44,12 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant = flags.getVariantSync(key, fallback)
+        val variant: MixpanelFlagVariant
+        try {
+            variant = flags.getVariantSync(key, fallback)
+        } catch (e: Exception) {
+            return generalError(defaultValue)
+        }
 
         if (variant === fallback) {
             return flagNotFound(defaultValue)
@@ -68,7 +73,12 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant = flags.getVariantSync(key, fallback)
+        val variant: MixpanelFlagVariant
+        try {
+            variant = flags.getVariantSync(key, fallback)
+        } catch (e: Exception) {
+            return generalError(defaultValue)
+        }
 
         if (variant === fallback) {
             return flagNotFound(defaultValue)
@@ -92,7 +102,12 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant = flags.getVariantSync(key, fallback)
+        val variant: MixpanelFlagVariant
+        try {
+            variant = flags.getVariantSync(key, fallback)
+        } catch (e: Exception) {
+            return generalError(defaultValue)
+        }
 
         if (variant === fallback) {
             return flagNotFound(defaultValue)
@@ -129,7 +144,12 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant = flags.getVariantSync(key, fallback)
+        val variant: MixpanelFlagVariant
+        try {
+            variant = flags.getVariantSync(key, fallback)
+        } catch (e: Exception) {
+            return generalError(defaultValue)
+        }
 
         if (variant === fallback) {
             return flagNotFound(defaultValue)
@@ -153,7 +173,12 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         }
 
         val fallback = MixpanelFlagVariant("", null)
-        val variant = flags.getVariantSync(key, fallback)
+        val variant: MixpanelFlagVariant
+        try {
+            variant = flags.getVariantSync(key, fallback)
+        } catch (e: Exception) {
+            return generalError(defaultValue)
+        }
 
         if (variant === fallback) {
             return flagNotFound(defaultValue)
@@ -192,6 +217,14 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.TYPE_MISMATCH,
+            reason = Reason.ERROR.toString()
+        )
+    }
+
+    private fun <T> generalError(defaultValue: T): ProviderEvaluation<T> {
+        return ProviderEvaluation(
+            value = defaultValue,
+            errorCode = ErrorCode.GENERAL,
             reason = Reason.ERROR.toString()
         )
     }

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -195,7 +195,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         return ProviderEvaluation(
             value = value,
             variant = variant,
-            reason = Reason.STATIC.toString()
+            reason = Reason.TARGETING_MATCH.toString()
         )
     }
 
@@ -212,7 +212,7 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         return ProviderEvaluation(
             value = defaultValue,
             errorCode = ErrorCode.FLAG_NOT_FOUND,
-            reason = Reason.ERROR.toString(),
+            reason = Reason.DEFAULT.toString(),
             errorMessage = "Flag \"$flagKey\" not found"
         )
     }

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -42,9 +42,11 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
      * @param options A [MixpanelOptions] instance to configure the Mixpanel SDK.
      */
     constructor(context: Context, token: String, options: MixpanelOptions) : this(
-        MixpanelAPI.getInstance(context, token, false, options).getFlags()
-    ) {
-        mixpanel = MixpanelAPI.getInstance(context, token, false, options)
+        MixpanelAPI.getInstance(context, token, false, options)
+    )
+
+    private constructor(mixpanelAPI: MixpanelAPI) : this(mixpanelAPI.getFlags()) {
+        mixpanel = mixpanelAPI
     }
 
     override val hooks: List<Hook<*>> = emptyList()

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -1,7 +1,9 @@
 package com.mixpanel.android.openfeature
 
+import android.content.Context
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import com.mixpanel.android.mpmetrics.MixpanelFlagVariant
+import com.mixpanel.android.mpmetrics.MixpanelOptions
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
@@ -19,6 +21,28 @@ import kotlin.coroutines.suspendCoroutine
  * @param flags The [MixpanelAPI.Flags] instance obtained via `mixpanel.getFlags()`.
  */
 class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
+
+    /**
+     * The underlying [MixpanelAPI] instance, if this provider was created via the
+     * convenience constructor. Users need this to call [MixpanelAPI.identify] and
+     * [MixpanelAPI.track] on the underlying instance.
+     */
+    var mixpanel: MixpanelAPI? = null
+        private set
+
+    /**
+     * Convenience constructor that creates a [MixpanelAPI] instance internally and
+     * extracts its [MixpanelAPI.Flags] for use as the backing flag source.
+     *
+     * @param context The application context.
+     * @param token Your Mixpanel project token.
+     * @param options A [MixpanelOptions] instance to configure the Mixpanel SDK.
+     */
+    constructor(context: Context, token: String, options: MixpanelOptions) : this(
+        MixpanelAPI.getInstance(context, token, false, options).getFlags()
+    ) {
+        mixpanel = MixpanelAPI.getInstance(context, token, false, options)
+    }
 
     override val hooks: List<Hook<*>> = emptyList()
 

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -26,15 +26,16 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         if (initialContext != null) {
-            val contextMap = evaluationContextToMap(initialContext)
-            suspendCoroutine<Unit> { continuation ->
-                flags.setContext(contextMap) { continuation.resume(Unit) }
-            }
+            applyContext(initialContext)
         }
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        val contextMap = evaluationContextToMap(newContext)
+        applyContext(newContext)
+    }
+
+    private suspend fun applyContext(context: EvaluationContext) {
+        val contextMap = evaluationContextToMap(context)
         suspendCoroutine<Unit> { continuation ->
             flags.setContext(contextMap) { continuation.resume(Unit) }
         }
@@ -49,28 +50,14 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         defaultValue: Boolean,
         context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
-        if (!flags.areFlagsReady()) {
-            return providerNotReady(defaultValue)
+        return resolveFlag(key, defaultValue) { variant ->
+            val value = variant.value
+            if (value is Boolean) {
+                success(value, variant.key)
+            } else {
+                typeMismatch(key, "Boolean", value, defaultValue)
+            }
         }
-
-        val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant: MixpanelFlagVariant
-        try {
-            variant = flags.getVariantSync(key, fallback)
-        } catch (e: Exception) {
-            return generalError(defaultValue, e.message)
-        }
-
-        if (variant === fallback) {
-            return flagNotFound(key, defaultValue)
-        }
-
-        val value = variant.value
-        if (value is Boolean) {
-            return success(value, variant.key)
-        }
-
-        return typeMismatch(key, "Boolean", value, defaultValue)
     }
 
     override fun getStringEvaluation(
@@ -78,28 +65,14 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         defaultValue: String,
         context: EvaluationContext?
     ): ProviderEvaluation<String> {
-        if (!flags.areFlagsReady()) {
-            return providerNotReady(defaultValue)
+        return resolveFlag(key, defaultValue) { variant ->
+            val value = variant.value
+            if (value is String) {
+                success(value, variant.key)
+            } else {
+                typeMismatch(key, "String", value, defaultValue)
+            }
         }
-
-        val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant: MixpanelFlagVariant
-        try {
-            variant = flags.getVariantSync(key, fallback)
-        } catch (e: Exception) {
-            return generalError(defaultValue, e.message)
-        }
-
-        if (variant === fallback) {
-            return flagNotFound(key, defaultValue)
-        }
-
-        val value = variant.value
-        if (value is String) {
-            return success(value, variant.key)
-        }
-
-        return typeMismatch(key, "String", value, defaultValue)
     }
 
     override fun getIntegerEvaluation(
@@ -107,41 +80,30 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
-        if (!flags.areFlagsReady()) {
-            return providerNotReady(defaultValue)
-        }
-
-        val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant: MixpanelFlagVariant
-        try {
-            variant = flags.getVariantSync(key, fallback)
-        } catch (e: Exception) {
-            return generalError(defaultValue, e.message)
-        }
-
-        if (variant === fallback) {
-            return flagNotFound(key, defaultValue)
-        }
-
-        val value = variant.value
-        val variantKey = variant.key
-        when (value) {
-            is Int -> return success(value, variantKey)
-            is Long -> return success(value.toInt(), variantKey)
-            is Double -> {
-                if (value == Math.floor(value) && !value.isInfinite()) {
-                    return success(value.toInt(), variantKey)
+        return resolveFlag(key, defaultValue) { variant ->
+            val value = variant.value
+            val variantKey = variant.key
+            when (value) {
+                is Int -> success(value, variantKey)
+                is Long -> success(value.toInt(), variantKey)
+                is Double -> {
+                    if (value == Math.floor(value) && !value.isInfinite()) {
+                        success(value.toInt(), variantKey)
+                    } else {
+                        typeMismatch(key, "Int", value, defaultValue)
+                    }
                 }
-            }
-            is Float -> {
-                val d = value.toDouble()
-                if (d == Math.floor(d) && !d.isInfinite()) {
-                    return success(value.toInt(), variantKey)
+                is Float -> {
+                    val d = value.toDouble()
+                    if (d == Math.floor(d) && !d.isInfinite()) {
+                        success(value.toInt(), variantKey)
+                    } else {
+                        typeMismatch(key, "Int", value, defaultValue)
+                    }
                 }
+                else -> typeMismatch(key, "Int", value, defaultValue)
             }
         }
-
-        return typeMismatch(key, "Int", value, defaultValue)
     }
 
     override fun getDoubleEvaluation(
@@ -149,28 +111,14 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         defaultValue: Double,
         context: EvaluationContext?
     ): ProviderEvaluation<Double> {
-        if (!flags.areFlagsReady()) {
-            return providerNotReady(defaultValue)
+        return resolveFlag(key, defaultValue) { variant ->
+            val value = variant.value
+            if (value is Number) {
+                success(value.toDouble(), variant.key)
+            } else {
+                typeMismatch(key, "Double", value, defaultValue)
+            }
         }
-
-        val fallback = MixpanelFlagVariant(defaultValue as Any)
-        val variant: MixpanelFlagVariant
-        try {
-            variant = flags.getVariantSync(key, fallback)
-        } catch (e: Exception) {
-            return generalError(defaultValue, e.message)
-        }
-
-        if (variant === fallback) {
-            return flagNotFound(key, defaultValue)
-        }
-
-        val value = variant.value
-        if (value is Number) {
-            return success(value.toDouble(), variant.key)
-        }
-
-        return typeMismatch(key, "Double", value, defaultValue)
     }
 
     override fun getObjectEvaluation(
@@ -178,26 +126,41 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
         defaultValue: Value,
         context: EvaluationContext?
     ): ProviderEvaluation<Value> {
+        return resolveFlag(key, defaultValue, fallbackVariant = MixpanelFlagVariant("", null)) { variant ->
+            success(toValue(variant.value), variant.key)
+        }
+    }
+
+    // --- Helpers ---
+
+    /**
+     * Shared resolution logic for all flag evaluation methods.
+     * Handles readiness checks, fallback creation, exception handling, and flag-not-found detection.
+     * The [coerce] block is only called when a flag variant is successfully found.
+     */
+    private fun <T> resolveFlag(
+        key: String,
+        defaultValue: T,
+        fallbackVariant: MixpanelFlagVariant = MixpanelFlagVariant(defaultValue as Any),
+        coerce: (MixpanelFlagVariant) -> ProviderEvaluation<T>
+    ): ProviderEvaluation<T> {
         if (!flags.areFlagsReady()) {
             return providerNotReady(defaultValue)
         }
 
-        val fallback = MixpanelFlagVariant("", null)
         val variant: MixpanelFlagVariant
         try {
-            variant = flags.getVariantSync(key, fallback)
+            variant = flags.getVariantSync(key, fallbackVariant)
         } catch (e: Exception) {
             return generalError(defaultValue, e.message)
         }
 
-        if (variant === fallback) {
+        if (variant === fallbackVariant) {
             return flagNotFound(key, defaultValue)
         }
 
-        return success(toValue(variant.value), variant.key)
+        return coerce(variant)
     }
-
-    // --- Helpers ---
 
     private fun <T> success(value: T, variant: String? = null): ProviderEvaluation<T> {
         return ProviderEvaluation(
@@ -261,7 +224,6 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
             is Map<*, *> -> Value.Structure(
                 obj.entries.associate { (k, v) -> k.toString() to toValue(v) }
             )
-            is List<*> -> Value.List(obj.map { toValue(it) })
             is Iterable<*> -> Value.List(obj.map { toValue(it) })
             else -> Value.String(obj.toString())
         }

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -1,0 +1,215 @@
+package com.mixpanel.android.openfeature
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import com.mixpanel.android.mpmetrics.MixpanelFlagVariant
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.FeatureProvider
+import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.ProviderEvaluation
+import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+
+/**
+ * An OpenFeature provider backed by the Mixpanel Android SDK's feature flags.
+ *
+ * @param flags The [MixpanelAPI.Flags] instance obtained via `mixpanel.getFlags()`.
+ */
+class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
+
+    override val hooks: List<Hook<*>> = emptyList()
+
+    override val metadata: ProviderMetadata = MixpanelProviderMetadata()
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        // No-op: the Mixpanel SDK manages its own initialization.
+    }
+
+    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+        // No-op: context is managed by the Mixpanel SDK via mixpanel.identify().
+    }
+
+    override fun shutdown() {
+        // No-op: the Mixpanel SDK manages its own lifecycle.
+    }
+
+    override fun getBooleanEvaluation(
+        key: String,
+        defaultValue: Boolean,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Boolean> {
+        if (!flags.areFlagsReady()) {
+            return providerNotReady(defaultValue)
+        }
+
+        val fallback = MixpanelFlagVariant(defaultValue as Any)
+        val variant = flags.getVariantSync(key, fallback)
+
+        if (variant === fallback) {
+            return flagNotFound(defaultValue)
+        }
+
+        val value = variant.value
+        if (value is Boolean) {
+            return success(value, variant.key)
+        }
+
+        return typeMismatch(defaultValue)
+    }
+
+    override fun getStringEvaluation(
+        key: String,
+        defaultValue: String,
+        context: EvaluationContext?
+    ): ProviderEvaluation<String> {
+        if (!flags.areFlagsReady()) {
+            return providerNotReady(defaultValue)
+        }
+
+        val fallback = MixpanelFlagVariant(defaultValue as Any)
+        val variant = flags.getVariantSync(key, fallback)
+
+        if (variant === fallback) {
+            return flagNotFound(defaultValue)
+        }
+
+        val value = variant.value
+        if (value is String) {
+            return success(value, variant.key)
+        }
+
+        return typeMismatch(defaultValue)
+    }
+
+    override fun getIntegerEvaluation(
+        key: String,
+        defaultValue: Int,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Int> {
+        if (!flags.areFlagsReady()) {
+            return providerNotReady(defaultValue)
+        }
+
+        val fallback = MixpanelFlagVariant(defaultValue as Any)
+        val variant = flags.getVariantSync(key, fallback)
+
+        if (variant === fallback) {
+            return flagNotFound(defaultValue)
+        }
+
+        val value = variant.value
+        val variantKey = variant.key
+        when (value) {
+            is Int -> return success(value, variantKey)
+            is Long -> return success(value.toInt(), variantKey)
+            is Double -> {
+                if (value == Math.floor(value) && !value.isInfinite()) {
+                    return success(value.toInt(), variantKey)
+                }
+            }
+            is Float -> {
+                val d = value.toDouble()
+                if (d == Math.floor(d) && !d.isInfinite()) {
+                    return success(value.toInt(), variantKey)
+                }
+            }
+        }
+
+        return typeMismatch(defaultValue)
+    }
+
+    override fun getDoubleEvaluation(
+        key: String,
+        defaultValue: Double,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Double> {
+        if (!flags.areFlagsReady()) {
+            return providerNotReady(defaultValue)
+        }
+
+        val fallback = MixpanelFlagVariant(defaultValue as Any)
+        val variant = flags.getVariantSync(key, fallback)
+
+        if (variant === fallback) {
+            return flagNotFound(defaultValue)
+        }
+
+        val value = variant.value
+        if (value is Number) {
+            return success(value.toDouble(), variant.key)
+        }
+
+        return typeMismatch(defaultValue)
+    }
+
+    override fun getObjectEvaluation(
+        key: String,
+        defaultValue: Value,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Value> {
+        if (!flags.areFlagsReady()) {
+            return providerNotReady(defaultValue)
+        }
+
+        val fallback = MixpanelFlagVariant("", null)
+        val variant = flags.getVariantSync(key, fallback)
+
+        if (variant === fallback) {
+            return flagNotFound(defaultValue)
+        }
+
+        return success(toValue(variant.value), variant.key)
+    }
+
+    // --- Helpers ---
+
+    private fun <T> success(value: T, variant: String? = null): ProviderEvaluation<T> {
+        return ProviderEvaluation(
+            value = value,
+            variant = variant,
+            reason = Reason.STATIC.toString()
+        )
+    }
+
+    private fun <T> providerNotReady(defaultValue: T): ProviderEvaluation<T> {
+        return ProviderEvaluation(
+            value = defaultValue,
+            errorCode = ErrorCode.PROVIDER_NOT_READY,
+            reason = Reason.ERROR.toString()
+        )
+    }
+
+    private fun <T> flagNotFound(defaultValue: T): ProviderEvaluation<T> {
+        return ProviderEvaluation(
+            value = defaultValue,
+            errorCode = ErrorCode.FLAG_NOT_FOUND,
+            reason = Reason.ERROR.toString()
+        )
+    }
+
+    private fun <T> typeMismatch(defaultValue: T): ProviderEvaluation<T> {
+        return ProviderEvaluation(
+            value = defaultValue,
+            errorCode = ErrorCode.TYPE_MISMATCH,
+            reason = Reason.ERROR.toString()
+        )
+    }
+
+    private fun toValue(obj: Any?): Value {
+        return when (obj) {
+            null -> Value.Null
+            is Boolean -> Value.Boolean(obj)
+            is String -> Value.String(obj)
+            is Int -> Value.Integer(obj)
+            is Long -> Value.Integer(obj.toInt())
+            is Double -> Value.Double(obj)
+            is Float -> Value.Double(obj.toDouble())
+            else -> Value.String(obj.toString())
+        }
+    }
+
+    private class MixpanelProviderMetadata : ProviderMetadata {
+        override val name: String = "mixpanel-provider"
+    }
+}

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -324,6 +324,68 @@ class MixpanelProviderTest {
         assertEquals(emptyList<Any>(), provider.hooks)
     }
 
+    // --- Error: SDK exception handling ---
+
+    @Test
+    fun `returns GENERAL error when getVariantSync throws for boolean`() {
+        setupFlagException("error-flag")
+        val result = provider.getBooleanEvaluation("error-flag", true, ImmutableContext())
+        assertEquals(true, result.value)
+        assertEquals(ErrorCode.GENERAL, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns GENERAL error when getVariantSync throws for string`() {
+        setupFlagException("error-flag")
+        val result = provider.getStringEvaluation("error-flag", "fallback", ImmutableContext())
+        assertEquals("fallback", result.value)
+        assertEquals(ErrorCode.GENERAL, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns GENERAL error when getVariantSync throws for integer`() {
+        setupFlagException("error-flag")
+        val result = provider.getIntegerEvaluation("error-flag", 99, ImmutableContext())
+        assertEquals(99, result.value)
+        assertEquals(ErrorCode.GENERAL, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns GENERAL error when getVariantSync throws for double`() {
+        setupFlagException("error-flag")
+        val result = provider.getDoubleEvaluation("error-flag", 1.5, ImmutableContext())
+        assertEquals(1.5, result.value!!, 0.001)
+        assertEquals(ErrorCode.GENERAL, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns GENERAL error when getVariantSync throws for object`() {
+        setupFlagException("error-flag")
+        val defaultValue = Value.String("fallback")
+        val result = provider.getObjectEvaluation("error-flag", defaultValue, ImmutableContext())
+        assertEquals(defaultValue, result.value)
+        assertEquals(ErrorCode.GENERAL, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    // --- Null variant key ---
+
+    @Test
+    fun `null variant key is included as null in evaluation result`() {
+        val variant = NullKeyVariantFactory.create("value")
+        `when`(mockFlags.getVariantSync(eq("flag"), any(MixpanelFlagVariant::class.java)))
+            .thenReturn(variant)
+        val result = provider.getStringEvaluation("flag", "default", ImmutableContext())
+        assertEquals("value", result.value)
+        assertNull(result.variant)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
     // --- Variant key passthrough ---
 
     @Test
@@ -368,4 +430,14 @@ class MixpanelProviderTest {
         `when`(mockFlags.getVariantSync(eq(flagName), any(MixpanelFlagVariant::class.java)))
             .thenAnswer { invocation -> invocation.getArgument(1) }
     }
+
+    /**
+     * Sets up the mock so that getVariantSync throws a RuntimeException,
+     * simulating an SDK error.
+     */
+    private fun setupFlagException(flagName: String) {
+        `when`(mockFlags.getVariantSync(eq(flagName), any(MixpanelFlagVariant::class.java)))
+            .thenThrow(RuntimeException("SDK internal error"))
+    }
+
 }

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -1,5 +1,6 @@
 package com.mixpanel.android.openfeature
 
+import com.mixpanel.android.mpmetrics.FlagCompletionCallback
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import com.mixpanel.android.mpmetrics.MixpanelFlagVariant
 import dev.openfeature.kotlin.sdk.ImmutableContext
@@ -14,6 +15,8 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.any
 import org.mockito.Mockito.eq
+import org.mockito.kotlin.whenever
+import org.mockito.kotlin.doAnswer
 
 class MixpanelProviderTest {
 
@@ -24,6 +27,12 @@ class MixpanelProviderTest {
     fun setUp() {
         mockFlags = mock(MixpanelAPI.Flags::class.java)
         `when`(mockFlags.areFlagsReady()).thenReturn(true)
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val callback = invocation.getArgument<FlagCompletionCallback<Boolean>>(1)
+            callback.onComplete(true)
+            null
+        }.whenever(mockFlags).setContext(any(), any())
         provider = MixpanelProvider(mockFlags)
     }
 

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -1,0 +1,371 @@
+package com.mixpanel.android.openfeature
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import com.mixpanel.android.mpmetrics.MixpanelFlagVariant
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
+import org.mockito.Mockito.eq
+
+class MixpanelProviderTest {
+
+    private lateinit var mockFlags: MixpanelAPI.Flags
+    private lateinit var provider: MixpanelProvider
+
+    @Before
+    fun setUp() {
+        mockFlags = mock(MixpanelAPI.Flags::class.java)
+        `when`(mockFlags.areFlagsReady()).thenReturn(true)
+        provider = MixpanelProvider(mockFlags)
+    }
+
+    // --- Metadata ---
+
+    @Test
+    fun `metadata name is mixpanel-provider`() {
+        assertEquals("mixpanel-provider", provider.metadata.name)
+    }
+
+    // --- Boolean evaluation ---
+
+    @Test
+    fun `resolves boolean flag to true`() {
+        setupFlag("bool-flag", true)
+        val result = provider.getBooleanEvaluation("bool-flag", false, ImmutableContext())
+        assertEquals(true, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    @Test
+    fun `resolves boolean flag to false`() {
+        setupFlag("bool-flag", false)
+        val result = provider.getBooleanEvaluation("bool-flag", true, ImmutableContext())
+        assertEquals(false, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    // --- String evaluation ---
+
+    @Test
+    fun `resolves string flag`() {
+        setupFlag("string-flag", "hello")
+        val result = provider.getStringEvaluation("string-flag", "default", ImmutableContext())
+        assertEquals("hello", result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    // --- Integer evaluation ---
+
+    @Test
+    fun `resolves integer flag`() {
+        setupFlag("int-flag", 42)
+        val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
+        assertEquals(42, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    @Test
+    fun `resolves integer flag from long value`() {
+        setupFlag("int-flag", 42L)
+        val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
+        assertEquals(42, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    @Test
+    fun `resolves integer flag from double with no fractional part`() {
+        setupFlag("int-flag", 42.0)
+        val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
+        assertEquals(42, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    // --- Double evaluation ---
+
+    @Test
+    fun `resolves double flag`() {
+        setupFlag("double-flag", 3.14)
+        val result = provider.getDoubleEvaluation("double-flag", 0.0, ImmutableContext())
+        assertEquals(3.14, result.value!!, 0.001)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    @Test
+    fun `resolves double flag from integer value`() {
+        setupFlag("double-flag", 42)
+        val result = provider.getDoubleEvaluation("double-flag", 0.0, ImmutableContext())
+        assertEquals(42.0, result.value!!, 0.001)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    // --- Object evaluation ---
+
+    @Test
+    fun `resolves object flag with string value`() {
+        setupFlag("obj-flag", "hello")
+        val defaultValue = Value.Null
+        val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
+        assertEquals(Value.String("hello"), result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    @Test
+    fun `resolves object flag with boolean value`() {
+        setupFlag("obj-flag", true)
+        val defaultValue = Value.Null
+        val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
+        assertEquals(Value.Boolean(true), result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    @Test
+    fun `resolves object flag with integer value`() {
+        setupFlag("obj-flag", 42)
+        val defaultValue = Value.Null
+        val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
+        assertEquals(Value.Integer(42), result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    @Test
+    fun `resolves object flag with double value`() {
+        setupFlag("obj-flag", 3.14)
+        val defaultValue = Value.Null
+        val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
+        assertEquals(Value.Double(3.14), result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    @Test
+    fun `resolves object flag with null value`() {
+        setupFlag("obj-flag", null)
+        val defaultValue = Value.String("default")
+        val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
+        assertEquals(Value.Null, result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+    }
+
+    // --- Error: FLAG_NOT_FOUND ---
+
+    @Test
+    fun `returns FLAG_NOT_FOUND error when flag does not exist for boolean`() {
+        setupFlagNotFound("missing-flag")
+        val result = provider.getBooleanEvaluation("missing-flag", true, ImmutableContext())
+        assertEquals(true, result.value)
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns FLAG_NOT_FOUND error when flag does not exist for string`() {
+        setupFlagNotFound("missing-flag")
+        val result = provider.getStringEvaluation("missing-flag", "fallback", ImmutableContext())
+        assertEquals("fallback", result.value)
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns FLAG_NOT_FOUND error when flag does not exist for integer`() {
+        setupFlagNotFound("missing-flag")
+        val result = provider.getIntegerEvaluation("missing-flag", 99, ImmutableContext())
+        assertEquals(99, result.value)
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns FLAG_NOT_FOUND error when flag does not exist for double`() {
+        setupFlagNotFound("missing-flag")
+        val result = provider.getDoubleEvaluation("missing-flag", 1.5, ImmutableContext())
+        assertEquals(1.5, result.value!!, 0.001)
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns FLAG_NOT_FOUND error when flag does not exist for object`() {
+        setupFlagNotFound("missing-flag")
+        val defaultValue = Value.String("fallback")
+        val result = provider.getObjectEvaluation("missing-flag", defaultValue, ImmutableContext())
+        assertEquals(defaultValue, result.value)
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    // --- Error: TYPE_MISMATCH ---
+
+    @Test
+    fun `returns TYPE_MISMATCH when boolean requested but string returned`() {
+        setupFlag("string-flag", "not-a-bool")
+        val result = provider.getBooleanEvaluation("string-flag", false, ImmutableContext())
+        assertEquals(false, result.value)
+        assertEquals(ErrorCode.TYPE_MISMATCH, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns TYPE_MISMATCH when string requested but boolean returned`() {
+        setupFlag("bool-flag", true)
+        val result = provider.getStringEvaluation("bool-flag", "default", ImmutableContext())
+        assertEquals("default", result.value)
+        assertEquals(ErrorCode.TYPE_MISMATCH, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns TYPE_MISMATCH when integer requested but string returned`() {
+        setupFlag("string-flag", "not-a-number")
+        val result = provider.getIntegerEvaluation("string-flag", 0, ImmutableContext())
+        assertEquals(0, result.value)
+        assertEquals(ErrorCode.TYPE_MISMATCH, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns TYPE_MISMATCH when double requested but string returned`() {
+        setupFlag("string-flag", "not-a-number")
+        val result = provider.getDoubleEvaluation("string-flag", 0.0, ImmutableContext())
+        assertEquals(0.0, result.value!!, 0.001)
+        assertEquals(ErrorCode.TYPE_MISMATCH, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns TYPE_MISMATCH when integer requested but double with fractional part returned`() {
+        setupFlag("double-flag", 3.14)
+        val result = provider.getIntegerEvaluation("double-flag", 0, ImmutableContext())
+        assertEquals(0, result.value)
+        assertEquals(ErrorCode.TYPE_MISMATCH, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    // --- Error: PROVIDER_NOT_READY ---
+
+    @Test
+    fun `returns PROVIDER_NOT_READY when flags are not ready for boolean`() {
+        `when`(mockFlags.areFlagsReady()).thenReturn(false)
+        val result = provider.getBooleanEvaluation("any-flag", true, ImmutableContext())
+        assertEquals(true, result.value)
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns PROVIDER_NOT_READY when flags are not ready for string`() {
+        `when`(mockFlags.areFlagsReady()).thenReturn(false)
+        val result = provider.getStringEvaluation("any-flag", "default", ImmutableContext())
+        assertEquals("default", result.value)
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns PROVIDER_NOT_READY when flags are not ready for integer`() {
+        `when`(mockFlags.areFlagsReady()).thenReturn(false)
+        val result = provider.getIntegerEvaluation("any-flag", 5, ImmutableContext())
+        assertEquals(5, result.value)
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns PROVIDER_NOT_READY when flags are not ready for double`() {
+        `when`(mockFlags.areFlagsReady()).thenReturn(false)
+        val result = provider.getDoubleEvaluation("any-flag", 2.5, ImmutableContext())
+        assertEquals(2.5, result.value!!, 0.001)
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    @Test
+    fun `returns PROVIDER_NOT_READY when flags are not ready for object`() {
+        `when`(mockFlags.areFlagsReady()).thenReturn(false)
+        val defaultValue = Value.String("default")
+        val result = provider.getObjectEvaluation("any-flag", defaultValue, ImmutableContext())
+        assertEquals(defaultValue, result.value)
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, result.errorCode)
+        assertEquals(Reason.ERROR.toString(), result.reason)
+    }
+
+    // --- Lifecycle ---
+
+    @Test
+    fun `initialize completes without error`() = kotlinx.coroutines.test.runTest {
+        provider.initialize(ImmutableContext())
+    }
+
+    @Test
+    fun `onContextSet completes without error`() = kotlinx.coroutines.test.runTest {
+        provider.onContextSet(ImmutableContext(), ImmutableContext())
+    }
+
+    @Test
+    fun `shutdown is a no-op`() {
+        // Should not throw
+        provider.shutdown()
+    }
+
+    @Test
+    fun `hooks list is empty`() {
+        assertEquals(emptyList<Any>(), provider.hooks)
+    }
+
+    // --- Variant key passthrough ---
+
+    @Test
+    fun `variant key from flag is included in evaluation result`() {
+        setupFlag("flag", "value")
+        val result = provider.getStringEvaluation("flag", "default", ImmutableContext())
+        assertEquals("variant-key", result.variant)
+    }
+
+    // --- Per-evaluation context is ignored ---
+
+    @Test
+    fun `per-evaluation context is ignored and does not affect resolution`() {
+        setupFlag("flag", "resolved-value")
+        val context = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("attr" to Value.String("val"))
+        )
+        val result = provider.getStringEvaluation("flag", "default", context)
+        assertEquals("resolved-value", result.value)
+        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertNull(result.errorCode)
+    }
+
+    // --- Helpers ---
+
+    /**
+     * Sets up the mock so that getVariantSync returns a variant with the given value.
+     * Uses Mockito's Answer to check the fallback argument and return a DIFFERENT object,
+     * ensuring identity check detects the flag was found.
+     */
+    private fun setupFlag(flagName: String, value: Any?) {
+        `when`(mockFlags.getVariantSync(eq(flagName), any(MixpanelFlagVariant::class.java)))
+            .thenReturn(MixpanelFlagVariant("variant-key", value))
+    }
+
+    /**
+     * Sets up the mock so that getVariantSync returns the same fallback object that was passed in,
+     * simulating a flag-not-found scenario (identity check).
+     */
+    private fun setupFlagNotFound(flagName: String) {
+        `when`(mockFlags.getVariantSync(eq(flagName), any(MixpanelFlagVariant::class.java)))
+            .thenAnswer { invocation -> invocation.getArgument(1) }
+    }
+}

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -50,7 +50,7 @@ class MixpanelProviderTest {
         setupFlag("bool-flag", true)
         val result = provider.getBooleanEvaluation("bool-flag", false, ImmutableContext())
         assertEquals(true, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -59,7 +59,7 @@ class MixpanelProviderTest {
         setupFlag("bool-flag", false)
         val result = provider.getBooleanEvaluation("bool-flag", true, ImmutableContext())
         assertEquals(false, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     // --- String evaluation ---
@@ -69,7 +69,7 @@ class MixpanelProviderTest {
         setupFlag("string-flag", "hello")
         val result = provider.getStringEvaluation("string-flag", "default", ImmutableContext())
         assertEquals("hello", result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -80,7 +80,7 @@ class MixpanelProviderTest {
         setupFlag("int-flag", 42)
         val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
         assertEquals(42, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -89,7 +89,7 @@ class MixpanelProviderTest {
         setupFlag("int-flag", 42L)
         val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
         assertEquals(42, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     @Test
@@ -97,7 +97,7 @@ class MixpanelProviderTest {
         setupFlag("int-flag", 42.0)
         val result = provider.getIntegerEvaluation("int-flag", 0, ImmutableContext())
         assertEquals(42, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     // --- Double evaluation ---
@@ -107,7 +107,7 @@ class MixpanelProviderTest {
         setupFlag("double-flag", 3.14)
         val result = provider.getDoubleEvaluation("double-flag", 0.0, ImmutableContext())
         assertEquals(3.14, result.value!!, 0.001)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -116,7 +116,7 @@ class MixpanelProviderTest {
         setupFlag("double-flag", 42)
         val result = provider.getDoubleEvaluation("double-flag", 0.0, ImmutableContext())
         assertEquals(42.0, result.value!!, 0.001)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     // --- Object evaluation ---
@@ -127,7 +127,7 @@ class MixpanelProviderTest {
         val defaultValue = Value.Null
         val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
         assertEquals(Value.String("hello"), result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -137,7 +137,7 @@ class MixpanelProviderTest {
         val defaultValue = Value.Null
         val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
         assertEquals(Value.Boolean(true), result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     @Test
@@ -146,7 +146,7 @@ class MixpanelProviderTest {
         val defaultValue = Value.Null
         val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
         assertEquals(Value.Integer(42), result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     @Test
@@ -155,7 +155,7 @@ class MixpanelProviderTest {
         val defaultValue = Value.Null
         val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
         assertEquals(Value.Double(3.14), result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     @Test
@@ -164,7 +164,7 @@ class MixpanelProviderTest {
         val defaultValue = Value.String("default")
         val result = provider.getObjectEvaluation("obj-flag", defaultValue, ImmutableContext())
         assertEquals(Value.Null, result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
     }
 
     // --- Error: FLAG_NOT_FOUND ---
@@ -175,7 +175,7 @@ class MixpanelProviderTest {
         val result = provider.getBooleanEvaluation("missing-flag", true, ImmutableContext())
         assertEquals(true, result.value)
         assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
-        assertEquals(Reason.ERROR.toString(), result.reason)
+        assertEquals(Reason.DEFAULT.toString(), result.reason)
     }
 
     @Test
@@ -184,7 +184,7 @@ class MixpanelProviderTest {
         val result = provider.getStringEvaluation("missing-flag", "fallback", ImmutableContext())
         assertEquals("fallback", result.value)
         assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
-        assertEquals(Reason.ERROR.toString(), result.reason)
+        assertEquals(Reason.DEFAULT.toString(), result.reason)
     }
 
     @Test
@@ -193,7 +193,7 @@ class MixpanelProviderTest {
         val result = provider.getIntegerEvaluation("missing-flag", 99, ImmutableContext())
         assertEquals(99, result.value)
         assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
-        assertEquals(Reason.ERROR.toString(), result.reason)
+        assertEquals(Reason.DEFAULT.toString(), result.reason)
     }
 
     @Test
@@ -202,7 +202,7 @@ class MixpanelProviderTest {
         val result = provider.getDoubleEvaluation("missing-flag", 1.5, ImmutableContext())
         assertEquals(1.5, result.value!!, 0.001)
         assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
-        assertEquals(Reason.ERROR.toString(), result.reason)
+        assertEquals(Reason.DEFAULT.toString(), result.reason)
     }
 
     @Test
@@ -212,7 +212,7 @@ class MixpanelProviderTest {
         val result = provider.getObjectEvaluation("missing-flag", defaultValue, ImmutableContext())
         assertEquals(defaultValue, result.value)
         assertEquals(ErrorCode.FLAG_NOT_FOUND, result.errorCode)
-        assertEquals(Reason.ERROR.toString(), result.reason)
+        assertEquals(Reason.DEFAULT.toString(), result.reason)
     }
 
     // --- Error: TYPE_MISMATCH ---
@@ -391,7 +391,7 @@ class MixpanelProviderTest {
         val result = provider.getStringEvaluation("flag", "default", ImmutableContext())
         assertEquals("value", result.value)
         assertNull(result.variant)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 
@@ -415,7 +415,7 @@ class MixpanelProviderTest {
         )
         val result = provider.getStringEvaluation("flag", "default", context)
         assertEquals("resolved-value", result.value)
-        assertEquals(Reason.STATIC.toString(), result.reason)
+        assertEquals(Reason.TARGETING_MATCH.toString(), result.reason)
         assertNull(result.errorCode)
     }
 

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/NullKeyVariantFactory.java
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/NullKeyVariantFactory.java
@@ -1,0 +1,24 @@
+package com.mixpanel.android.openfeature;
+
+import com.mixpanel.android.mpmetrics.MixpanelFlagVariant;
+
+import java.lang.reflect.Field;
+
+/**
+ * Test helper that creates a MixpanelFlagVariant with a null key field.
+ * This bypasses the @NonNull annotation to simulate a runtime edge case.
+ */
+class NullKeyVariantFactory {
+
+    static MixpanelFlagVariant create(Object value) {
+        MixpanelFlagVariant variant = new MixpanelFlagVariant("placeholder", value);
+        try {
+            Field keyField = MixpanelFlagVariant.class.getDeclaredField("key");
+            keyField.setAccessible(true);
+            keyField.set(variant, null);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create null-key variant", e);
+        }
+        return variant;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,3 +4,4 @@ plugins {
 
 rootProject.name = "mixpanel-android"
 include ':mixpaneldemo'
+include ':openfeature-provider'

--- a/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -50,6 +50,7 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
   private final Set<String> mTrackedFlags = new HashSet<>();
   private boolean mIsFetching = false;
   private List<FlagCompletionCallback<Boolean>> mFetchCompletionCallbacks = new ArrayList<>();
+  private volatile JSONObject mCustomContext;
   // Track last fetch time and latency for $experiment_started event
   private volatile FetchTiming mFetchTiming = FetchTiming.neverFetched();
 
@@ -109,6 +110,11 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
     mFlagsRecordingEndpoint = delegate.getMPConfig().getFlagsRecordingEndpoint();
     mHttpService = httpService;
     mFlagsConfig = flagsConfig;
+    try {
+      mCustomContext = new JSONObject(flagsConfig.context.toString());
+    } catch (JSONException e) {
+      mCustomContext = new JSONObject();
+    }
 
     // Dedicated thread for serializing access to flags state
     HandlerThread handlerThread =
@@ -126,6 +132,17 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
   public void loadFlags() {
     // Send message to the handler thread to check and potentially fetch
     mHandler.sendMessage(mHandler.obtainMessage(MSG_FETCH_FLAGS_IF_NEEDED));
+  }
+
+  @Override
+  public void setContext(@NonNull Map<String, Object> context, @NonNull FlagCompletionCallback<Boolean> completion) {
+    try {
+      mCustomContext = new JSONObject(context);
+    } catch (Exception e) {
+      MPLog.e(LOGTAG, "Failed to set custom context", e);
+      mCustomContext = new JSONObject();
+    }
+    mHandler.post(() -> _fetchFlagsIfNeeded(completion));
   }
 
   /**
@@ -527,17 +544,15 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
       return;
     }
 
+    if (completion != null) {
+      mFetchCompletionCallbacks.add(completion);
+    }
+
     if (!mIsFetching) {
       mIsFetching = true;
       shouldStartFetch = true;
-      if (completion != null) {
-        mFetchCompletionCallbacks.add(completion);
-      }
     } else {
       MPLog.d(LOGTAG, "Fetch already in progress, queueing completion handler.");
-      if (completion != null) {
-        mFetchCompletionCallbacks.add(completion);
-      }
     }
 
     if (shouldStartFetch) {
@@ -581,7 +596,7 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
     try {
       // 1. Build Query Parameters
       // Defensive copy: we mutate contextJson below (adding distinct_id, device_id)
-      JSONObject contextJson = new JSONObject(mFlagsConfig.context.toString());
+      JSONObject contextJson = new JSONObject(mCustomContext.toString());
       contextJson.put("distinct_id", distinctId);
       if (deviceId != null) {
         contextJson.put("device_id", deviceId);

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -2082,6 +2082,20 @@ public class MixpanelAPI implements FeatureFlagDelegate {
          *                   if fetching fails.
          */
         void getAllVariants(@NonNull FlagCompletionCallback<Map<String, MixpanelFlagVariant>> completion);
+
+        /**
+         * Replaces the current custom flag evaluation context and triggers a flag re-fetch.
+         *
+         * <p>The provided context map entirely replaces any previously set custom context.
+         * After updating the context, a new flag fetch is initiated. The completion callback
+         * is invoked on the main thread once the fetch completes.
+         *
+         * @param context A map of context key-value pairs to send with flag evaluation requests.
+         *                This must not be null.
+         * @param completion A callback invoked on the main thread when the fetch completes.
+         *                   This must not be null.
+         */
+        void setContext(@NonNull Map<String, Object> context, @NonNull FlagCompletionCallback<Boolean> completion);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds a comprehensive README for the `openfeature-provider` package
- Documents installation, quick start, usage examples, flag types, context mapping, API reference, error handling, and troubleshooting
- Includes a note about needing to call `identify()` and `track()` on the same `MixpanelAPI` instance passed to the provider for user identity updates and Runtime Events

*Re-targeted from PR #929 which was accidentally merged into `msiebert-openfeature-provider` instead of `master`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)