### PR TITLE
fix(analytics): expose Flags.shutdown() to release worker thread + executor (SDK-88)

### DIFF
--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/FeatureFlagManager.java
@@ -175,10 +175,14 @@ class FeatureFlagManager implements MixpanelAPI.Flags {
     }
   }
 
-  // Stop the worker HandlerThread and network executor so they don't outlive a test JVM
-  // worker (non-daemon threads would otherwise keep gradle's test JVM alive after a failure).
-  // Package-private; idempotent.
-  void close() {
+  /**
+   * Stops the worker {@link HandlerThread} and the network request executor.
+   * Invoked from lifecycle hooks that own this flag instance — notably
+   * an OpenFeature {@code FeatureProvider.shutdown()} hook — so the
+   * non-daemon threads don't outlive their intended owner. Idempotent.
+   */
+  @Override
+  public void shutdown() {
     try {
       mHandler.getLooper().quitSafely();
     } catch (Exception e) {

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -1983,6 +1983,19 @@ public class MixpanelAPI implements FeatureFlagDelegate {
          */
         boolean areFlagsReady();
 
+        /**
+         * Releases resources held by this flags instance. Intended to be
+         * invoked from lifecycle hooks that own the flag instance — most
+         * notably an OpenFeature {@code FeatureProvider.shutdown()} hook.
+         * The SDK-provided implementation stops its dedicated worker
+         * thread and network executor; both are non-daemon and would
+         * otherwise keep a long-lived process from exiting cleanly.
+         *
+         * <p>Idempotent. Calling any flag method after {@code shutdown()}
+         * is undefined and may silently no-op.
+         */
+        void shutdown();
+
         // --- Sync Flag Retrieval ---
 
         /**

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/FeatureFlagManagerTest.java
@@ -336,7 +336,7 @@ public class FeatureFlagManagerTest {
   @After
   public void tearDown() {
     if (mFeatureFlagManager != null) {
-      mFeatureFlagManager.close();
+      mFeatureFlagManager.shutdown();
     }
     MPLog.setLevel(mPreviousLogLevel);
   }


### PR DESCRIPTION
## Summary

`FeatureFlagManager` creates a non-daemon `HandlerThread` + single-thread `ExecutorService` that previously had no public release path. The package-private `close()` existed only as a test-only escape hatch. OpenFeature's `FeatureProvider.shutdown()` lifecycle hook — the primary motivating caller — has no way to release those resources today.

- Add `shutdown()` to the public `MixpanelAPI.Flags` interface
- Rename `FeatureFlagManager.close()` → public `shutdown()` (same body, idempotent)
- Reframe docs around the OpenFeature lifecycle motivation

The `MixpanelProvider.shutdown()` wiring that actually invokes this is split into a follow-up PR — `openfeature-provider`'s `build.gradle.kts` pins a Maven coordinate for `mixpanel-android`, so it cannot compile against the new interface method until this ships as a release.

## Compatibility

Adding a method to a public interface is a source and binary break for anyone implementing `MixpanelAPI.Flags` themselves. Mockito mocks are unaffected. External implementers are rare — the interface exists mainly to be consumed via `mixpanel.getFlags()` — but this is worth calling out in the CHANGELOG for the release cutting the change.

## Test plan

- [x] `:analytics:testDebugUnitTest` passes (`FeatureFlagManagerTest.tearDown()` exercises `shutdown()` on every test)
- [x] `:openfeature-provider:compileDebugKotlin` still resolves against `mixpanel-android:8.5.0` on Maven and compiles cleanly (this branch no longer touches the provider)

## Context

Linear: SDK-88