### PR TITLE
feat(analytics): add excludeProperties API for events and People.set()

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,6 +37,8 @@ jobs:
       run: ./gradlew :common:ktlintCheck
     - name: Lint
       run:  ./gradlew :analytics:lint
+    - name: AnimalSniffer (Java/Android API compatibility)
+      run:  ./gradlew :analytics:animalsnifferRelease
     - name: Upload test report
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       if: always()
@@ -71,6 +73,12 @@ jobs:
       with:
         name: Lint Report
         path: analytics/build/reports/lint-results-*.*
+    - name: Upload AnimalSniffer report
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+      if: always()
+      with:
+        name: AnimalSniffer Report
+        path: analytics/build/reports/animalsniffer/
     - name: Android docs
       run:  ./gradlew --info :analytics:androidJavadocs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ Before submitting any PR, you MUST:
 ```bash
 ./gradlew :analytics:lint
 # Review any warnings in analytics/build/reports/lint-results-debug.html
+
+./gradlew :analytics:animalsnifferRelease
+# Fails on Java 9+ APIs and unguarded Android calls above minSdk.
+# Report at analytics/build/reports/animalsniffer/release.text
 ```
 
 ### 4. Manual Verification
@@ -216,6 +220,7 @@ Your PR description should include:
 - `./gradlew :analytics:build` - ✅ Passed
 - `./gradlew :analytics:connectedAndroidTest` - ✅ All tests pass
 - `./gradlew :analytics:lint` - ✅ No new warnings
+- `./gradlew :analytics:animalsnifferRelease` - ✅ No API compatibility violations
 ```
 
 ## Success Metrics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Lint checks
 ./gradlew :analytics:lint
 
+# AnimalSniffer (Java/Android API compatibility — fails on Java 9+ APIs and Android calls
+# above minSdk that aren't SDK_INT-gated; report at analytics/build/reports/animalsniffer/)
+./gradlew :analytics:animalsnifferRelease
+
 # Build demo app
 ./gradlew :analytics:mixpaneldemo:build
 ```

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -2,6 +2,16 @@ plugins {
     id 'com.android.library'
     id 'mixpanel.maven-publish'
     id 'jacoco'
+    id 'ru.vyarus.animalsniffer' version '2.0.0'
+}
+
+animalsniffer {
+    // Real CI gate: the per-variant animalsniffer{Debug,Release} tasks are wired
+    // into `check` by the plugin, so a Java 9+ / unsupported-Android API will fail
+    // the build.
+    ignoreFailures = false
+    // Runtime-gated by SDK_INT >= TIRAMISU; animalsniffer can't see the version check.
+    ignore 'android.content.pm.PackageManager'
 }
 
 
@@ -67,6 +77,8 @@ android {
     lint {
         abortOnError false
         targetSdk 34
+        error 'NewApi'
+        checkReleaseBuilds true
     }
     testOptions {
         targetSdk 34
@@ -127,6 +139,7 @@ tasks.register("androidJavadocs", Javadoc) {
 dependencies {
     // official release
     implementation 'com.mixpanel.android:mixpanel-android-common:1.0.1'
+    signature 'net.sf.androidscents.signature:android-api-level-21:5.0.1_r2@signature'
     // or use below for local testing
     // implementation project(':common')
     implementation "androidx.annotation:annotation:1.8.2"

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import javax.net.ssl.SSLSocketFactory;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +38,23 @@ import org.json.JSONObject;
  * <p>This class straddles the thread boundary between user threads and a logical Mixpanel thread.
  */
 /* package */ class AnalyticsMessages {
+
+    /**
+     * Removes any property whose key appears in {@code excludeProperties} from {@code target},
+     * skipping keys in {@link MixpanelOptions#RESERVED_PROPERTY_KEYS} that ingestion or identity
+     * require. Package-private + static so it can be unit-tested directly.
+     */
+    /* package */ static void applyExcludeProperties(JSONObject target, Set<String> excludeProperties) {
+        if (target == null || excludeProperties == null || excludeProperties.isEmpty()) {
+            return;
+        }
+        for (final String key : excludeProperties) {
+            if (MixpanelOptions.RESERVED_PROPERTY_KEYS.contains(key)) {
+                continue;
+            }
+            target.remove(key);
+        }
+    }
 
     /** Do not call directly. You should call AnalyticsMessages.getInstance() */
     /* package */ AnalyticsMessages(final Context context, MPConfig config) {
@@ -227,10 +246,22 @@ import org.json.JSONObject;
                 String token,
                 boolean isAutomatic,
                 JSONObject sessionMetadata) {
+            this(eventName, properties, token, isAutomatic, sessionMetadata, Collections.emptySet());
+        }
+
+        public EventDescription(
+                String eventName,
+                JSONObject properties,
+                String token,
+                boolean isAutomatic,
+                JSONObject sessionMetadata,
+                Set<String> excludeProperties) {
             super(token, properties);
             mEventName = eventName;
             mIsAutomatic = isAutomatic;
             mSessionMetadata = sessionMetadata;
+            mExcludeProperties =
+                    excludeProperties == null ? Collections.emptySet() : excludeProperties;
         }
 
         public String getEventName() {
@@ -249,9 +280,14 @@ import org.json.JSONObject;
             return mIsAutomatic;
         }
 
+        public Set<String> getExcludeProperties() {
+            return mExcludeProperties;
+        }
+
         private final String mEventName;
         private final JSONObject mSessionMetadata;
         private final boolean mIsAutomatic;
+        private final Set<String> mExcludeProperties;
     }
 
     static class PeopleDescription extends MixpanelMessageDescription {
@@ -636,7 +672,7 @@ import org.json.JSONObject;
                                         url, mConfig.getProxyServerInteractor(), params, null, null, socketFactory);
                         byte[] response = result.getResponse();
                         String actualUrl = result.getRequestUrl(); // Get the actual URL that succeeded
-                        
+
                         if (null == response) {
                             deleteEvents = false;
                             logAboutMessageToMixpanel(
@@ -762,6 +798,7 @@ import org.json.JSONObject;
                         sendProperties.put(key, eventProperties.get(key));
                     }
                 }
+                applyExcludeProperties(sendProperties, eventDescription.getExcludeProperties());
                 eventObj.put("event", eventDescription.getEventName());
                 eventObj.put("properties", sendProperties);
                 eventObj.put("$mp_metadata", eventDescription.getSessionMetadata());

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -232,6 +233,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
         mEventTimings = mPersistentIdentity.getTimeEvents();
 
         mFeatureFlagOptions = options.getFeatureFlagOptions();
+        mExcludeProperties = options.getExcludeProperties();
         // Resolve the effective policy once at init: a persisting policy with non-positive TTL
         // is collapsed to NetworkOnly, since "persist on every fetch but the TTL makes nothing
         // ever serve" does no useful work. Logs a warning when the substitution happens.
@@ -2838,7 +2840,8 @@ public class MixpanelAPI implements FeatureFlagDelegate {
                 messageProps,
                 mToken,
                 isAutomaticEvent,
-                mSessionMetadata.getMetadataForEvent());
+                mSessionMetadata.getMetadataForEvent(),
+                mExcludeProperties);
     }
 
     private void recordPeopleMessage(JSONObject message) {
@@ -3000,6 +3003,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
     private MixpanelActivityLifecycleCallbacks mMixpanelActivityLifecycleCallbacks;
     private final SessionMetadata mSessionMetadata;
     private final FeatureFlagOptions mFeatureFlagOptions;
+    private final Set<String> mExcludeProperties;
     private FeatureFlagManager mFeatureFlagManager;
     private RemoteService mHttpService;
     // Flag to track if app has entered foreground

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -234,6 +234,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
 
         mFeatureFlagOptions = options.getFeatureFlagOptions();
         mExcludeProperties = options.getExcludeProperties();
+        warnIfStrippingLibProperties(mExcludeProperties);
         // Resolve the effective policy once at init: a persisting policy with non-positive TTL
         // is collapsed to NetworkOnly, since "persist on every fetch but the TTL makes nothing
         // ever serve" does no useful work. Logs a warning when the substitution happens.
@@ -2319,6 +2320,17 @@ public class MixpanelAPI implements FeatureFlagDelegate {
     private static String storedPrefsName(String token, String instanceName) {
         final String instanceKey = instanceName != null ? instanceName : token;
         return "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
+    }
+
+    private static void warnIfStrippingLibProperties(Set<String> excludeProperties) {
+        if (excludeProperties.contains("mp_lib") || excludeProperties.contains("$lib_version")) {
+            MPLog.w(
+                    LOGTAG,
+                    "MixpanelOptions.excludeProperties is stripping 'mp_lib' and/or"
+                            + " '$lib_version'. These are not required for ingestion or identity,"
+                            + " but Mixpanel uses them to identify the SDK source and version of"
+                            + " each event — stripping them is not recommended.");
+        }
     }
 
     /* package */ boolean sendAppOpen() {

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -2380,6 +2380,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
                     final String key = (String) iter.next();
                     sendProperties.put(key, properties.get(key));
                 }
+                AnalyticsMessages.applyExcludeProperties(sendProperties, mExcludeProperties);
 
                 final JSONObject message = stdPeopleMessage("$set", sendProperties);
                 recordPeopleMessage(message);

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
@@ -10,7 +10,18 @@ import com.mixpanel.android.util.ProxyServerInteractor;
 
 import org.json.JSONObject;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class MixpanelOptions {
+
+    /**
+     * Property keys that are required for ingestion or identity resolution and will never be
+     * stripped by {@link Builder#excludeProperties(Set)}, even if a customer lists them.
+     */
+    public static final Set<String> RESERVED_PROPERTY_KEYS = Set.of(
+        "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id"
+    );
 
     private final String instanceName;
     private final boolean optOutTrackingDefault;
@@ -19,6 +30,7 @@ public class MixpanelOptions {
     private final DeviceIdProvider deviceIdProvider;
     private final String serverURL;
     private final ProxyServerInteractor proxyServerInteractor;
+    private final Set<String> excludeProperties;
 
     private MixpanelOptions(Builder builder) {
         this.instanceName = builder.instanceName;
@@ -28,6 +40,7 @@ public class MixpanelOptions {
         this.serverURL = builder.serverURL;
         this.proxyServerInteractor = builder.proxyServerInteractor;
         this.mFeatureFlagOptions = builder.mFeatureFlagOptions;
+        this.excludeProperties = builder.excludeProperties;
     }
 
     public String getInstanceName() {
@@ -95,6 +108,18 @@ public class MixpanelOptions {
         return proxyServerInteractor;
     }
 
+    /**
+     * Returns the set of property keys that will be stripped from every event before it is
+     * sent to Mixpanel. Returns an empty set if none were configured. The returned set is
+     * unmodifiable.
+     *
+     * @return The configured exclude set, or an empty unmodifiable set.
+     */
+    @NonNull
+    public Set<String> getExcludeProperties() {
+        return excludeProperties;
+    }
+
     public static class Builder {
         private String instanceName;
         private boolean optOutTrackingDefault = false;
@@ -103,6 +128,7 @@ public class MixpanelOptions {
         private DeviceIdProvider deviceIdProvider = null;
         private String serverURL;
         private ProxyServerInteractor proxyServerInteractor;
+        private Set<String> excludeProperties = Collections.emptySet();
 
         public Builder() {
         }
@@ -275,6 +301,30 @@ public class MixpanelOptions {
         ) {
             this.serverURL = serverURL;
             this.proxyServerInteractor = proxyServerInteractor;
+            return this;
+        }
+
+        /**
+         * Sets a set of property keys that should be stripped from every event before it is
+         * sent to Mixpanel.
+         *
+         * <p>Use this to reduce per-event payload size or to suppress properties the project
+         * has no interest in. Matching is exact and case-sensitive. Keys in
+         * {@link MixpanelOptions#RESERVED_PROPERTY_KEYS} are never stripped, even if listed.
+         *
+         * <p>A {@code null} or empty set disables filtering entirely with zero per-event
+         * overhead.
+         *
+         * @param excludeProperties The set of property keys to strip.
+         * @return This Builder instance for chaining.
+         */
+        public Builder excludeProperties(@Nullable Set<String> excludeProperties) {
+            if (excludeProperties == null || excludeProperties.isEmpty()) {
+                this.excludeProperties = Collections.emptySet();
+            } else {
+                // Defensive copy + immutable wrapper so callers can't mutate post-build.
+                this.excludeProperties = Set.copyOf(excludeProperties);
+            }
             return this;
         }
 

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
@@ -10,7 +10,9 @@ import com.mixpanel.android.util.ProxyServerInteractor;
 
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class MixpanelOptions {
@@ -19,8 +21,10 @@ public class MixpanelOptions {
      * Property keys that are required for ingestion or identity resolution and will never be
      * stripped by {@link Builder#excludeProperties(Set)}, even if a customer lists them.
      */
-    public static final Set<String> RESERVED_PROPERTY_KEYS = Set.of(
-        "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id"
+    public static final Set<String> RESERVED_PROPERTY_KEYS = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(
+            "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id"
+        ))
     );
 
     private final String instanceName;
@@ -323,7 +327,8 @@ public class MixpanelOptions {
          * </ul>
          *
          * <p>Use this to reduce per-payload size or to suppress properties the project has
-         * no interest in. Matching is exact and case-sensitive. Keys in
+         * no interest in. Matching is exact, case-sensitive, and applied only to top-level
+         * property keys (values that are themselves objects are not traversed). Keys in
          * {@link MixpanelOptions#RESERVED_PROPERTY_KEYS} are never stripped, even if listed.
          *
          * <p>A {@code null} or empty set disables filtering entirely with zero per-event
@@ -337,7 +342,7 @@ public class MixpanelOptions {
                 this.excludeProperties = Collections.emptySet();
             } else {
                 // Defensive copy + immutable wrapper so callers can't mutate post-build.
-                this.excludeProperties = Set.copyOf(excludeProperties);
+                this.excludeProperties = Collections.unmodifiableSet(new HashSet<>(excludeProperties));
             }
             return this;
         }

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
@@ -305,11 +305,25 @@ public class MixpanelOptions {
         }
 
         /**
-         * Sets a set of property keys that should be stripped from every event before it is
-         * sent to Mixpanel.
+         * Sets a set of property keys that should be stripped from outgoing payloads before
+         * they are sent to Mixpanel.
          *
-         * <p>Use this to reduce per-event payload size or to suppress properties the project
-         * has no interest in. Matching is exact and case-sensitive. Keys in
+         * <p>The filter is applied at two chokepoints:
+         * <ul>
+         *   <li>Every event (super properties, caller properties, referrer properties, and
+         *       SDK auto-properties like {@code $screen_height} / {@code $lib_version}).</li>
+         *   <li>The {@code $set} bag on {@code People.set(...)}, which auto-merges SDK
+         *       device info such as {@code $android_lib_version} and {@code $android_model}.
+         *       The mutating operators ({@code $set_once}, {@code $add}, {@code $append},
+         *       {@code $union}, {@code $remove}, {@code $unset}, {@code $merge},
+         *       {@code $delete}) are pass-through — they don't merge device info, and
+         *       filtering inside them would change semantics (e.g. silently dropping a name
+         *       from an {@code $unset} list). Group updates are not filtered because they
+         *       never merge device info.</li>
+         * </ul>
+         *
+         * <p>Use this to reduce per-payload size or to suppress properties the project has
+         * no interest in. Matching is exact and case-sensitive. Keys in
          * {@link MixpanelOptions#RESERVED_PROPERTY_KEYS} are never stripped, even if listed.
          *
          * <p>A {@code null} or empty set disables filtering entirely with zero per-event

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelOptions.java
@@ -331,6 +331,13 @@ public class MixpanelOptions {
          * property keys (values that are themselves objects are not traversed). Keys in
          * {@link MixpanelOptions#RESERVED_PROPERTY_KEYS} are never stripped, even if listed.
          *
+         * <p><b>Recommended: do not strip {@code mp_lib} or {@code $lib_version}.</b> Mixpanel
+         * does not need them for ingestion or identity resolution, so stripping them is
+         * permitted — but they are how Mixpanel identifies which SDK (and which version)
+         * produced an event. Removing them limits reporting accuracy (e.g. per-platform
+         * breakdowns) and makes it harder for support to debug issues on your project. If
+         * either key is included here, the SDK logs a warning at instance creation time.
+         *
          * <p>A {@code null} or empty set disables filtering entirely with zero per-event
          * overhead.
          *

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/ExcludePropertiesTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/ExcludePropertiesTest.java
@@ -1,0 +1,174 @@
+package com.mixpanel.android.mpmetrics;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the property exclude set applied to outgoing events.
+ *
+ * <p>The exclude set is configured at SDK init via {@link MixpanelOptions.Builder#excludeProperties(Set)}.
+ * It is applied at two chokepoints:
+ * <ol>
+ *   <li>{@code MixpanelAPI.buildEventDescription} for user / super / referrer properties</li>
+ *   <li>{@link AnalyticsMessages#applyExcludeProperties(JSONObject, Set)} for SDK auto-properties
+ *       (the default-event-properties added in the worker just before send).</li>
+ * </ol>
+ *
+ * <p>These tests target the second chokepoint directly, since it's the one with the most
+ * customer value (those auto-properties are usually what bloats {@code $mp_event_size}).
+ * Tests for the {@link MixpanelOptions} builder live in {@link MixpanelOptionsTest}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ExcludePropertiesTest {
+
+    private JSONObject buildSampleAutoProps() throws JSONException {
+        // Mirrors a representative subset of what
+        // AnalyticsMessages.Worker.getDefaultEventProperties() produces.
+        JSONObject props = new JSONObject();
+        props.put("token", "test-token");
+        props.put("time", 1700000000000L);
+        props.put("distinct_id", "abc-123");
+        props.put("$device_id", "device-xyz");
+        props.put("$user_id", "user-42");
+        props.put("$insert_id", "insert-1");
+        props.put("$had_persisted_distinct_id", true);
+        props.put("mp_lib", "android");
+        props.put("$lib_version", "7.0.0");
+        props.put("$os", "Android");
+        props.put("$screen_height", 1920);
+        props.put("$screen_width", 1080);
+        props.put("$carrier", "Verizon");
+        props.put("custom_user_prop", "value");
+        return props;
+    }
+
+    @Test
+    public void testNullExcludeSetIsNoOp() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        int before = props.length();
+        AnalyticsMessages.applyExcludeProperties(props, null);
+        assertEquals(before, props.length());
+    }
+
+    @Test
+    public void testEmptyExcludeSetIsNoOp() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        int before = props.length();
+        AnalyticsMessages.applyExcludeProperties(props, Collections.<String>emptySet());
+        assertEquals(before, props.length());
+    }
+
+    @Test
+    public void testStripsAutoProperty() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        AnalyticsMessages.applyExcludeProperties(props, Collections.singleton("$screen_height"));
+        assertFalse(props.has("$screen_height"));
+        // Adjacent auto-props remain untouched.
+        assertTrue(props.has("$screen_width"));
+        assertTrue(props.has("$lib_version"));
+    }
+
+    @Test
+    public void testStripsCustomUserProperty() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        AnalyticsMessages.applyExcludeProperties(props, Collections.singleton("custom_user_prop"));
+        assertFalse(props.has("custom_user_prop"));
+    }
+
+    @Test
+    public void testReservedKeysAreNeverStripped() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        // Drive the test from the canonical reserved set so adding a new reserved key
+        // here automatically tightens this test rather than leaving it stale.
+        Set<String> exclude = new HashSet<>(MixpanelOptions.RESERVED_PROPERTY_KEYS);
+
+        // Sanity check: every reserved key we're about to try to exclude is actually
+        // present in the sample, otherwise the test would silently pass for missing keys.
+        for (String key : MixpanelOptions.RESERVED_PROPERTY_KEYS) {
+            assertTrue("Sample auto-props is missing reserved key " + key, props.has(key));
+        }
+
+        AnalyticsMessages.applyExcludeProperties(props, exclude);
+
+        for (String key : MixpanelOptions.RESERVED_PROPERTY_KEYS) {
+            assertTrue("Reserved key was stripped: " + key, props.has(key));
+        }
+    }
+
+    /**
+     * {@code $insert_id} is in the Mixpanel ingestion vocabulary but this SDK never writes it
+     * (we use {@code $mp_event_id} inside {@code $mp_metadata} for dedup, which lives outside
+     * the properties bag). So if a customer lists {@code $insert_id} in their exclude set we
+     * should honor it — there is nothing to protect.
+     */
+    @Test
+    public void testInsertIdIsNotReserved() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        AnalyticsMessages.applyExcludeProperties(props, Collections.singleton("$insert_id"));
+        assertFalse(props.has("$insert_id"));
+    }
+
+    @Test
+    public void testMultiplePropertiesStripped() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        Set<String> exclude = new HashSet<>();
+        exclude.add("$screen_height");
+        exclude.add("$screen_width");
+        exclude.add("$carrier");
+        exclude.add("custom_user_prop");
+
+        AnalyticsMessages.applyExcludeProperties(props, exclude);
+
+        assertFalse(props.has("$screen_height"));
+        assertFalse(props.has("$screen_width"));
+        assertFalse(props.has("$carrier"));
+        assertFalse(props.has("custom_user_prop"));
+        // Untouched samples
+        assertTrue(props.has("$os"));
+        assertTrue(props.has("$lib_version"));
+    }
+
+    @Test
+    public void testExcludedKeyNotPresentIsNoOp() throws JSONException {
+        JSONObject props = buildSampleAutoProps();
+        int before = props.length();
+        AnalyticsMessages.applyExcludeProperties(props, Collections.singleton("never_added"));
+        assertEquals(before, props.length());
+    }
+
+    @Test
+    public void testNullTargetIsNoOp() {
+        // No exception should be thrown.
+        AnalyticsMessages.applyExcludeProperties(null, Collections.singleton("$lib_version"));
+    }
+
+    /**
+     * Plumbing check: an EventDescription built without an exclude set defaults to empty,
+     * and one built with an exclude set exposes the same set to the worker.
+     */
+    @Test
+    public void testEventDescriptionPlumbsExcludeProperties() throws JSONException {
+        JSONObject props = new JSONObject();
+        props.put("k", "v");
+
+        AnalyticsMessages.EventDescription noExclude = new AnalyticsMessages.EventDescription(
+                "evt", props, "tok", false, new JSONObject());
+        assertTrue(noExclude.getExcludeProperties().isEmpty());
+
+        Set<String> exclude = Collections.singleton("$screen_height");
+        AnalyticsMessages.EventDescription withExclude = new AnalyticsMessages.EventDescription(
+                "evt", props, "tok", false, new JSONObject(), exclude);
+        assertEquals(exclude, withExclude.getExcludeProperties());
+    }
+}

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/ExcludePropertiesTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/ExcludePropertiesTest.java
@@ -1,5 +1,9 @@
 package com.mixpanel.android.mpmetrics;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -9,25 +13,34 @@ import org.robolectric.RobolectricTestRunner;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests for the property exclude set applied to outgoing events.
+ * Tests for the property exclude set applied to outgoing payloads.
  *
  * <p>The exclude set is configured at SDK init via {@link MixpanelOptions.Builder#excludeProperties(Set)}.
  * It is applied at two chokepoints:
  * <ol>
- *   <li>{@code MixpanelAPI.buildEventDescription} for user / super / referrer properties</li>
- *   <li>{@link AnalyticsMessages#applyExcludeProperties(JSONObject, Set)} for SDK auto-properties
- *       (the default-event-properties added in the worker just before send).</li>
+ *   <li>{@code AnalyticsMessages.Worker.prepareEventObject} for every event, covering super /
+ *       caller / referrer properties and the SDK auto-properties merged in just before send.</li>
+ *   <li>{@code MixpanelAPI.PeopleImpl.set} for the {@code $set} bag, which auto-merges the
+ *       SDK's device-info properties. Other people operators and group updates do not merge
+ *       SDK fat and are not filtered.</li>
  * </ol>
  *
- * <p>These tests target the second chokepoint directly, since it's the one with the most
- * customer value (those auto-properties are usually what bloats {@code $mp_event_size}).
- * Tests for the {@link MixpanelOptions} builder live in {@link MixpanelOptionsTest}.
+ * <p>Most of these tests target {@link AnalyticsMessages#applyExcludeProperties(JSONObject, Set)}
+ * directly because it carries the substantive behavior; one end-to-end test
+ * ({@link #testPeopleSetStripsAutoMergedDeviceInfo}) verifies the people-side wiring through a
+ * real {@link MixpanelAPI}. Tests for the {@link MixpanelOptions} builder live in
+ * {@link MixpanelOptionsTest}.
  */
 @RunWith(RobolectricTestRunner.class)
 public class ExcludePropertiesTest {
@@ -151,6 +164,60 @@ public class ExcludePropertiesTest {
     public void testNullTargetIsNoOp() {
         // No exception should be thrown.
         AnalyticsMessages.applyExcludeProperties(null, Collections.singleton("$lib_version"));
+    }
+
+    /**
+     * End-to-end check that {@code People.set(...)} honors the exclude set by stripping an
+     * auto-merged device-info key while preserving caller-supplied properties. This is the
+     * one wiring path that {@link AnalyticsMessages#applyExcludeProperties(JSONObject, Set)}
+     * alone can't cover, since the merge happens in {@link MixpanelAPI} before the worker
+     * sees it.
+     */
+    @Test
+    public void testPeopleSetStripsAutoMergedDeviceInfo() throws Exception {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final String token = UUID.randomUUID().toString();
+        final BlockingQueue<AnalyticsMessages.PeopleDescription> seen =
+                new LinkedBlockingQueue<>();
+
+        final AnalyticsMessages capturing = new AnalyticsMessages(
+                context, MPConfig.getInstance(context, null)) {
+            @Override
+            public void peopleMessage(PeopleDescription description) {
+                seen.add(description);
+                // Don't forward; we just want to inspect the bag the API constructed.
+            }
+        };
+
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(Collections.singleton("$android_lib_version"))
+                .build();
+
+        MixpanelAPI mixpanel = new TestUtils.CleanMixpanelAPI(
+                context, new TestUtils.EmptyPreferences(context), token, options) {
+            @Override
+            protected AnalyticsMessages getAnalyticsMessages() {
+                return capturing;
+            }
+        };
+        mixpanel.identify("user-under-test");
+
+        JSONObject callerProps = new JSONObject();
+        callerProps.put("custom_prop", "kept");
+        mixpanel.getPeople().set(callerProps);
+
+        AnalyticsMessages.PeopleDescription description =
+                seen.poll(5, TimeUnit.SECONDS);
+        assertNotNull("PeopleDescription should have been recorded", description);
+
+        JSONObject setBag = description.getMessage().getJSONObject("$set");
+        assertFalse("Excluded auto-merged property should be stripped",
+                setBag.has("$android_lib_version"));
+        assertEquals("Caller property should pass through",
+                "kept", setBag.getString("custom_prop"));
+        // Adjacent auto-properties should still be present.
+        assertTrue("Adjacent auto-property should remain",
+                setBag.has("$android_os"));
     }
 
     /**

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelOptionsTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelOptionsTest.java
@@ -5,8 +5,11 @@ import com.mixpanel.android.util.ProxyServerInteractor;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -25,6 +28,66 @@ public class MixpanelOptionsTest {
         assertNull(options.getDeviceIdProvider());
         assertNull(options.getServerURL());
         assertNull(options.getProxyServerInteractor());
+        assertNotNull(options.getExcludeProperties());
+        assertTrue(options.getExcludeProperties().isEmpty());
+    }
+
+    @Test
+    public void testExcludeProperties() {
+        Set<String> exclude = new HashSet<>();
+        exclude.add("$screen_height");
+        exclude.add("$lib_version");
+
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(exclude)
+                .build();
+
+        assertEquals(2, options.getExcludeProperties().size());
+        assertTrue(options.getExcludeProperties().contains("$screen_height"));
+        assertTrue(options.getExcludeProperties().contains("$lib_version"));
+    }
+
+    @Test
+    public void testExcludePropertiesDefensiveCopy() {
+        Set<String> exclude = new HashSet<>();
+        exclude.add("$screen_height");
+
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(exclude)
+                .build();
+
+        // Mutating the source should not affect the stored set.
+        exclude.add("$lib_version");
+        assertEquals(1, options.getExcludeProperties().size());
+        assertTrue(options.getExcludeProperties().contains("$screen_height"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testExcludePropertiesGetterIsImmutable() {
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(Collections.singleton("$screen_height"))
+                .build();
+        options.getExcludeProperties().add("anything");
+    }
+
+    @Test
+    public void testNullExcludeProperties() {
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(null)
+                .build();
+
+        assertNotNull(options.getExcludeProperties());
+        assertTrue(options.getExcludeProperties().isEmpty());
+    }
+
+    @Test
+    public void testEmptyExcludeProperties() {
+        MixpanelOptions options = new MixpanelOptions.Builder()
+                .excludeProperties(Collections.emptySet())
+                .build();
+
+        assertNotNull(options.getExcludeProperties());
+        assertTrue(options.getExcludeProperties().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `MixpanelOptions.Builder.excludeProperties(Set<String>)` so projects can opt into stripping specific keys from outgoing payloads — useful when a downstream contract or warehouse caps per-payload size.
- Filter is applied at two chokepoints:
  - **Events**: `AnalyticsMessages.prepareEventObject` — covers super properties, caller properties, referrer properties, and SDK auto-properties uniformly.
  - **`People.set()`**: filters the bag *after* `mDeviceInfo` is merged but *before* it reaches `stdPeopleMessage`, so the 8 auto-injected device keys (`$android_lib_version`, `$android_os`, `$android_model`, etc.) are subject to the same exclude set as event auto-properties.
- Matching is exact and case-sensitive; null/empty set disables filtering with zero per-payload overhead.
- Identity/routing keys are protected via `MixpanelOptions.RESERVED_PROPERTY_KEYS` (`token`, `time`, `distinct_id`, `$device_id`, `$user_id`, `$had_persisted_distinct_id`) — the constant is the single source of truth for the runtime filter, the Javadoc, and the test (which iterates the constant so a new reserved key tightens coverage automatically).

## Scope notes
- **`People.set_once` / `$add` / `$append` / `$union` / `$remove` / `$unset` / `$merge` / `$delete`** are pass-through. They don't merge `mDeviceInfo`, and filtering inside mutating operators would silently change semantics (e.g. dropping a name from an `$unset` list).
- **Group updates** are unaffected — they never merge `mDeviceInfo`.
- `$mp_metadata` (sibling of `properties` on the event JSON) is structurally outside the filter's traversal scope.