### PR TITLE
fix: track() and flags getVariant() sequential ordering

### DIFF
--- a/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -214,31 +214,17 @@ import org.json.JSONObject;
     ////////////////////////////////////////////////////
 
     static class EventDescription extends MixpanelMessageDescription {
-        public EventDescription(String eventName, JSONObject properties, String token) {
-            this(eventName, properties, token, false, new JSONObject(), null);
-        }
 
         public EventDescription(
                 String eventName,
                 JSONObject properties,
                 String token,
                 boolean isAutomatic,
-                JSONObject sessionMetada) {
-            this(eventName, properties, token, isAutomatic, sessionMetada, null);
-        }
-
-        public EventDescription(
-                String eventName,
-                JSONObject properties,
-                String token,
-                boolean isAutomatic,
-                JSONObject sessionMetada,
-                FirstTimeEventListener firstTimeEventListener) {
+                JSONObject sessionMetadata) {
             super(token, properties);
             mEventName = eventName;
             mIsAutomatic = isAutomatic;
-            mSessionMetadata = sessionMetada;
-            mFirstTimeEventListener = firstTimeEventListener;
+            mSessionMetadata = sessionMetadata;
         }
 
         public String getEventName() {
@@ -257,14 +243,9 @@ import org.json.JSONObject;
             return mIsAutomatic;
         }
 
-        public FirstTimeEventListener getFirstTimeEventListener() {
-            return mFirstTimeEventListener;
-        }
-
         private final String mEventName;
         private final JSONObject mSessionMetadata;
         private final boolean mIsAutomatic;
-        private final FirstTimeEventListener mFirstTimeEventListener;
     }
 
     static class PeopleDescription extends MixpanelMessageDescription {
@@ -487,13 +468,6 @@ import org.json.JSONObject;
                         try {
                             token = eventDescription.getToken();
                             returnCode = insertEventToDb(eventDescription);
-                            // Check first-time event targeting for this event
-                            FirstTimeEventListener listener = eventDescription.getFirstTimeEventListener();
-                            if (listener != null) {
-                                listener.onEventTracked(
-                                        eventDescription.getEventName(),
-                                        eventDescription.getProperties());
-                            }
                         } catch (final JSONException e) {
                             MPLog.e(LOGTAG, "Exception tracking event " + eventDescription.getEventName(), e);
                         }

--- a/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -2678,9 +2678,17 @@ public class MixpanelAPI implements FeatureFlagDelegate {
 
         try {
             final AnalyticsMessages.EventDescription eventDescription =
-                    buildEventDescription(eventName, properties, isAutomaticEvent, eventBegin,
-                            mFeatureFlagManager != null ? mFeatureFlagManager::checkFirstTimeEvent : null);
+                    buildEventDescription(eventName, properties, isAutomaticEvent, eventBegin);
             mMessages.eventsMessage(eventDescription);
+            // Post first-time event check directly to the FeatureFlagManager handler
+            // thread from the calling thread, rather than routing through the
+            // AnalyticsMessages worker. This ensures that when track() and getVariant()
+            // are called sequentially on the same thread, the check is queued on the
+            // handler before getVariant's lookup.
+            if (mFeatureFlagManager != null) {
+                mFeatureFlagManager.checkFirstTimeEvent(
+                        eventName, eventDescription.getProperties());
+            }
         } catch (final JSONException e) {
             MPLog.e(LOGTAG, "Exception tracking event " + eventName, e);
         }
@@ -2694,8 +2702,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
             String eventName,
             JSONObject properties,
             boolean isAutomaticEvent,
-            Long eventBegin,
-            FirstTimeEventListener firstTimeEventListener) throws JSONException {
+            Long eventBegin) throws JSONException {
         final JSONObject messageProps = new JSONObject();
 
         final Map<String, String> referrerProperties = mPersistentIdentity.getReferrerProperties();
@@ -2743,8 +2750,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
                 messageProps,
                 mToken,
                 isAutomaticEvent,
-                mSessionMetadata.getMetadataForEvent(),
-                firstTimeEventListener);
+                mSessionMetadata.getMetadataForEvent());
     }
 
     private void recordPeopleMessage(JSONObject message) {
@@ -2768,7 +2774,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
     private void enqueueFirstLaunchCheck() {
         try {
             final AnalyticsMessages.EventDescription eventDescription =
-                    buildEventDescription(AutomaticEvents.FIRST_OPEN, null, true, null, null);
+                    buildEventDescription(AutomaticEvents.FIRST_OPEN, null, true, null);
 
             final AnalyticsMessages.FirstLaunchDescription firstLaunchDescription =
                     new AnalyticsMessages.FirstLaunchDescription(


### PR DESCRIPTION
Prevent a race condition where track() and flags.getVariant are called sequentially.

Previously, the tracked event was getting posted to a handler. Inside the handler, we were notifying FirstTimeEventListener.

If a customer were to call getVariant before the handler was able to process the tracked event, it could result in a race condition and return an unexpected value.