### PR TITLE
chore: run JVM unit tests in PR CI and fix FeatureFlagManagerTest hang

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,6 +33,8 @@ jobs:
       run: ./gradlew :openfeature-provider:test
     - name: Run Common module tests
       run: ./gradlew :common:test
+    - name: Run analytics JVM unit tests
+      run: ./gradlew :analytics:test
     - name: Run Common ktlint check
       run: ./gradlew :common:ktlintCheck
     - name: Lint
@@ -51,6 +53,14 @@ jobs:
       with:
         name: OpenFeature Unit Test Report
         path: openfeature-provider/build/reports/tests/
+    - name: Upload analytics JVM unit test report
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+      if: always()
+      with:
+        name: Analytics JVM Unit Test Report
+        path: |
+          analytics/build/reports/tests/
+          analytics/build/test-results/
     - name: Upload Common test report
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       if: always()

--- a/.github/workflows/release-maven-central.yml
+++ b/.github/workflows/release-maven-central.yml
@@ -114,6 +114,7 @@ jobs:
         run: ./gradlew "${TASK_PREFIX}build"
 
       - name: Test
+        timeout-minutes: 30
         env:
           TASK_PREFIX: ${{ steps.module.outputs.gradle_task_prefix }}
         run: ./gradlew "${TASK_PREFIX}test"

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -175,6 +175,22 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
     }
   }
 
+  // Stop the worker HandlerThread and network executor so they don't outlive a test JVM
+  // worker (non-daemon threads would otherwise keep gradle's test JVM alive after a failure).
+  // Package-private; idempotent.
+  void close() {
+    try {
+      mHandler.getLooper().quitSafely();
+    } catch (Exception e) {
+      MPLog.e(LOGTAG, "Error quitting FeatureFlagManager looper", e);
+    }
+    try {
+      mNetworkExecutor.shutdownNow();
+    } catch (Exception e) {
+      MPLog.e(LOGTAG, "Error shutting down FeatureFlagManager network executor", e);
+    }
+  }
+
   /**
    * Returns {@code true} when the configured policy reads/writes the on-disk persistence
    * (PersistenceUntilNetworkSuccess or NetworkFirst). NetworkOnly returns {@code false}.

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -60,18 +60,28 @@ public class FeatureFlagManagerTest {
   /**
    * Flushes all background loopers and the main looper repeatedly to drive
    * async Handler-based operations to completion in Robolectric.
+   *
+   * <p>Sibling test classes (e.g. {@code MixpanelBasicTest}) create real {@code MixpanelAPI}
+   * instances without per-test teardown, so {@link ShadowLooper#getAllLoopers()} can include
+   * loopers whose queued handlers reference state torn down between tests (closed SQLite
+   * cursors, etc.). Idling those throws — swallow it here so unrelated tests don't fail.
    */
   private void flushAllLoopers() {
     for (int i = 0; i < 10; i++) {
-      ShadowLooper.idleMainLooper();
-      for (Looper looper : ShadowLooper.getAllLoopers()) {
-        Shadows.shadowOf(looper).idle();
-      }
-      // Give the network executor thread time to run
+      idleAllLoopers();
       try { Thread.sleep(50); } catch (InterruptedException ignored) {}
-      ShadowLooper.idleMainLooper();
-      for (Looper looper : ShadowLooper.getAllLoopers()) {
+      idleAllLoopers();
+    }
+  }
+
+  private void idleAllLoopers() {
+    ShadowLooper.idleMainLooper();
+    for (Looper looper : ShadowLooper.getAllLoopers()) {
+      try {
         Shadows.shadowOf(looper).idle();
+      } catch (RuntimeException e) {
+        MPLog.w("MixpanelAPI.FeatureFlagManagerTest",
+            "Ignoring exception while idling looper " + looper, e);
       }
     }
   }
@@ -325,6 +335,9 @@ public class FeatureFlagManagerTest {
 
   @After
   public void tearDown() {
+    if (mFeatureFlagManager != null) {
+      mFeatureFlagManager.close();
+    }
     MPLog.setLevel(mPreviousLogLevel);
   }
 

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/HttpTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/HttpTest.java
@@ -365,30 +365,40 @@ public class HttpTest {
 
   private void flushAllLoopers() {
     for (int i = 0; i < 10; i++) {
-      ShadowLooper.idleMainLooper();
-      for (Looper looper : ShadowLooper.getAllLoopers()) {
-        Shadows.shadowOf(looper).idle();
-      }
+      idleAllLoopers();
       try { Thread.sleep(50); } catch (InterruptedException ignored) {}
-      ShadowLooper.idleMainLooper();
-      for (Looper looper : ShadowLooper.getAllLoopers()) {
+      idleAllLoopers();
+    }
+  }
+
+  // Quitted/dead loopers left behind by sibling test classes (e.g. FeatureFlagManagerTest
+  // closes its worker HandlerThread in tearDown) cause Shadows.idle()/idleFor() to throw.
+  // Swallow those so an unrelated test's leftover doesn't fail this test.
+  private void idleAllLoopers() {
+    ShadowLooper.idleMainLooper();
+    for (Looper looper : ShadowLooper.getAllLoopers()) {
+      try {
         Shadows.shadowOf(looper).idle();
-      }
+      } catch (RuntimeException ignored) {}
+    }
+  }
+
+  private void idleAllLoopersFor(Duration duration) {
+    for (Looper looper : ShadowLooper.getAllLoopers()) {
+      try {
+        Shadows.shadowOf(looper).idleFor(duration);
+      } catch (RuntimeException ignored) {}
     }
   }
 
   private void waitForBackOffTimeInterval() throws InterruptedException {
     long waitForMs = mMetrics.getAnalyticsMessages().getTrackEngageRetryAfter();
-    for (Looper looper : ShadowLooper.getAllLoopers()) {
-      Shadows.shadowOf(looper).idleFor(Duration.ofMillis(waitForMs + 100));
-    }
+    idleAllLoopersFor(Duration.ofMillis(waitForMs + 100));
     flushAllLoopers();
   }
 
   private void waitForFlushInternval() throws InterruptedException {
-    for (Looper looper : ShadowLooper.getAllLoopers()) {
-      Shadows.shadowOf(looper).idleFor(Duration.ofMillis(mFlushInterval + 100));
-    }
+    idleAllLoopersFor(Duration.ofMillis(mFlushInterval + 100));
     flushAllLoopers();
   }
 


### PR DESCRIPTION
## Summary

- A Maven Central release hung for ~21 minutes after `FeatureFlagManagerTest.testIsEnabled_Async_flagsReady_booleanFalse` failed with `IllegalStateException` at `SQLiteClosable.java:58`, then never exited.
- Two root causes: (1) PR CI never executed the analytics JVM/Robolectric unit tests under `analytics/src/test/` — release was the first place they ran; (2) `FeatureFlagManagerTest` leaked a `HandlerThread` + non-daemon executor every test, and `flushAllLoopers()` iterates *every* looper in the JVM, so a stale handler from a sibling Robolectric test (with a closed SQLite resource) drove `idle()` to throw and the non-daemon thread kept the gradle test JVM alive past the failure.

## Changes

1. `.github/workflows/android.yml` — add `./gradlew :analytics:test` step + upload report on failure.
2. `.github/workflows/release-maven-central.yml` — add `timeout-minutes: 30` to the Test step so a future hang fails fast.
3. `FeatureFlagManager.java` — new package-private `close()` that quits the worker `HandlerThread` and shuts down the network `ExecutorService`. Idempotent and defensive.
4. `FeatureFlagManagerTest.java` — call `mFeatureFlagManager.close()` in `@After`; wrap the per-looper `idle()` calls in `flushAllLoopers()` so a quitted/dead looper left behind by a sibling test class doesn't fail this test.
5. `HttpTest.java` — same hardening on `flushAllLoopers()` / `idleFor()` (its loopers can now legitimately be quit because of #4).

## Test plan

- [x] `./gradlew :analytics:testDebugUnitTest` passes locally (4m30s)
- [x] `./gradlew :analytics:testReleaseUnitTest` passes locally (4m30s)
- [x] `./gradlew :analytics:testDebugUnitTest --tests "*FeatureFlagManagerTest"` passes
- [ ] PR CI (now running `:analytics:test`) is green
- [ ] Re-run the release workflow and confirm the Test step completes and proceeds to Publish

## Out of scope

A real audit of the suite-wide Robolectric test isolation (adding `@After` teardowns to `MixpanelBasicTest` etc. that create real `MixpanelAPI` instances) — the changes here make the symptom go away by giving `FeatureFlagManager` proper lifecycle hooks and making the looper-flush helpers defensive. A deeper test-isolation pass should be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)