### PR TITLE
fix(session-replay): respect remoteSettingsMode for event triggers

### DIFF
--- a/session-replay/src/main/java/com/mixpanel/android/sessionreplay/MPSessionReplay.kt
+++ b/session-replay/src/main/java/com/mixpanel/android/sessionreplay/MPSessionReplay.kt
@@ -30,6 +30,16 @@ sealed class MPSessionReplayError : Exception() {
     data class InitializationError(override val cause: Throwable) : MPSessionReplayError()
 }
 
+/**
+ * Consolidated result from applying remote settings.
+ * Contains all values needed for SDK initialization in one place.
+ */
+internal data class ResolvedRemoteSettings(
+    val isRecordingEnabled: Boolean,
+    val config: MPSessionReplayConfig,
+    val recordingEventTriggers: Map<String, RecordingEventTrigger>?
+)
+
 open class MPSessionReplay {
     // Class-level properties and other methods can go here if needed
 
@@ -158,26 +168,25 @@ object SessionReplayManager {
 
                 // Now we're in foreground, safe to make network call
                 val settingsResult = remoteSettingsService.fetchRemoteSettings(token)
-                val finalConfig = applyRemoteSettings(config, settingsResult)
+                val resolvedSettings = applyRemoteSettings(config, settingsResult)
 
                 withContext(Dispatchers.Main) {
-                    if (settingsResult.isRecordingEnabled) {
-                        finalConfig?.let { config ->
-                            instance = MPSessionReplayInstance(appContext, token, distinctId, config)
-
-                            // Setup event triggers from remote settings
-                            setupEventTriggers(settingsResult.sdkConfig?.recordingEventTriggers)
-
-                            completion(Result.success(instance))
-                        } ?: run {
-                            val error = "Session Replay is disabled because remote settings could not be fetched in STRICT mode."
+                    when {
+                        resolvedSettings == null -> {
+                            val error = "Session Replay is disabled (STRICT mode: settings unavailable)"
                             Logger.warn(error)
                             completion(Result.failure(MPSessionReplayError.Disabled(error)))
                         }
-                    } else {
-                        val error = "Session Replay is disabled via remote settings"
-                        Logger.warn(error)
-                        completion(Result.failure(MPSessionReplayError.Disabled(error)))
+                        !resolvedSettings.isRecordingEnabled -> {
+                            val error = "Session Replay is disabled via remote settings"
+                            Logger.warn(error)
+                            completion(Result.failure(MPSessionReplayError.Disabled(error)))
+                        }
+                        else -> {
+                            instance = MPSessionReplayInstance(appContext, token, distinctId, resolvedSettings.config)
+                            setupEventTriggers(resolvedSettings.recordingEventTriggers)
+                            completion(Result.success(instance))
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -191,24 +200,36 @@ object SessionReplayManager {
 
     /**
      * Applies remote settings to the config based on remoteSettingsMode.
-     * Returns a new config with remote settings applied, preserving immutability.
+     * Returns a consolidated ResolvedRemoteSettings containing all values needed for initialization.
      * Returns null if SDK initialization should be disabled (STRICT mode with API failure or missing sdk_config).
      */
     @VisibleForTesting
     internal fun applyRemoteSettings(
         config: MPSessionReplayConfig,
         remoteSettings: RemoteSettingsResult
-    ): MPSessionReplayConfig? = when (config.remoteSettingsMode) {
-        RemoteSettingsMode.DISABLED -> config
+    ): ResolvedRemoteSettings? = when (config.remoteSettingsMode) {
+        RemoteSettingsMode.DISABLED -> ResolvedRemoteSettings(
+            isRecordingEnabled = remoteSettings.isRecordingEnabled,
+            config = config,
+            recordingEventTriggers = null // Ignored in DISABLED mode
+        )
 
         RemoteSettingsMode.STRICT -> if (remoteSettings.isFromCache || remoteSettings.sdkConfig == null) {
-            // The API call failed or the response did not include sdk_config.config, so the SDK will not be initialized.
+            // The API call failed or the response did not include sdk_config.config
             null
         } else {
-            applyRemoteConfigValues(config, remoteSettings)
+            ResolvedRemoteSettings(
+                isRecordingEnabled = remoteSettings.isRecordingEnabled,
+                config = applyRemoteConfigValues(config, remoteSettings),
+                recordingEventTriggers = remoteSettings.sdkConfig.recordingEventTriggers
+            )
         }
 
-        RemoteSettingsMode.FALLBACK -> applyRemoteConfigValues(config, remoteSettings)
+        RemoteSettingsMode.FALLBACK -> ResolvedRemoteSettings(
+            isRecordingEnabled = remoteSettings.isRecordingEnabled,
+            config = applyRemoteConfigValues(config, remoteSettings),
+            recordingEventTriggers = remoteSettings.sdkConfig?.recordingEventTriggers
+        )
     }
 
     /**

--- a/session-replay/src/main/java/com/mixpanel/android/sessionreplay/MPSessionReplay.kt
+++ b/session-replay/src/main/java/com/mixpanel/android/sessionreplay/MPSessionReplay.kt
@@ -168,7 +168,7 @@ object SessionReplayManager {
 
                 // Now we're in foreground, safe to make network call
                 val settingsResult = remoteSettingsService.fetchRemoteSettings(token)
-                val resolvedSettings = applyRemoteSettings(config, settingsResult)
+                val resolvedSettings = resolveRemoteSettings(config, settingsResult)
 
                 withContext(Dispatchers.Main) {
                     when {
@@ -204,7 +204,7 @@ object SessionReplayManager {
      * Returns null if SDK initialization should be disabled (STRICT mode with API failure or missing sdk_config).
      */
     @VisibleForTesting
-    internal fun applyRemoteSettings(
+    internal fun resolveRemoteSettings(
         config: MPSessionReplayConfig,
         remoteSettings: RemoteSettingsResult
     ): ResolvedRemoteSettings? = when (config.remoteSettingsMode) {

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 
 /**
  * Tests for remote settings mode functionality.
- * These tests verify that the applyRemoteSettings logic works correctly for all modes.
+ * These tests verify that the resolveRemoteSettings logic works correctly for all modes.
  */
 class RemoteSettingsModeTest {
 
@@ -31,7 +31,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should keep original config, ignoring remote config
         assertEquals(config, resolvedSettings?.config)
@@ -46,8 +46,8 @@ class RemoteSettingsModeTest {
         val enabledResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = null)
         val disabledResult = RemoteSettingsResult(isRecordingEnabled = false, sdkConfig = null)
 
-        assertTrue(SessionReplayManager.applyRemoteSettings(config, enabledResult)?.isRecordingEnabled == true)
-        assertFalse(SessionReplayManager.applyRemoteSettings(config, disabledResult)?.isRecordingEnabled == true)
+        assertTrue(SessionReplayManager.resolveRemoteSettings(config, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.resolveRemoteSettings(config, disabledResult)?.isRecordingEnabled == true)
     }
 
     // --- STRICT Mode Tests ---
@@ -63,7 +63,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 10.0)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should apply remote value
         assertEquals(config.copy(recordingSessionsPercent = 10.0), resolvedSettings?.config)
@@ -82,7 +82,7 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // STRICT mode should return null when API fails, disabling SDK initialization
         assertNull(resolvedSettings)
@@ -101,7 +101,7 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // STRICT mode should return null when sdk_config is missing, disabling SDK initialization
         assertNull(resolvedSettings)
@@ -118,7 +118,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should use init value when remote value is null
         assertEquals(80.0, resolvedSettings?.config?.recordingSessionsPercent)
@@ -136,7 +136,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = -10.0)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
         assertEquals(50.0, resolvedSettings?.config?.recordingSessionsPercent)
@@ -154,14 +154,14 @@ class RemoteSettingsModeTest {
             isRecordingEnabled = true,
             sdkConfig = SdkConfig(recordSessionsPercent = 0.0)
         )
-        assertEquals(0.0, SessionReplayManager.applyRemoteSettings(config, result0)?.config?.recordingSessionsPercent)
+        assertEquals(0.0, SessionReplayManager.resolveRemoteSettings(config, result0)?.config?.recordingSessionsPercent)
 
         // Test 100.0 (valid boundary)
         val result100 = RemoteSettingsResult(
             isRecordingEnabled = true,
             sdkConfig = SdkConfig(recordSessionsPercent = 100.0)
         )
-        assertEquals(100.0, SessionReplayManager.applyRemoteSettings(config, result100)?.config?.recordingSessionsPercent)
+        assertEquals(100.0, SessionReplayManager.resolveRemoteSettings(config, result100)?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -173,7 +173,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         assertEquals(triggers, resolvedSettings?.recordingEventTriggers)
     }
@@ -191,7 +191,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should apply remote value
         assertEquals(config.copy(recordingSessionsPercent = 25.0), resolvedSettings?.config)
@@ -210,7 +210,7 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // FALLBACK mode should keep original config
         assertEquals(config, resolvedSettings?.config)
@@ -228,7 +228,7 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should use cached value
         assertEquals(config.copy(recordingSessionsPercent = 50.0), resolvedSettings?.config)
@@ -246,7 +246,7 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should keep original config when sdk_config is missing
         assertEquals(config, resolvedSettings?.config)
@@ -263,7 +263,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should use init value when remote value is null
         assertEquals(60.0, resolvedSettings?.config?.recordingSessionsPercent)
@@ -280,7 +280,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 150.0) // Invalid: > 100
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
         assertEquals(40.0, resolvedSettings?.config?.recordingSessionsPercent)
@@ -295,7 +295,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         assertEquals(triggers, resolvedSettings?.recordingEventTriggers)
     }
@@ -314,7 +314,7 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // DISABLED mode should ignore even cached config
         assertEquals(config, resolvedSettings?.config)
@@ -332,7 +332,7 @@ class RemoteSettingsModeTest {
             isFromCache = true // Simulating API failure
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // DISABLED mode should return resolved (not null like STRICT)
         assertNotNull(resolvedSettings)
@@ -348,7 +348,7 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings = SessionReplayManager.resolveRemoteSettings(config, result)
 
         // DISABLED mode should return null for event triggers
         assertNull(resolvedSettings?.recordingEventTriggers)
@@ -364,17 +364,17 @@ class RemoteSettingsModeTest {
         // STRICT: sdkConfig object exists, so SDK initializes with init value
         val strictConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.STRICT)
         val strictResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(strictConfig, strictResult)?.config?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.resolveRemoteSettings(strictConfig, strictResult)?.config?.recordingSessionsPercent)
 
         // FALLBACK: uses init value
         val fallbackConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.FALLBACK)
         val fallbackResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(fallbackConfig, fallbackResult)?.config?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.resolveRemoteSettings(fallbackConfig, fallbackResult)?.config?.recordingSessionsPercent)
 
         // DISABLED: always uses init value
         val disabledConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.DISABLED)
         val disabledResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(disabledConfig, disabledResult)?.config?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.resolveRemoteSettings(disabledConfig, disabledResult)?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -387,17 +387,17 @@ class RemoteSettingsModeTest {
 
         // STRICT mode
         val strictConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.STRICT)
-        assertTrue(SessionReplayManager.applyRemoteSettings(strictConfig, enabledResult)?.isRecordingEnabled == true)
-        assertFalse(SessionReplayManager.applyRemoteSettings(strictConfig, disabledResult)?.isRecordingEnabled == true)
+        assertTrue(SessionReplayManager.resolveRemoteSettings(strictConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.resolveRemoteSettings(strictConfig, disabledResult)?.isRecordingEnabled == true)
 
         // FALLBACK mode
         val fallbackConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.FALLBACK)
-        assertTrue(SessionReplayManager.applyRemoteSettings(fallbackConfig, enabledResult)?.isRecordingEnabled == true)
-        assertFalse(SessionReplayManager.applyRemoteSettings(fallbackConfig, disabledResult)?.isRecordingEnabled == true)
+        assertTrue(SessionReplayManager.resolveRemoteSettings(fallbackConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.resolveRemoteSettings(fallbackConfig, disabledResult)?.isRecordingEnabled == true)
 
         // DISABLED mode
         val disabledConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.DISABLED)
-        assertTrue(SessionReplayManager.applyRemoteSettings(disabledConfig, enabledResult)?.isRecordingEnabled == true)
-        assertFalse(SessionReplayManager.applyRemoteSettings(disabledConfig, disabledResult)?.isRecordingEnabled == true)
+        assertTrue(SessionReplayManager.resolveRemoteSettings(disabledConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.resolveRemoteSettings(disabledConfig, disabledResult)?.isRecordingEnabled == true)
     }
 }

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
@@ -31,12 +31,12 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should keep original config, ignoring remote config
-        assertEquals(config, resolved?.config)
+        assertEquals(config, resolvedSettings?.config)
         // Event triggers should be null in DISABLED mode
-        assertNull(resolved?.recordingEventTriggers)
+        assertNull(resolvedSettings?.recordingEventTriggers)
     }
 
     @Test
@@ -63,10 +63,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 10.0)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should apply remote value
-        assertEquals(config.copy(recordingSessionsPercent = 10.0), resolved?.config)
+        assertEquals(config.copy(recordingSessionsPercent = 10.0), resolvedSettings?.config)
     }
 
     @Test
@@ -82,10 +82,10 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // STRICT mode should return null when API fails, disabling SDK initialization
-        assertNull(resolved)
+        assertNull(resolvedSettings)
     }
 
     @Test
@@ -101,10 +101,10 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // STRICT mode should return null when sdk_config is missing, disabling SDK initialization
-        assertNull(resolved)
+        assertNull(resolvedSettings)
     }
 
     @Test
@@ -118,10 +118,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is null
-        assertEquals(80.0, resolved?.config?.recordingSessionsPercent)
+        assertEquals(80.0, resolvedSettings?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -136,10 +136,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = -10.0)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
-        assertEquals(50.0, resolved?.config?.recordingSessionsPercent)
+        assertEquals(50.0, resolvedSettings?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -173,9 +173,9 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
-        assertEquals(triggers, resolved?.recordingEventTriggers)
+        assertEquals(triggers, resolvedSettings?.recordingEventTriggers)
     }
 
     // --- FALLBACK Mode Tests ---
@@ -191,10 +191,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should apply remote value
-        assertEquals(config.copy(recordingSessionsPercent = 25.0), resolved?.config)
+        assertEquals(config.copy(recordingSessionsPercent = 25.0), resolvedSettings?.config)
     }
 
     @Test
@@ -210,10 +210,10 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // FALLBACK mode should keep original config
-        assertEquals(config, resolved?.config)
+        assertEquals(config, resolvedSettings?.config)
     }
 
     @Test
@@ -228,10 +228,10 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use cached value
-        assertEquals(config.copy(recordingSessionsPercent = 50.0), resolved?.config)
+        assertEquals(config.copy(recordingSessionsPercent = 50.0), resolvedSettings?.config)
     }
 
     @Test
@@ -246,10 +246,10 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should keep original config when sdk_config is missing
-        assertEquals(config, resolved?.config)
+        assertEquals(config, resolvedSettings?.config)
     }
 
     @Test
@@ -263,10 +263,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is null
-        assertEquals(60.0, resolved?.config?.recordingSessionsPercent)
+        assertEquals(60.0, resolvedSettings?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -280,10 +280,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 150.0) // Invalid: > 100
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
-        assertEquals(40.0, resolved?.config?.recordingSessionsPercent)
+        assertEquals(40.0, resolvedSettings?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -295,9 +295,9 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
-        assertEquals(triggers, resolved?.recordingEventTriggers)
+        assertEquals(triggers, resolvedSettings?.recordingEventTriggers)
     }
 
     // --- DISABLED Mode Additional Tests ---
@@ -314,10 +314,10 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // DISABLED mode should ignore even cached config
-        assertEquals(config, resolved?.config)
+        assertEquals(config, resolvedSettings?.config)
     }
 
     @Test
@@ -332,11 +332,11 @@ class RemoteSettingsModeTest {
             isFromCache = true // Simulating API failure
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // DISABLED mode should return resolved (not null like STRICT)
-        assertNotNull(resolved)
-        assertEquals(config, resolved?.config)
+        assertNotNull(resolvedSettings)
+        assertEquals(config, resolvedSettings?.config)
     }
 
     @Test
@@ -348,10 +348,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordingEventTriggers = triggers)
         )
 
-        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolvedSettings =SessionReplayManager.applyRemoteSettings(config, result)
 
         // DISABLED mode should return null for event triggers
-        assertNull(resolved?.recordingEventTriggers)
+        assertNull(resolvedSettings?.recordingEventTriggers)
     }
 
     // --- Edge Case Tests ---

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsModeTest.kt
@@ -1,11 +1,15 @@
 package com.mixpanel.android.sessionreplay
 
 import com.mixpanel.android.sessionreplay.models.MPSessionReplayConfig
+import com.mixpanel.android.sessionreplay.models.RecordingEventTrigger
 import com.mixpanel.android.sessionreplay.models.RemoteSettingsMode
 import com.mixpanel.android.sessionreplay.network.SdkConfig
 import com.mixpanel.android.sessionreplay.services.RemoteSettingsResult
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 /**
@@ -27,10 +31,23 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should keep original config, ignoring remote config
-        assertEquals(config, finalConfig)
+        assertEquals(config, resolved?.config)
+        // Event triggers should be null in DISABLED mode
+        assertNull(resolved?.recordingEventTriggers)
+    }
+
+    @Test
+    fun testDisabledModePreservesIsRecordingEnabled() {
+        val config = MPSessionReplayConfig(remoteSettingsMode = RemoteSettingsMode.DISABLED)
+
+        val enabledResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = null)
+        val disabledResult = RemoteSettingsResult(isRecordingEnabled = false, sdkConfig = null)
+
+        assertTrue(SessionReplayManager.applyRemoteSettings(config, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.applyRemoteSettings(config, disabledResult)?.isRecordingEnabled == true)
     }
 
     // --- STRICT Mode Tests ---
@@ -46,10 +63,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 10.0)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should apply remote value
-        assertEquals(config.copy(recordingSessionsPercent = 10.0), finalConfig)
+        assertEquals(config.copy(recordingSessionsPercent = 10.0), resolved?.config)
     }
 
     @Test
@@ -65,10 +82,10 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // STRICT mode should return null when API fails, disabling SDK initialization
-        assertNull(finalConfig)
+        assertNull(resolved)
     }
 
     @Test
@@ -84,10 +101,10 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // STRICT mode should return null when sdk_config is missing, disabling SDK initialization
-        assertNull(finalConfig)
+        assertNull(resolved)
     }
 
     @Test
@@ -101,10 +118,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is null
-        assertEquals(80.0, finalConfig?.recordingSessionsPercent)
+        assertEquals(80.0, resolved?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -119,10 +136,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = -10.0)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
-        assertEquals(50.0, finalConfig?.recordingSessionsPercent)
+        assertEquals(50.0, resolved?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -137,14 +154,28 @@ class RemoteSettingsModeTest {
             isRecordingEnabled = true,
             sdkConfig = SdkConfig(recordSessionsPercent = 0.0)
         )
-        assertEquals(0.0, SessionReplayManager.applyRemoteSettings(config, result0)?.recordingSessionsPercent)
+        assertEquals(0.0, SessionReplayManager.applyRemoteSettings(config, result0)?.config?.recordingSessionsPercent)
 
         // Test 100.0 (valid boundary)
         val result100 = RemoteSettingsResult(
             isRecordingEnabled = true,
             sdkConfig = SdkConfig(recordSessionsPercent = 100.0)
         )
-        assertEquals(100.0, SessionReplayManager.applyRemoteSettings(config, result100)?.recordingSessionsPercent)
+        assertEquals(100.0, SessionReplayManager.applyRemoteSettings(config, result100)?.config?.recordingSessionsPercent)
+    }
+
+    @Test
+    fun testStrictModeIncludesEventTriggers() {
+        val config = MPSessionReplayConfig(remoteSettingsMode = RemoteSettingsMode.STRICT)
+        val triggers = mapOf("Purchase" to RecordingEventTrigger(percentage = 50.0))
+        val result = RemoteSettingsResult(
+            isRecordingEnabled = true,
+            sdkConfig = SdkConfig(recordingEventTriggers = triggers)
+        )
+
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+
+        assertEquals(triggers, resolved?.recordingEventTriggers)
     }
 
     // --- FALLBACK Mode Tests ---
@@ -160,10 +191,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 25.0)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should apply remote value
-        assertEquals(config.copy(recordingSessionsPercent = 25.0), finalConfig)
+        assertEquals(config.copy(recordingSessionsPercent = 25.0), resolved?.config)
     }
 
     @Test
@@ -179,10 +210,10 @@ class RemoteSettingsModeTest {
             isFromCache = true // API failed, using cache
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // FALLBACK mode should keep original config
-        assertEquals(config, finalConfig)
+        assertEquals(config, resolved?.config)
     }
 
     @Test
@@ -197,10 +228,10 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use cached value
-        assertEquals(config.copy(recordingSessionsPercent = 50.0), finalConfig)
+        assertEquals(config.copy(recordingSessionsPercent = 50.0), resolved?.config)
     }
 
     @Test
@@ -215,10 +246,10 @@ class RemoteSettingsModeTest {
             isFromCache = false // API succeeded but no sdk_config
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should keep original config when sdk_config is missing
-        assertEquals(config, finalConfig)
+        assertEquals(config, resolved?.config)
     }
 
     @Test
@@ -232,10 +263,10 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = null)
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is null
-        assertEquals(60.0, finalConfig?.recordingSessionsPercent)
+        assertEquals(60.0, resolved?.config?.recordingSessionsPercent)
     }
 
     @Test
@@ -249,10 +280,24 @@ class RemoteSettingsModeTest {
             sdkConfig = SdkConfig(recordSessionsPercent = 150.0) // Invalid: > 100
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // Should use init value when remote value is invalid
-        assertEquals(40.0, finalConfig?.recordingSessionsPercent)
+        assertEquals(40.0, resolved?.config?.recordingSessionsPercent)
+    }
+
+    @Test
+    fun testFallbackModeIncludesEventTriggers() {
+        val config = MPSessionReplayConfig(remoteSettingsMode = RemoteSettingsMode.FALLBACK)
+        val triggers = mapOf("Checkout" to RecordingEventTrigger(percentage = 100.0))
+        val result = RemoteSettingsResult(
+            isRecordingEnabled = true,
+            sdkConfig = SdkConfig(recordingEventTriggers = triggers)
+        )
+
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+
+        assertEquals(triggers, resolved?.recordingEventTriggers)
     }
 
     // --- DISABLED Mode Additional Tests ---
@@ -269,10 +314,10 @@ class RemoteSettingsModeTest {
             isFromCache = true
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
         // DISABLED mode should ignore even cached config
-        assertEquals(config, finalConfig)
+        assertEquals(config, resolved?.config)
     }
 
     @Test
@@ -287,10 +332,26 @@ class RemoteSettingsModeTest {
             isFromCache = true // Simulating API failure
         )
 
-        val finalConfig = SessionReplayManager.applyRemoteSettings(config, result)
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
 
-        // DISABLED mode should return config (not null like STRICT)
-        assertEquals(config, finalConfig)
+        // DISABLED mode should return resolved (not null like STRICT)
+        assertNotNull(resolved)
+        assertEquals(config, resolved?.config)
+    }
+
+    @Test
+    fun testDisabledModeIgnoresEventTriggers() {
+        val config = MPSessionReplayConfig(remoteSettingsMode = RemoteSettingsMode.DISABLED)
+        val triggers = mapOf("Test Event" to RecordingEventTrigger(percentage = 100.0))
+        val result = RemoteSettingsResult(
+            isRecordingEnabled = true,
+            sdkConfig = SdkConfig(recordingEventTriggers = triggers)
+        )
+
+        val resolved = SessionReplayManager.applyRemoteSettings(config, result)
+
+        // DISABLED mode should return null for event triggers
+        assertNull(resolved?.recordingEventTriggers)
     }
 
     // --- Edge Case Tests ---
@@ -303,16 +364,40 @@ class RemoteSettingsModeTest {
         // STRICT: sdkConfig object exists, so SDK initializes with init value
         val strictConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.STRICT)
         val strictResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(strictConfig, strictResult)?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(strictConfig, strictResult)?.config?.recordingSessionsPercent)
 
         // FALLBACK: uses init value
         val fallbackConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.FALLBACK)
         val fallbackResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(fallbackConfig, fallbackResult)?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(fallbackConfig, fallbackResult)?.config?.recordingSessionsPercent)
 
         // DISABLED: always uses init value
         val disabledConfig = initConfig.copy(remoteSettingsMode = RemoteSettingsMode.DISABLED)
         val disabledResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = emptySdkConfig)
-        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(disabledConfig, disabledResult)?.recordingSessionsPercent)
+        assertEquals(75.0, SessionReplayManager.applyRemoteSettings(disabledConfig, disabledResult)?.config?.recordingSessionsPercent)
+    }
+
+    @Test
+    fun testIsRecordingEnabledAlwaysPreserved() {
+        // isRecordingEnabled should be preserved in the resolved result regardless of mode
+        val config = MPSessionReplayConfig()
+
+        val enabledResult = RemoteSettingsResult(isRecordingEnabled = true, sdkConfig = SdkConfig())
+        val disabledResult = RemoteSettingsResult(isRecordingEnabled = false, sdkConfig = SdkConfig())
+
+        // STRICT mode
+        val strictConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.STRICT)
+        assertTrue(SessionReplayManager.applyRemoteSettings(strictConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.applyRemoteSettings(strictConfig, disabledResult)?.isRecordingEnabled == true)
+
+        // FALLBACK mode
+        val fallbackConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.FALLBACK)
+        assertTrue(SessionReplayManager.applyRemoteSettings(fallbackConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.applyRemoteSettings(fallbackConfig, disabledResult)?.isRecordingEnabled == true)
+
+        // DISABLED mode
+        val disabledConfig = config.copy(remoteSettingsMode = RemoteSettingsMode.DISABLED)
+        assertTrue(SessionReplayManager.applyRemoteSettings(disabledConfig, enabledResult)?.isRecordingEnabled == true)
+        assertFalse(SessionReplayManager.applyRemoteSettings(disabledConfig, disabledResult)?.isRecordingEnabled == true)
     }
 }


### PR DESCRIPTION
## Summary
- Refactored remote settings handling to use a new `ResolvedRemoteSettings` data class
- Consolidates all values needed for SDK initialization in one place:
  - `isRecordingEnabled`: always preserved from remote settings
  - `config`: processed MPSessionReplayConfig based on mode
  - `recordingEventTriggers`: null in DISABLED mode, otherwise from remote config
- Simplifies initialization code by removing scattered mode checks
- Event triggers from remote config are now properly skipped when `remoteSettingsMode = DISABLED`

## Test plan
- [x] Unit tests pass (`./gradlew :session-replay:testDebugUnitTest`)
- [ ] Manual test: Initialize with `remoteSettingsMode = DISABLED` and verify event triggers are not applied
- [ ] Manual test: Initialize with `STRICT` and `FALLBACK` modes and verify event triggers work