### PR TITLE
fix(analytics): isolate AnalyticsMessages and HttpService per instance [SDK-109]

### DIFF
--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutomaticEventsTest.java
@@ -156,7 +156,7 @@ public class AutomaticEventsTest {
 
             @Override
                 /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token, final String instanceName, final DeviceIdProvider deviceIdProvider) {
-                String instanceKey = instanceName != null ? instanceName : token;
+                String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
                 final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
                 final SharedPreferences ret = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
                 ret.edit().clear().commit();

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagOptionsTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/FeatureFlagOptionsTest.java
@@ -43,7 +43,8 @@ public class FeatureFlagOptionsTest {
     AnalyticsMessages messages =
         AnalyticsMessages.getInstance(
             InstrumentationRegistry.getInstrumentation().getContext(),
-            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null));
+            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null),
+            null);
     messages.hardKill();
     Thread.sleep(2000);
   }

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -56,7 +56,8 @@ public class MixpanelBasicTest {
     AnalyticsMessages messages =
         AnalyticsMessages.getInstance(
             InstrumentationRegistry.getInstrumentation().getContext(),
-            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null));
+            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null),
+            null);
     messages.hardKill();
     Thread.sleep(2000);
 
@@ -1139,7 +1140,7 @@ public class MixpanelBasicTest {
           final String token,
           final String instanceName,
           final DeviceIdProvider deviceIdProvider) {
-        String instanceKey = instanceName != null ? instanceName : token;
+        String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
         final String mixpanelPrefsName = "com.mixpanel.android.mpmetrics.Mixpanel";
         final SharedPreferences mpSharedPrefs =
             context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);
@@ -1573,7 +1574,7 @@ public class MixpanelBasicTest {
           final String token,
           final String instanceName,
           final DeviceIdProvider deviceIdProvider) {
-        String instanceKey = instanceName != null ? instanceName : token;
+        String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
         final String mixpanelPrefsName = "com.mixpanel.android.mpmetrics.Mixpanel";
         final SharedPreferences mpSharedPrefs =
             context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelDeviceIdProviderTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelDeviceIdProviderTest.java
@@ -41,7 +41,7 @@ public class MixpanelDeviceIdProviderTest {
 
         // Kill any existing AnalyticsMessages to ensure clean state
         AnalyticsMessages messages = AnalyticsMessages.getInstance(
-                mContext, MPConfig.getInstance(mContext, null));
+                mContext, MPConfig.getInstance(mContext, null), null);
         messages.hardKill();
         Thread.sleep(500);
     }
@@ -50,7 +50,7 @@ public class MixpanelDeviceIdProviderTest {
     public void tearDown() throws Exception {
         // Clean up any singleton instances
         AnalyticsMessages messages = AnalyticsMessages.getInstance(
-                mContext, MPConfig.getInstance(mContext, null));
+                mContext, MPConfig.getInstance(mContext, null), null);
         messages.hardKill();
         Thread.sleep(200);
     }

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelScreenTrackingTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/MixpanelScreenTrackingTest.java
@@ -32,7 +32,8 @@ public class MixpanelScreenTrackingTest {
     AnalyticsMessages messages =
         AnalyticsMessages.getInstance(
             InstrumentationRegistry.getInstrumentation().getContext(),
-            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null));
+            MPConfig.getInstance(InstrumentationRegistry.getInstrumentation().getContext(), null),
+            null);
     messages.hardKill();
     Thread.sleep(2000);
   }

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/AnalyticsMessages.java
@@ -60,7 +60,6 @@ import org.json.JSONObject;
     /* package */ AnalyticsMessages(final Context context, MPConfig config) {
         mContext = context;
         mConfig = config;
-        mInstanceName = config.getInstanceName();
         mWorker = createWorker();
         getPoster().checkIsServerBlocked();
     }
@@ -72,20 +71,27 @@ import org.json.JSONObject;
     /**
      * Use this to get an instance of AnalyticsMessages instead of creating one directly for yourself.
      *
+     * <p>Instances are keyed by {@code MPConfig.getInstanceName()} when set, otherwise by the
+     * project {@code token}. This mirrors {@code MixpanelAPI.getInstance} so that two
+     * {@code MixpanelAPI} instances configured with different tokens (and no explicit instance
+     * name) do not share a worker, config, or HTTP poster.
+     *
      * @param messageContext should be the Main Activity of the application associated with these
      *     messages.
      * @param config The MPConfig configuration settings for the AnalyticsMessages instance.
+     * @param token The Mixpanel project token, used as the map key when no instance name is set.
      */
-    public static AnalyticsMessages getInstance(final Context messageContext, MPConfig config) {
+    public static AnalyticsMessages getInstance(
+            final Context messageContext, MPConfig config, String token) {
         synchronized (sInstances) {
             final Context appContext = messageContext.getApplicationContext();
             AnalyticsMessages ret;
-            String instanceName = config.getInstanceName();
-            if (!sInstances.containsKey(instanceName)) {
+            String instanceKey = MPConfig.resolveInstanceKey(config.getInstanceName(), token);
+            if (!sInstances.containsKey(instanceKey)) {
                 ret = new AnalyticsMessages(appContext, config);
-                sInstances.put(instanceName, ret);
+                sInstances.put(instanceKey, ret);
             } else {
-                ret = sInstances.get(instanceName);
+                ret = sInstances.get(instanceKey);
             }
             return ret;
         }
@@ -207,8 +213,8 @@ import org.json.JSONObject;
     private volatile HttpService mHttpService;
 
     protected RemoteService getPoster() {
+        String serverHost = extractHostFromUrl(mConfig.getEventsEndpoint());
         if (mHttpService == null) {
-            String serverHost = extractHostFromUrl(mConfig.getEventsEndpoint());
             mHttpService =
                     new HttpService(
                             mConfig.shouldGzipRequestPayload(),
@@ -216,7 +222,9 @@ import org.json.JSONObject;
                             mConfig.getBackupHost(),
                             serverHost);
         } else {
-            // Update backup host and listener in case they changed at runtime
+            // Re-sync mutable settings in case setServerURL/setBackupHost/etc. was called
+            // after the poster was first created.
+            mHttpService.setServerHost(serverHost);
             mHttpService.setBackupHost(mConfig.getBackupHost());
             mHttpService.setNetworkErrorListener(mNetworkErrorListener);
         }
@@ -860,7 +868,6 @@ import org.json.JSONObject;
 
     // Used across thread boundaries
     private final Worker mWorker;
-    private final String mInstanceName;
     protected final Context mContext;
     protected final MPConfig mConfig;
     protected MixpanelNetworkErrorListener mNetworkErrorListener;

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MPConfig.java
@@ -349,6 +349,16 @@ public class MPConfig {
         return mInstanceName;
     }
 
+    /**
+     * Resolves the key used to identify a Mixpanel instance in the SDK's internal instance
+     * tables (AnalyticsMessages, MixpanelAPI, preferences file names, etc.). Instances are keyed
+     * by {@code instanceName} when set, falling back to the project {@code token}. Keep this the
+     * single source of truth — a mismatch causes multi-instance setups to silently share state.
+     */
+    /* package */ static String resolveInstanceKey(String instanceName, String token) {
+        return instanceName != null ? instanceName : token;
+    }
+
     public boolean getDisableAppOpenEvent() {
         return mDisableAppOpenEvent;
     }

--- a/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
+++ b/analytics/src/main/java/com/mixpanel/android/mpmetrics/MixpanelAPI.java
@@ -618,7 +618,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
             if (null == sReferrerPrefs) {
                 sReferrerPrefs = sPrefsLoader.loadPreferences(context, MPConfig.REFERRER_PREFS_NAME, null);
             }
-            String instanceKey = options.getInstanceName() != null ? options.getInstanceName() : token;
+            String instanceKey = MPConfig.resolveInstanceKey(options.getInstanceName(), token);
             Map<Context, MixpanelAPI> instances = sInstanceMap.get(instanceKey);
             if (null == instances) {
                 instances = new HashMap<Context, MixpanelAPI>();
@@ -766,7 +766,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
      * @param listener
      */
     public void setNetworkErrorListener(MixpanelNetworkErrorListener listener) {
-        AnalyticsMessages.getInstance(mContext, mConfig).setNetworkErrorListener(listener);
+        AnalyticsMessages.getInstance(mContext, mConfig, mToken).setNetworkErrorListener(listener);
     }
 
     public Boolean getTrackAutomaticEvents() {
@@ -2372,7 +2372,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
     // non-test client code.
 
     /* package */ AnalyticsMessages getAnalyticsMessages() {
-        return AnalyticsMessages.getInstance(mContext, mConfig);
+        return AnalyticsMessages.getInstance(mContext, mConfig, mToken);
     }
 
     /* package */ PersistentIdentity getPersistentIdentity(
@@ -2405,7 +2405,7 @@ public class MixpanelAPI implements FeatureFlagDelegate {
                     }
                 };
 
-        String instanceKey = instanceName != null ? instanceName : token;
+        String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
         final Future<SharedPreferences> storedPreferences =
                 sPrefsLoader.loadPreferences(context, storedPrefsName(token, instanceName), listener);
 
@@ -2423,8 +2423,8 @@ public class MixpanelAPI implements FeatureFlagDelegate {
     }
 
     private static String storedPrefsName(String token, String instanceName) {
-        final String instanceKey = instanceName != null ? instanceName : token;
-        return "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
+        return "com.mixpanel.android.mpmetrics.MixpanelAPI_"
+                + MPConfig.resolveInstanceKey(instanceName, token);
     }
 
     private static void warnIfStrippingLibProperties(Set<String> excludeProperties) {

--- a/analytics/src/main/java/com/mixpanel/android/util/HttpService.java
+++ b/analytics/src/main/java/com/mixpanel/android/util/HttpService.java
@@ -60,7 +60,7 @@ public class HttpService implements RemoteService {
         this.shouldGzipRequestPayload = shouldGzipRequestPayload;
         this.networkErrorListener = networkErrorListener;
         this.mBackupHost = backupHost;
-        this.mServerHost = TextUtils.isEmpty(serverHost) ? DEFAULT_SERVER_HOST : serverHost;
+        setServerHost(serverHost);
     }
 
     public HttpService(
@@ -74,6 +74,14 @@ public class HttpService implements RemoteService {
 
     public void setBackupHost(String backupHost) {
         this.mBackupHost = backupHost;
+    }
+
+    public void setServerHost(String serverHost) {
+        this.mServerHost = TextUtils.isEmpty(serverHost) ? DEFAULT_SERVER_HOST : serverHost;
+    }
+
+    public String getServerHost() {
+        return mServerHost;
     }
 
     public void setNetworkErrorListener(MixpanelNetworkErrorListener networkErrorListener) {

--- a/analytics/src/sharedTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
+++ b/analytics/src/sharedTest/java/com/mixpanel/android/mpmetrics/TestUtils.java
@@ -42,7 +42,7 @@ public class TestUtils {
 
         @Override
             /* package */ PersistentIdentity getPersistentIdentity(final Context context, final Future<SharedPreferences> referrerPreferences, final String token, final String instanceName, final DeviceIdProvider deviceIdProvider) {
-            String instanceKey = instanceName != null ? instanceName : token;
+            String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
             final String prefsName = "com.mixpanel.android.mpmetrics.MixpanelAPI_" + instanceKey;
             final SharedPreferences ret = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
             ret.edit().clear().commit();

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelBasicTest.java
@@ -53,7 +53,8 @@ public class MixpanelBasicTest {
     AnalyticsMessages messages =
         AnalyticsMessages.getInstance(
             ApplicationProvider.getApplicationContext(),
-            MPConfig.getInstance(ApplicationProvider.getApplicationContext(), null));
+            MPConfig.getInstance(ApplicationProvider.getApplicationContext(), null),
+            null);
     messages.hardKill();
     Thread.sleep(2000);
   } // end of setUp() method definition
@@ -1119,7 +1120,7 @@ public class MixpanelBasicTest {
           final String token,
           final String instanceName,
           final DeviceIdProvider deviceIdProvider) {
-        String instanceKey = instanceName != null ? instanceName : token;
+        String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
         final String mixpanelPrefsName = "com.mixpanel.android.mpmetrics.Mixpanel";
         final SharedPreferences mpSharedPrefs =
             context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);
@@ -1554,7 +1555,7 @@ public class MixpanelBasicTest {
           final String token,
           final String instanceName,
           final DeviceIdProvider deviceIdProvider) {
-        String instanceKey = instanceName != null ? instanceName : token;
+        String instanceKey = MPConfig.resolveInstanceKey(instanceName, token);
         final String mixpanelPrefsName = "com.mixpanel.android.mpmetrics.Mixpanel";
         final SharedPreferences mpSharedPrefs =
             context.getSharedPreferences(mixpanelPrefsName, Context.MODE_PRIVATE);

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelDeviceIdProviderTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/MixpanelDeviceIdProviderTest.java
@@ -39,7 +39,7 @@ public class MixpanelDeviceIdProviderTest {
 
         // Kill any existing AnalyticsMessages to ensure clean state
         AnalyticsMessages messages = AnalyticsMessages.getInstance(
-                mContext, MPConfig.getInstance(mContext, null));
+                mContext, MPConfig.getInstance(mContext, null), null);
         messages.hardKill();
         Thread.sleep(500);
     }
@@ -48,7 +48,7 @@ public class MixpanelDeviceIdProviderTest {
     public void tearDown() throws Exception {
         // Clean up any singleton instances
         AnalyticsMessages messages = AnalyticsMessages.getInstance(
-                mContext, MPConfig.getInstance(mContext, null));
+                mContext, MPConfig.getInstance(mContext, null), null);
         messages.hardKill();
         Thread.sleep(200);
     }

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/MultiInstanceIsolationTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/MultiInstanceIsolationTest.java
@@ -1,0 +1,82 @@
+package com.mixpanel.android.mpmetrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import androidx.test.core.app.ApplicationProvider;
+import com.mixpanel.android.util.HttpService;
+import com.mixpanel.android.util.RemoteService;
+import java.util.concurrent.Future;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Regression coverage for the multi-token/no-instanceName isolation bug where two MixpanelAPI
+ * instances configured with different tokens (and no explicit {@code instanceName}) would share
+ * a single AnalyticsMessages worker and HttpService, causing events for the second instance to be
+ * POSTed to the first instance's server URL.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MultiInstanceIsolationTest {
+
+    private static final String EU_URL = "https://api-eu.mixpanel.com";
+    private static final String US_URL = "https://api.mixpanel.com";
+
+    private Context mContext;
+    private Future<SharedPreferences> mPrefs;
+
+    @Before
+    public void setUp() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mPrefs = new TestUtils.EmptyPreferences(mContext);
+    }
+
+    @Test
+    public void differentTokensGetIndependentWorkersAndPosters() {
+        MixpanelOptions euOptions = new MixpanelOptions.Builder().serverURL(EU_URL).build();
+        MixpanelOptions usOptions = new MixpanelOptions.Builder().serverURL(US_URL).build();
+
+        MixpanelAPI euApi = new TestUtils.CleanMixpanelAPI(mContext, mPrefs, "eu_token", euOptions);
+        MixpanelAPI usApi = new TestUtils.CleanMixpanelAPI(mContext, mPrefs, "us_token", usOptions);
+
+        AnalyticsMessages euMessages = euApi.getAnalyticsMessages();
+        AnalyticsMessages usMessages = usApi.getAnalyticsMessages();
+
+        assertNotSame(
+                "AnalyticsMessages must not be shared across tokens when no instanceName is set",
+                euMessages,
+                usMessages);
+
+        assertTrue(euMessages.mConfig.getEventsEndpoint().startsWith(EU_URL));
+        assertTrue(usMessages.mConfig.getEventsEndpoint().startsWith(US_URL));
+
+        RemoteService euPoster = euMessages.getPoster();
+        RemoteService usPoster = usMessages.getPoster();
+
+        assertNotSame("Each worker must own its own HttpService", euPoster, usPoster);
+        assertEquals("api-eu.mixpanel.com", ((HttpService) euPoster).getServerHost());
+        assertEquals("api.mixpanel.com", ((HttpService) usPoster).getServerHost());
+    }
+
+    @Test
+    public void setServerURLRefreshesPosterServerHost() {
+        MixpanelAPI api = new TestUtils.CleanMixpanelAPI(mContext, mPrefs, "single_token");
+        AnalyticsMessages messages = api.getAnalyticsMessages();
+
+        HttpService initial = (HttpService) messages.getPoster();
+        String initialHost = initial.getServerHost();
+
+        api.setServerURL(EU_URL);
+        HttpService after = (HttpService) messages.getPoster();
+
+        assertEquals("Poster instance should be reused, not recreated", initial, after);
+        assertNotSame(
+                "serverHost must reflect the updated endpoint", initialHost, after.getServerHost());
+        assertEquals("api-eu.mixpanel.com", after.getServerHost());
+    }
+}

--- a/analytics/src/test/java/com/mixpanel/android/mpmetrics/MultiInstanceIsolationTest.java
+++ b/analytics/src/test/java/com/mixpanel/android/mpmetrics/MultiInstanceIsolationTest.java
@@ -2,6 +2,7 @@ package com.mixpanel.android.mpmetrics;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -74,7 +75,7 @@ public class MultiInstanceIsolationTest {
         api.setServerURL(EU_URL);
         HttpService after = (HttpService) messages.getPoster();
 
-        assertEquals("Poster instance should be reused, not recreated", initial, after);
+        assertSame("Poster instance should be reused, not recreated", initial, after);
         assertNotSame(
                 "serverHost must reflect the updated endpoint", initialHost, after.getServerHost());
         assertEquals("api-eu.mixpanel.com", after.getServerHost());


### PR DESCRIPTION
## Summary

Two `MixpanelAPI` instances configured with different tokens and no explicit `instanceName` silently shared a single `AnalyticsMessages` worker (and therefore its `MPConfig` and `HttpService`), so events for the second instance were POSTed to the first instance's server URL. Independently, runtime `setServerURL` calls updated `MPConfig` endpoints but never refreshed the `HttpService` `serverHost` captured at construction.

## Changes

- `AnalyticsMessages.getInstance` now takes a `token` and keys `sInstances` by `MPConfig.resolveInstanceKey(instanceName, token)`, mirroring `MixpanelAPI.getInstance` and matching iOS `MixpanelManager` behavior.
- `AnalyticsMessages.getPoster` re-syncs `serverHost` (in addition to `backupHost` and the error listener) on every call, so `setServerURL` propagates to the poster.
- Added `HttpService.setServerHost` / `getServerHost`; the constructor delegates to `setServerHost` so the empty-check + `DEFAULT_SERVER_HOST` fallback lives in one place.
- Extracted the `instanceName ?? token` fallback into `MPConfig.resolveInstanceKey` — the five prior inline copies (plus three in tests) now call it, avoiding future drift.
- Removed the dead `mInstanceName` field on `AnalyticsMessages`.

## Workaround

Users on older SDK versions can side-step both bugs by giving each `MixpanelOptions` a distinct `instanceName` and setting the server URL via `MixpanelOptions.serverURL(...)` (which is applied before the first `getPoster()` call, so `HttpService` is constructed with the right host on first creation).
