### PR TITLE
fix(openfeature): wire MixpanelProvider.shutdown() to release flags

### DIFF
--- a/openfeature-provider/build.gradle.kts
+++ b/openfeature-provider/build.gradle.kts
@@ -43,7 +43,7 @@ java {
 
 dependencies {
     // official release
-    implementation("com.mixpanel.android:mixpanel-android:8.5.0")
+    implementation("com.mixpanel.android:mixpanel-android:8.9.0")
     // or use below for local testing
     // implementation(project(":analytics"))
 

--- a/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
+++ b/openfeature-provider/src/main/java/com/mixpanel/android/openfeature/MixpanelProvider.kt
@@ -71,7 +71,15 @@ class MixpanelProvider(private val flags: MixpanelAPI.Flags) : FeatureProvider {
     }
 
     override fun shutdown() {
-        // No-op: the Mixpanel SDK manages its own lifecycle.
+        // Only release the flags worker when this provider created the
+        // MixpanelAPI itself (via the convenience constructor). When flags
+        // were injected via MixpanelProvider(mixpanel.getFlags()), the
+        // caller owns the MixpanelAPI lifecycle — shutting down its
+        // flags HandlerThread here would silently break every subsequent
+        // flag evaluation on the shared instance.
+        if (mixpanel != null) {
+            flags.shutdown()
+        }
     }
 
     override fun getBooleanEvaluation(

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -12,6 +12,8 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.any
 import org.mockito.Mockito.eq
@@ -323,9 +325,13 @@ class MixpanelProviderTest {
     }
 
     @Test
-    fun `shutdown is a no-op`() {
-        // Should not throw
+    fun `shutdown does not tear down injected flags`() {
+        // provider was constructed via MixpanelProvider(mockFlags), i.e. the
+        // caller owns the MixpanelAPI lifecycle. Shutting down flags here
+        // would silently break every subsequent flag evaluation on the
+        // shared MixpanelAPI instance.
         provider.shutdown()
+        verify(mockFlags, never()).shutdown()
     }
 
     @Test

--- a/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
+++ b/openfeature-provider/src/test/java/com/mixpanel/android/openfeature/MixpanelProviderTest.kt
@@ -335,6 +335,21 @@ class MixpanelProviderTest {
     }
 
     @Test
+    fun `shutdown tears down flags when this provider owns the MixpanelAPI`() {
+        // Simulate having been constructed via the convenience constructor
+        // (which sets `mixpanel` to the internally-created MixpanelAPI).
+        // The convenience constructor itself requires a real Android Context
+        // and would create a live MixpanelAPI singleton, so we bypass it
+        // with reflection — the branch under test only reads `mixpanel != null`.
+        val mixpanelField = MixpanelProvider::class.java.getDeclaredField("mixpanel")
+        mixpanelField.isAccessible = true
+        mixpanelField.set(provider, mock(MixpanelAPI::class.java))
+
+        provider.shutdown()
+        verify(mockFlags).shutdown()
+    }
+
+    @Test
     fun `hooks list is empty`() {
         assertEquals(emptyList<Any>(), provider.hooks)
     }


### PR DESCRIPTION
## Status: READY — prerequisites satisfied

Both blockers from the original PR description are now resolved:

1. ✅ #984 merged to `master` (2026-07-06).
2. ✅ `mixpanel-android:8.9.0` released to Maven Central (2026-07-06 20:09 UTC) — contains `MixpanelAPI.Flags.shutdown()`.

Local run against 8.9.0: `./gradlew :openfeature-provider:testDebugUnitTest` → 41/41 passed.

## Summary

Once `MixpanelAPI.Flags.shutdown()` is available, the OpenFeature provider's `shutdown()` hook can actually release the flags worker `HandlerThread` + network executor. Prior to this, the hook was a no-op with a comment claiming "the Mixpanel SDK manages its own lifecycle" — misleading, since `MixpanelAPI` had no `shutdown()` and `flags` didn't either.

Behavior is scoped to the convenience-constructor path (where this provider owns the `MixpanelAPI` instance). When flags were injected via `MixpanelProvider(mixpanel.getFlags())`, the caller owns the `MixpanelAPI` lifecycle — shutting down its worker thread here would silently break every subsequent flag evaluation on the shared instance.

## Test plan
- [x] Unit tests updated: `shutdown does not tear down injected flags` verifies `verify(mockFlags, never()).shutdown()`
- [x] Local run against 8.9.0: 41/41 pass
- [ ] Verify against an integration test that constructs via the convenience constructor and asserts the worker thread is released after `shutdown()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)