### PR TITLE
feat(analytics): extend Source.Fallback with Reason enum (SDK-79)

### DIFF
--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -660,8 +660,52 @@ public class FeatureFlagManagerTest {
     assertNotNull(resultRef.get());
     assertEquals(fallback.key, resultRef.get().key);
     assertEquals(fallback.value, resultRef.get().value);
+    // SDK-79: async fetch-fail with no cached/persisted data → BACKEND_ERROR,
+    // distinguishing "the backend gave us nothing" from "we haven't tried yet."
+    assertEquals(
+        MixpanelFlagVariant.Source.fallback(
+            MixpanelFlagVariant.Source.Fallback.Reason.BACKEND_ERROR),
+        resultRef.get().source);
     assertFalse(mFeatureFlagManager.areFlagsReady());
     assertEquals(0, mMockDelegate.trackCalls.size()); // No tracking on fallback
+  }
+
+  @Test
+  public void testGetVariant_Async_flagsReady_flagMissing_returnsFallbackWithFlagNotFound()
+      throws InterruptedException {
+    // Prime a successful fetch so mFlags is populated but doesn't contain the key we'll ask for.
+    setupFlagsConfig(true, new JSONObject());
+    Map<String, MixpanelFlagVariant> serverFlags = new HashMap<>();
+    serverFlags.put("some_other_flag", new MixpanelFlagVariant("v", "val"));
+    mMockRemoteService.addResponse(
+        createFlagsResponseJson(serverFlags).getBytes(StandardCharsets.UTF_8));
+    mFeatureFlagManager.loadFlags();
+    for (int i = 0; i < 20 && !mFeatureFlagManager.areFlagsReady(); ++i) Thread.sleep(100);
+    assertTrue(mFeatureFlagManager.areFlagsReady());
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<MixpanelFlagVariant> resultRef = new AtomicReference<>();
+    MixpanelFlagVariant fallback = new MixpanelFlagVariant("fb_key_async", "fb_val_async");
+
+    mFeatureFlagManager.getVariant(
+        "not_in_the_response",
+        fallback,
+        result -> {
+          resultRef.set(result);
+          latch.countDown();
+        });
+
+    assertTrue(
+        "Callback should complete within timeout",
+        latch.await(ASYNC_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    assertNotNull(resultRef.get());
+    assertEquals(fallback.key, resultRef.get().key);
+    assertEquals(fallback.value, resultRef.get().value);
+    // Flags loaded, key just isn't there — FLAG_NOT_FOUND, not NOT_READY or BACKEND_ERROR.
+    assertEquals(
+        MixpanelFlagVariant.Source.fallback(
+            MixpanelFlagVariant.Source.Fallback.Reason.FLAG_NOT_FOUND),
+        resultRef.get().source);
   }
 
   @Test

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -351,7 +351,8 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
       MPLog.w(
           LOGTAG,
           "Flags not ready for getVariantSync call for '" + flagName + "'. Returning fallback.");
-      return fallback;
+      return fallback.withSource(
+          MixpanelFlagVariant.Source.fallback(MixpanelFlagVariant.Source.Fallback.Reason.NOT_READY));
     }
 
     // Use a container to get results back from the handler thread runnable
@@ -397,7 +398,8 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
     } else {
       // Flag key not found in the loaded flags
       MPLog.i(LOGTAG, "Flag '" + flagName + "' not found sync. Returning fallback.");
-      return fallback;
+      return fallback.withSource(
+          MixpanelFlagVariant.Source.fallback(MixpanelFlagVariant.Source.Fallback.Reason.FLAG_NOT_FOUND));
     }
   }
 

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -483,7 +483,15 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
             MixpanelFlagVariant flagVariant = mFlags.get(flagName);
             final MixpanelFlagVariant variantForLambda = flagVariant;
             boolean needsTracking = (variantForLambda != null) && checkAndSetTrackedFlag(flagName);
-            MixpanelFlagVariant result = (variantForLambda != null) ? variantForLambda : fallback;
+            // Flags loaded (not network-first-awaiting, not stale) but this key isn't in
+            // mFlags — stamp .FLAG_NOT_FOUND so the OpenFeature wrapper can map to
+            // FLAG_NOT_FOUND. Same treatment getVariantSync applies on its miss path.
+            MixpanelFlagVariant result =
+                (variantForLambda != null)
+                    ? variantForLambda
+                    : fallback.withSource(
+                        MixpanelFlagVariant.Source.fallback(
+                            MixpanelFlagVariant.Source.Fallback.Reason.FLAG_NOT_FOUND));
 
             new Handler(Looper.getMainLooper())
                 .post(
@@ -535,8 +543,18 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
                 final MixpanelFlagVariant variantForLambda = fetchedVariant;
                 boolean tracked =
                     (variantForLambda != null) && checkAndSetTrackedFlag(flagName);
+                // No served variant. Distinguish "fetch failed AND we have no cached/persisted
+                // flags" (BACKEND_ERROR) from "key just isn't in the loaded set" (FLAG_NOT_FOUND).
+                // The former lets the OpenFeature wrapper map to GENERAL_ERROR instead of
+                // FLAG_NOT_FOUND.
+                final MixpanelFlagVariant.Source.Fallback.Reason fallbackReason =
+                    (!success && mFlags == null)
+                        ? MixpanelFlagVariant.Source.Fallback.Reason.BACKEND_ERROR
+                        : MixpanelFlagVariant.Source.Fallback.Reason.FLAG_NOT_FOUND;
                 MixpanelFlagVariant finalResult =
-                    (variantForLambda != null) ? variantForLambda : fallback;
+                    (variantForLambda != null)
+                        ? variantForLambda
+                        : fallback.withSource(MixpanelFlagVariant.Source.fallback(fallbackReason));
 
                 new Handler(Looper.getMainLooper())
                     .post(

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -47,10 +47,25 @@ public class MixpanelFlagVariant {
             return new Persistence(persistedAtMillis);
         }
 
-        /** Singleton {@link Fallback} instance — every call returns the same one. */
+        /**
+         * Singleton {@link Fallback} instance with {@link Fallback.Reason#UNSPECIFIED}.
+         * Used when constructing developer-supplied fallbacks; the SDK stamps a
+         * specific reason before returning.
+         */
         @NonNull
         public static Fallback fallback() {
             return Fallback.INSTANCE;
+        }
+
+        /**
+         * Returns a {@link Fallback} source tagged with the given reason.
+         * The SDK uses this to explain why a fallback was returned (flag missing
+         * from the cache, evaluation error, etc.) so callers — especially the
+         * OpenFeature wrapper — can map to the right user-facing error code.
+         */
+        @NonNull
+        public static Fallback fallback(@NonNull Fallback.Reason reason) {
+            return new Fallback(reason);
         }
 
         /** Variant assigned by the most recent successful /flags/ network call. */
@@ -76,13 +91,50 @@ public class MixpanelFlagVariant {
          * Developer-supplied fallback returned by the SDK because no flag was found, the
          * lookup happened before flags were ready, or a fetch failed without a usable
          * persisted blob to fall back to.
+         *
+         * <p>Carries a {@link Reason} so callers can tell <em>why</em> the SDK fell back —
+         * previously a Fallback meant only "not a real variant," which collapsed several
+         * distinct outcomes into one (SDK-79).
          */
         public static final class Fallback extends Source {
+            /**
+             * Why the SDK returned the developer fallback.
+             *
+             * <p>Network/cache SDKs (like Android) cannot distinguish "flag does not exist"
+             * from "user is not in any rollout" without server-side cooperation — both
+             * surface as {@link #FLAG_NOT_FOUND} for now. Future server changes can add
+             * a more specific reason without breaking callers that already handle this enum.
+             */
+            public enum Reason {
+                /**
+                 * Developer-constructed default. The SDK stamps a more specific reason
+                 * before returning, so callers should rarely observe this value.
+                 */
+                UNSPECIFIED,
+                /** Flag key was not present in the cache or network response. */
+                FLAG_NOT_FOUND,
+                /** Flags were not ready when the sync lookup happened. */
+                NOT_READY,
+                /** An exception occurred during evaluation. */
+                EVALUATION_ERROR,
+            }
+
+            /** Singleton for the unspecified case (developer construction). */
             // Held inside the subclass so the outer class's <clinit> does not reference it,
             // sidestepping the "subclass referenced from superclass initializer" deadlock pattern.
-            static final Fallback INSTANCE = new Fallback();
+            static final Fallback INSTANCE = new Fallback(Reason.UNSPECIFIED);
 
-            Fallback() {}
+            /** Reason the SDK returned this fallback. */
+            @NonNull
+            public final Reason reason;
+
+            Fallback() {
+                this(Reason.UNSPECIFIED);
+            }
+
+            Fallback(@NonNull Reason reason) {
+                this.reason = reason;
+            }
         }
     }
 
@@ -191,9 +243,13 @@ public class MixpanelFlagVariant {
     /**
      * Returns a copy of this variant stamped with the given source metadata.
      * Other fields (key, value, experiment fields) are preserved by reference.
+     *
+     * <p>Public so callers (and tests in adjacent packages) can construct
+     * variants with explicit source metadata — the SDK uses this internally
+     * to stamp the reason a developer-supplied fallback was returned.
      */
     @NonNull
-    MixpanelFlagVariant withSource(@NonNull Source source) {
+    public MixpanelFlagVariant withSource(@NonNull Source source) {
         return new MixpanelFlagVariant(
                 this.key,
                 this.value,

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -48,16 +48,6 @@ public class MixpanelFlagVariant {
         }
 
         /**
-         * Singleton {@link Fallback} instance with {@link Fallback.Reason#UNSPECIFIED}.
-         * Used when constructing developer-supplied fallbacks; the SDK stamps a
-         * specific reason before returning.
-         */
-        @NonNull
-        public static Fallback fallback() {
-            return Fallback.INSTANCE;
-        }
-
-        /**
          * Returns a {@link Fallback} source tagged with the given reason.
          * The SDK uses this to explain why a fallback was returned (flag missing
          * from the cache, evaluation error, etc.) so callers — especially the
@@ -122,29 +112,15 @@ public class MixpanelFlagVariant {
              * a more specific reason without breaking callers that already handle this enum.
              */
             public enum Reason {
-                /**
-                 * Developer-constructed default. The SDK stamps a more specific reason
-                 * before returning, so callers should rarely observe this value.
-                 */
-                UNSPECIFIED,
                 /** Flag key was not present in the cache or network response. */
                 FLAG_NOT_FOUND,
                 /** Flags were not ready when the sync lookup happened. */
                 NOT_READY,
             }
 
-            /** Singleton for the unspecified case (developer construction). */
-            // Held inside the subclass so the outer class's <clinit> does not reference it,
-            // sidestepping the "subclass referenced from superclass initializer" deadlock pattern.
-            static final Fallback INSTANCE = new Fallback(Reason.UNSPECIFIED);
-
             /** Reason the SDK returned this fallback. */
             @NonNull
             public final Reason reason;
-
-            Fallback() {
-                this(Reason.UNSPECIFIED);
-            }
 
             Fallback(@NonNull Reason reason) {
                 this.reason = reason;
@@ -227,7 +203,7 @@ public class MixpanelFlagVariant {
         this.experimentID = null;
         this.isExperimentActive = null;
         this.isQATester = null;
-        this.source = Source.fallback();
+        this.source = Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);
     }
 
     /**
@@ -246,7 +222,7 @@ public class MixpanelFlagVariant {
         this.experimentID = experimentID;
         this.isExperimentActive = isExperimentActive;
         this.isQATester = isQATester;
-        this.source = Source.fallback();
+        this.source = Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);
     }
 
     /**
@@ -301,7 +277,7 @@ public class MixpanelFlagVariant {
         this.experimentID = null;
         this.isExperimentActive = null;
         this.isQATester = null;
-        this.source = Source.fallback();
+        this.source = Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);
     }
 
     /**
@@ -319,7 +295,7 @@ public class MixpanelFlagVariant {
         this.experimentID = null;
         this.isExperimentActive = null;
         this.isQATester = null;
-        this.source = Source.fallback();
+        this.source = Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);
     }
 
     /**
@@ -333,6 +309,6 @@ public class MixpanelFlagVariant {
         this.experimentID = null;
         this.isExperimentActive = null;
         this.isQATester = null;
-        this.source = Source.fallback();
+        this.source = Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);
     }
 }

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -25,7 +25,8 @@ public class MixpanelFlagVariant {
      * keyword) so that variant-specific data — namely the {@code persistedAtMillis}
      * timestamp on {@link Persistence} — is bundled with the variant rather than
      * floating as a separate nullable field on {@link MixpanelFlagVariant}.
-     * Construct via {@link #network()} / {@link #persistence(long)} / {@link #fallback()}.
+     * Construct via {@link #network()} / {@link #persistence(long)} /
+     * {@link #fallback(Fallback.Reason)}.
      */
     public abstract static class Source {
         Source() {}
@@ -116,6 +117,13 @@ public class MixpanelFlagVariant {
                 FLAG_NOT_FOUND,
                 /** Flags were not ready when the sync lookup happened. */
                 NOT_READY,
+                /**
+                 * Network fetch failed and no cached/persisted variant was available.
+                 * Only surfaced on the async {@link MixpanelAPI.Flags#getVariant} path —
+                 * {@link MixpanelAPI.Flags#getVariantSync} cannot distinguish
+                 * "network error" from "flags never loaded."
+                 */
+                BACKEND_ERROR,
             }
 
             /** Reason the SDK returned this fallback. */

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -75,6 +75,8 @@ public class MixpanelFlagVariant {
             static final Network INSTANCE = new Network();
 
             Network() {}
+
+            @Override public String toString() { return "Network"; }
         }
 
         /** Variant loaded from the on-disk persistence layer. */
@@ -85,6 +87,20 @@ public class MixpanelFlagVariant {
             Persistence(long persistedAtMillis) {
                 this.persistedAtMillis = persistedAtMillis;
             }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (!(o instanceof Persistence)) return false;
+                return persistedAtMillis == ((Persistence) o).persistedAtMillis;
+            }
+
+            @Override
+            public int hashCode() {
+                return (int) (persistedAtMillis ^ (persistedAtMillis >>> 32));
+            }
+
+            @Override public String toString() { return "Persistence(persistedAtMillis=" + persistedAtMillis + ")"; }
         }
 
         /**
@@ -133,6 +149,20 @@ public class MixpanelFlagVariant {
             Fallback(@NonNull Reason reason) {
                 this.reason = reason;
             }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (!(o instanceof Fallback)) return false;
+                return reason == ((Fallback) o).reason;
+            }
+
+            @Override
+            public int hashCode() {
+                return reason.hashCode();
+            }
+
+            @Override public String toString() { return "Fallback(" + reason + ")"; }
         }
     }
 

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelFlagVariant.java
@@ -115,8 +115,6 @@ public class MixpanelFlagVariant {
                 FLAG_NOT_FOUND,
                 /** Flags were not ready when the sync lookup happened. */
                 NOT_READY,
-                /** An exception occurred during evaluation. */
-                EVALUATION_ERROR,
             }
 
             /** Singleton for the unspecified case (developer construction). */

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -462,6 +462,9 @@ public class FeatureFlagManagerTest {
 
     assertEquals("Should return fallback key", fallback.key, result.key);
     assertEquals("Should return fallback value", fallback.value, result.value);
+    assertEquals(
+        MixpanelFlagVariant.Source.fallback(MixpanelFlagVariant.Source.Fallback.Reason.NOT_READY),
+        result.source);
   }
 
   @Test
@@ -499,6 +502,10 @@ public class FeatureFlagManagerTest {
 
     assertEquals("Should return fallback key", fallback.key, result.key);
     assertEquals("Should return fallback value", fallback.value, result.value);
+    assertEquals(
+        MixpanelFlagVariant.Source.fallback(
+            MixpanelFlagVariant.Source.Fallback.Reason.FLAG_NOT_FOUND),
+        result.source);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **`MixpanelFlagVariant.Source.Fallback` now carries a `Reason`**: `FLAG_NOT_FOUND` | `NOT_READY` | `BACKEND_ERROR`. `getVariantSync` stamps `NOT_READY` when flags haven't loaded and `FLAG_NOT_FOUND` when the key is absent from the loaded set. Async `getVariant` upgrades to `BACKEND_ERROR` when a network fetch fails and no cached/persisted flags are available.
- `MixpanelFlagVariant.withSource(Source)` is now public so callers (and the openfeature-provider) can stamp source metadata.
- `Source.Fallback` and `Source.Persistence` gained `equals` / `hashCode` / `toString` so tests and downstream code can compare instances.

## ⚠ Breaking change

`Source.Fallback` gained a required `Reason`, and the no-arg `Source.fallback()` factory was removed:

```java
// Before
switch (source) { case Source.Fallback f: ... }
if (source instanceof Source.Fallback) { ... }
Source.fallback();

// After
switch (source) { case Source.Fallback f: /* f.reason */ ... }
if (source instanceof Source.Fallback) { ((Source.Fallback) source).reason /* ... */ }
Source.fallback(Source.Fallback.Reason.FLAG_NOT_FOUND);   // reason required
```

The default-arg trick isn't idiomatic in Java, so this is a hard cut. Dropping the no-arg factory forces every construction site to name an explicit reason — every value the customer observes is actionable, and no placeholder can leak into the SDK's typed contract.

## Why

Today the OpenFeature wrapper in `openfeature-provider/` collapses every fallback to `FLAG_NOT_FOUND`, sending callers debugging a default value chasing the flag name when the real cause was usually `NOT_READY` or a backend failure. The new `Reason` lets the wrapper map each case to the spec-correct error code.

Discriminated union (`Source.Fallback` carrying `Reason`) rather than two flat fields because the type system can model it: invalid states like "successful evaluation with a fallback reason" are unrepresentable, mirroring the existing `Source.Persistence.persistedAtMillis` design. Reason names align with the Swift SDK-79 shape ([mixpanel-swift#745](https://github.com/mixpanel/mixpanel-swift/pull/745)); the dynamic-typed SDKs (JS, PHP) use a sibling flat `fallback_reason` string field with matching values.

Cross-SDK fix tracked at [Linear SDK-79](https://linear.app/mixpanel/issue/SDK-79).

## Server-side note

`FLAG_NOT_FOUND` today still collapses "flag does not exist" with "user not in any rollout" because the `/flags` response can't tell them apart. This change preps the SDK to surface the distinction once the server returns it; no behavioral change for that case until then.

## Follow-up PR

The `openfeature-provider/` module needs a matching update to dispatch on `Source.Fallback.reason` — that PR depends on this one shipping in a new `mixpanel-android` release first (the provider consumes the published Maven coordinate). It'll come right after release.

## Test plan

- [x] `./gradlew :analytics:compileDebugJavaWithJavac` — clean compile
- [x] `./gradlew :analytics:androidJavadocs` — passes (was CI blocker on the prior commit)
- [x] JVM unit tests: `getVariantSync` returns the right `Reason` for each fallback path (`NOT_READY` / `FLAG_NOT_FOUND`)
- [x] Instrumented tests updated: `testGetVariant_Async_flagsNotReady_fetchFails_returnsFallback` now asserts `BACKEND_ERROR`; new `testGetVariant_Async_flagsReady_flagMissing_returnsFallbackWithFlagNotFound` covers the async served-immediately miss path
- [ ] Wrapper PR pending base SDK release (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)