### PR TITLE
fix(analytics): Ensure MixpanelNetworkErrorListener fires

### DIFF
--- a/analytics/src/androidTest/java/com/mixpanel/android/util/HttpServiceTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/util/HttpServiceTest.java
@@ -1,0 +1,68 @@
+package com.mixpanel.android.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(AndroidJUnit4.class)
+public class HttpServiceTest {
+
+    private Context mContext;
+
+    @Before
+    public void setUp() {
+        mContext = InstrumentationRegistry.getInstrumentation().getContext();
+    }
+
+    @Test
+    public void testNetworkErrorListener_SetAfterGetInstance_FiresOnUnknownHost()
+            throws InterruptedException {
+        final BlockingQueue<Exception> errors = new LinkedBlockingQueue<>();
+
+        // Unique token avoids the MixpanelAPI singleton cache from prior tests.
+        final String token = "net-err-listener-" + UUID.randomUUID();
+        MixpanelAPI mixpanel = MixpanelAPI.getInstance(mContext, token, false);
+
+        // Point at a host guaranteed to fail DNS resolution. .invalid is reserved by RFC 2606.
+        mixpanel.setServerURL("https://api.mixpanel-fail.invalid");
+
+        // Listener registered AFTER getInstance() must still propagate to the cached HttpService.
+        mixpanel.setNetworkErrorListener(new MixpanelNetworkErrorListener() {
+            @Override
+            public void onNetworkError(String endpointUrl, String ipAddress, long durationMillis,
+                                       long uncompressedBodySize, long compressedBodySize,
+                                       int responseCode, String responseMessage,
+                                       Exception exception) {
+                errors.add(exception);
+            }
+        });
+
+        mixpanel.track("listener event");
+        mixpanel.flush();
+
+        // HttpService retries up to 3 times with progressive backoff (100/200/300ms) plus DNS
+        // resolution time per attempt. 20s comfortably covers the worst case.
+        Exception captured = errors.poll(20, TimeUnit.SECONDS);
+        assertNotNull("Listener should fire when set after getInstance()", captured);
+        assertTrue(
+                "Expected UnknownHostException, got: " + captured,
+                captured instanceof UnknownHostException
+                        || captured.getCause() instanceof UnknownHostException);
+    }
+}

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -74,6 +74,9 @@ import org.json.JSONObject;
 
     public void setNetworkErrorListener(MixpanelNetworkErrorListener errorListener) {
         mNetworkErrorListener = errorListener;
+        if (mHttpService != null) {
+            mHttpService.setNetworkErrorListener(errorListener);
+        }
     }
 
     public void eventsMessage(final EventDescription eventDescription) {
@@ -194,8 +197,9 @@ import org.json.JSONObject;
                             mConfig.getBackupHost(),
                             serverHost);
         } else {
-            // Update backup host in case it changed at runtime
+            // Update backup host and listener in case they changed at runtime
             mHttpService.setBackupHost(mConfig.getBackupHost());
+            mHttpService.setNetworkErrorListener(mNetworkErrorListener);
         }
         return mHttpService;
     }

--- a/analytics/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/analytics/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -38,7 +38,7 @@ import javax.net.ssl.SSLSocketFactory;
 public class HttpService implements RemoteService {
 
     private final boolean shouldGzipRequestPayload;
-    private final MixpanelNetworkErrorListener networkErrorListener;
+    private MixpanelNetworkErrorListener networkErrorListener;
     private String mBackupHost;
     private String mServerHost;
 
@@ -74,6 +74,10 @@ public class HttpService implements RemoteService {
 
     public void setBackupHost(String backupHost) {
         this.mBackupHost = backupHost;
+    }
+
+    public void setNetworkErrorListener(MixpanelNetworkErrorListener networkErrorListener) {
+        this.networkErrorListener = networkErrorListener;
     }
 
     @Override


### PR DESCRIPTION
## Summary

  `MixpanelAPI.setNetworkErrorListener(...)` was a no-op for every caller. The listener was captured at `HttpService` construction time, but `AnalyticsMessages` caches the `HttpService` instance — which was built before the user could call `setNetworkErrorListener`. The cached instance ran with a null
  listener, so failed requests (including `UnknownHostException` against bad/blocked hosts) were silently dropped.

  This was introduced when `HttpService` started getting cached to support mutable backup-host updates; the listener wasn't given the same mutable-update treatment.

  ## Changes

  - `HttpService`: drop `final` from `networkErrorListener`, add `setNetworkErrorListener(...)` setter.
  - `AnalyticsMessages.setNetworkErrorListener(...)`: forward the listener to the cached `HttpService` (if already constructed).
  - `AnalyticsMessages.getPoster()`: re-sync the listener on the cached instance, alongside the existing backup-host re-sync.
  - New instrumented test `HttpServiceTest#testNetworkErrorListener_SetAfterGetInstance_FiresOnUnknownHost` — registers the listener after `getInstance()`, flushes to a `.invalid` host, asserts the listener fires with `UnknownHostException`.

  ## Impact

  Any customer relying on `setNetworkErrorListener` to observe network failures has been receiving zero callbacks since the `HttpService` caching change. After this fix, the listener fires on every failed attempt as documented.
