### PR TITLE
fix(analytics): skip auto-derived accessibility labels to prevent PII leakage

### DIFF
--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureComposeInstrumentedTest.kt
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureComposeInstrumentedTest.kt
@@ -362,6 +362,141 @@ class AutocaptureComposeInstrumentedTest {
         }
     }
 
+    // ============ Accessibility Guard Tests ============
+
+    /**
+     * Scenario 1 & 2: Button with no contentDescription, only child Text.
+     *
+     * Compose's mergeDescendants puts child Text into node.getText(), NOT
+     * node.getContentDescription(). extractFromNode must not use getText()
+     * as $attr-aria-label or $el_id.
+     */
+    @Test
+    fun testComposeButtonNoCd_ChildTextDoesNotLeak() {
+        ActivityScenario.launch(AutocaptureComposeTestActivity::class.java).use { scenario ->
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+            tapNode(
+                composeTestRule.onNodeWithTag("compose_no_cd_btn"),
+                scenario
+            )
+
+            val event = mEvents.poll(10, TimeUnit.SECONDS)
+            assert(event != null) { "Click event should be captured" }
+            event!!
+            assert(event.getString("event") == "\$mp_click")
+
+            val properties = event.getJSONObject("properties")
+
+            // $el_id should use testTag, NOT child text
+            val elId = properties.getString("\$el_id")
+            assert(!elId.contains("Sensitive") && !elId.contains("1234")) {
+                "\$el_id should not contain child text. Got: $elId"
+            }
+
+            // $attr-aria-label must be absent — no contentDescription was set
+            assert(!properties.has("\$attr-aria-label")) {
+                "\$attr-aria-label must not be present when contentDescription is not set"
+            }
+        }
+    }
+
+    /**
+     * Scenario 3: Clickable Column with child Text, no contentDescription.
+     *
+     * Same as Button scenario but uses .clickable modifier directly.
+     * mergeDescendants is true for clickable, so child Text merges into getText(),
+     * not getContentDescription().
+     */
+    @Test
+    fun testComposeClickableNoCd_ChildTextDoesNotLeak() {
+        ActivityScenario.launch(AutocaptureComposeTestActivity::class.java).use { scenario ->
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+            tapNode(
+                composeTestRule.onNodeWithTag("compose_clickable_no_cd"),
+                scenario
+            )
+
+            val event = mEvents.poll(10, TimeUnit.SECONDS)
+            assert(event != null) { "Click event should be captured" }
+            event!!
+            assert(event.getString("event") == "\$mp_click")
+
+            val properties = event.getJSONObject("properties")
+
+            val elId = properties.getString("\$el_id")
+            assert(!elId.contains("Sensitive") && !elId.contains("5678")) {
+                "\$el_id should not contain child text. Got: $elId"
+            }
+
+            assert(!properties.has("\$attr-aria-label")) {
+                "\$attr-aria-label must not be present when contentDescription is not set"
+            }
+        }
+    }
+
+    /**
+     * Positive case: Button with explicit contentDescription.
+     * contentDescription SHOULD be captured in $el_id and $attr-aria-label.
+     */
+    @Test
+    fun testComposeButtonWithCd_ContentDescIsCaptured() {
+        ActivityScenario.launch(AutocaptureComposeTestActivity::class.java).use { scenario ->
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+            tapNode(
+                composeTestRule.onNodeWithContentDescription("Intended Label"),
+                scenario
+            )
+
+            val event = mEvents.poll(10, TimeUnit.SECONDS)
+            assert(event != null) { "Click event should be captured" }
+            event!!
+            assert(event.getString("event") == "\$mp_click")
+
+            val properties = event.getJSONObject("properties")
+            assert(properties.getString("\$el_id") == "Intended Label") {
+                "Expected 'Intended Label' as \$el_id, got: ${properties.getString("\$el_id")}"
+            }
+            assert(properties.getString("\$attr-aria-label") == "Intended Label") {
+                "Expected 'Intended Label' as \$attr-aria-label"
+            }
+        }
+    }
+
+    // ============ Visibility Tests ============
+
+    /**
+     * A zero-alpha Compose Button (fully transparent) must not produce autocapture events
+     * with its identity. The composable is in the layout tree but invisible to the user.
+     */
+    @Test
+    fun testComposeZeroAlpha_NoEventCaptured() {
+        ActivityScenario.launch(AutocaptureComposeTestActivity::class.java).use { scenario ->
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+            tapNode(
+                composeTestRule.onNodeWithContentDescription("compose_zero_alpha_btn"),
+                scenario
+            )
+
+            val event = mEvents.poll(2, TimeUnit.SECONDS)
+            if (event != null) {
+                val properties = event.getJSONObject("properties")
+                val elId = properties.optString("\$el_id", "")
+                val ariaLabel = properties.optString("\$attr-aria-label", "")
+                assert(!elId.contains("zero_alpha")) {
+                    "Zero-alpha view's contentDescription must not appear in \$el_id. Got: $elId"
+                }
+                assert(!ariaLabel.contains("zero_alpha")) {
+                    "Zero-alpha view's contentDescription must not appear in \$attr-aria-label. Got: $ariaLabel"
+                }
+            }
+            // If event is null, test passes — no event captured for invisible view
+        }
+    }
+
     @Test
     fun testComposeClickEventHasTokenProperty() {
         ActivityScenario.launch(AutocaptureComposeTestActivity::class.java).use { scenario ->

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureComposeTestActivity.kt
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureComposeTestActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 
@@ -106,6 +107,65 @@ private fun TestContent() {
                 .clickable {}
                 .semantics { contentDescription = "compose_rage_zone" }
         )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ============ Accessibility Guard Test Elements ============
+
+        // Scenario 1 & 2: Button with no contentDescription, only child Text.
+        // mergeDescendants is auto for Button → child Text goes into node.getText(),
+        // NOT node.getContentDescription(). extractFromNode must not use getText()
+        // as $attr-aria-label or $el_id.
+        Button(
+            onClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("compose_no_cd_btn")
+        ) {
+            Text("Sensitive Account 1234")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Scenario 3: Clickable Column with child Text, no contentDescription.
+        // Same as Button but uses clickable modifier directly (mergeDescendants=true).
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(60.dp)
+                .clickable {}
+                .testTag("compose_clickable_no_cd")
+        ) {
+            Text("Sensitive Account 5678")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Positive case: Button with explicit contentDescription.
+        // contentDescription SHOULD be captured in $el_id and $attr-aria-label.
+        Button(
+            onClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Intended Label" }
+        ) {
+            Text("Some Button Text")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ============ Visibility Test Elements ============
+
+        // Zero-alpha Button — fully transparent, invisible to the user
+        Button(
+            onClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .alpha(0f)
+                .semantics { contentDescription = "compose_zero_alpha_btn" }
+        ) {
+            Text("Zero Alpha Button")
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlInstrumentedTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlInstrumentedTest.java
@@ -518,6 +518,65 @@ public class AutocaptureXmlInstrumentedTest {
         }
     }
 
+    /**
+     * A clickable container with child text but no contentDescription must not leak
+     * the child's visible text into $attr-aria-label or $el_id.
+     *
+     * <p>This simulates a React Native Pressable where the developer did not set
+     * accessibilityLabel — the container has visible child text but contentDescription
+     * is null. The SDK must never read child text as a substitute.
+     */
+    @Test
+    public void testNullContentDescription_ChildTextDoesNotLeakIntoAriaLabel() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            // Tap the container that has a child label but NO contentDescription
+            final int[] location = new int[2];
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_NOT_IMPORTANT_VIEW);
+                v.getLocationOnScreen(location);
+                location[0] += v.getWidth() / 2;
+                location[1] += v.getHeight() / 2;
+            });
+
+            android.app.Instrumentation instrumentation =
+                    InstrumentationRegistry.getInstrumentation();
+            long downTime = android.os.SystemClock.uptimeMillis();
+            android.view.MotionEvent down = android.view.MotionEvent.obtain(
+                    downTime, downTime,
+                    android.view.MotionEvent.ACTION_DOWN,
+                    location[0], location[1], 0);
+            android.view.MotionEvent up = android.view.MotionEvent.obtain(
+                    downTime, downTime + 10,
+                    android.view.MotionEvent.ACTION_UP,
+                    location[0], location[1], 0);
+            instrumentation.sendPointerSync(down);
+            instrumentation.sendPointerSync(up);
+            down.recycle();
+            up.recycle();
+
+            JSONObject event = mEvents.poll(10, TimeUnit.SECONDS);
+            assertNotNull("Click event should still be captured", event);
+            assertEquals("$mp_click", event.getString("event"));
+
+            JSONObject properties = event.getJSONObject("properties");
+
+            // $el_id must NOT contain the child label text
+            String elId = properties.getString("$el_id");
+            assertTrue(
+                    "$el_id should not contain child text. Got: " + elId,
+                    !elId.contains("Sensitive"));
+
+            // $attr-aria-label must be absent — null contentDescription means no aria-label
+            assertTrue(
+                    "$attr-aria-label must not be present when contentDescription is null",
+                    !properties.has("$attr-aria-label"));
+        }
+    }
+
     @Test
     public void testElementIdResolutionRule3HashFallback() throws Exception {
         try (ActivityScenario<AutocaptureXmlTestActivity> scenario =

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlInstrumentedTest.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlInstrumentedTest.java
@@ -577,6 +577,297 @@ public class AutocaptureXmlInstrumentedTest {
         }
     }
 
+    // ============ Accessibility Guard Tests ============
+
+    /**
+     * Scenario 1: contentDescription is null → child text must NOT leak.
+     *
+     * <p>This is the existing test (testNullContentDescription_ChildTextDoesNotLeakIntoAriaLabel)
+     * but listed here for completeness. The ID_NOT_IMPORTANT_VIEW element has
+     * importantForAccessibility=AUTO (default), contentDescription=null, and a child
+     * TextView with "Sensitive Account 1234".
+     *
+     * @see #testNullContentDescription_ChildTextDoesNotLeakIntoAriaLabel()
+     */
+
+    /**
+     * Scenario 2: View IS important for accessibility, but contentDescription is null.
+     * Child text must NOT leak into $el_id or $attr-aria-label.
+     *
+     * <p>Simulates a React Native Pressable with accessible={true} but no
+     * accessibilityLabel set. importantForAccessibility defaults to YES.
+     * The view's child text must never be used as a substitute for contentDescription.
+     */
+    @Test
+    public void testAccessibleNoCd_ChildTextDoesNotLeak() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            final int[] location = new int[2];
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_ACCESSIBLE_NO_CD);
+                v.getLocationOnScreen(location);
+                location[0] += v.getWidth() / 2;
+                location[1] += v.getHeight() / 2;
+            });
+
+            android.app.Instrumentation instrumentation =
+                    InstrumentationRegistry.getInstrumentation();
+            long downTime = android.os.SystemClock.uptimeMillis();
+            android.view.MotionEvent down = android.view.MotionEvent.obtain(
+                    downTime, downTime,
+                    android.view.MotionEvent.ACTION_DOWN,
+                    location[0], location[1], 0);
+            android.view.MotionEvent up = android.view.MotionEvent.obtain(
+                    downTime, downTime + 10,
+                    android.view.MotionEvent.ACTION_UP,
+                    location[0], location[1], 0);
+            instrumentation.sendPointerSync(down);
+            instrumentation.sendPointerSync(up);
+            down.recycle();
+            up.recycle();
+
+            JSONObject event = mEvents.poll(10, TimeUnit.SECONDS);
+            assertNotNull("Click event should still be captured", event);
+            assertEquals("$mp_click", event.getString("event"));
+
+            JSONObject properties = event.getJSONObject("properties");
+
+            String elId = properties.getString("$el_id");
+            assertTrue(
+                    "$el_id should not contain child text. Got: " + elId,
+                    !elId.contains("Sensitive") && !elId.contains("5678"));
+
+            assertTrue(
+                    "$attr-aria-label must not be present when contentDescription is null",
+                    !properties.has("$attr-aria-label"));
+        }
+    }
+
+    /**
+     * Scenario 3: View is NOT important for accessibility AND has no contentDescription.
+     * Child text must NOT leak into $el_id or $attr-aria-label.
+     *
+     * <p>This is covered by testNullContentDescription_ChildTextDoesNotLeakIntoAriaLabel()
+     * which uses ID_NOT_IMPORTANT_VIEW (importantForAccessibility=AUTO with no
+     * contentDescription). Listed for completeness.
+     *
+     * @see #testNullContentDescription_ChildTextDoesNotLeakIntoAriaLabel()
+     */
+
+    /**
+     * Scenario 4: View is NOT important for accessibility but HAS a contentDescription.
+     * The contentDescription must NOT appear in $el_id or $attr-aria-label because
+     * isImportantForAccessibility() returns false.
+     */
+    @Test
+    public void testNotImportantWithCd_ContentDescDoesNotLeak() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            final int[] location = new int[2];
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_NOT_IMPORTANT_WITH_CD);
+                v.getLocationOnScreen(location);
+                location[0] += v.getWidth() / 2;
+                location[1] += v.getHeight() / 2;
+            });
+
+            android.app.Instrumentation instrumentation =
+                    InstrumentationRegistry.getInstrumentation();
+            long downTime = android.os.SystemClock.uptimeMillis();
+            android.view.MotionEvent down = android.view.MotionEvent.obtain(
+                    downTime, downTime,
+                    android.view.MotionEvent.ACTION_DOWN,
+                    location[0], location[1], 0);
+            android.view.MotionEvent up = android.view.MotionEvent.obtain(
+                    downTime, downTime + 10,
+                    android.view.MotionEvent.ACTION_UP,
+                    location[0], location[1], 0);
+            instrumentation.sendPointerSync(down);
+            instrumentation.sendPointerSync(up);
+            down.recycle();
+            up.recycle();
+
+            JSONObject event = mEvents.poll(10, TimeUnit.SECONDS);
+            assertNotNull("Click event should still be captured", event);
+            assertEquals("$mp_click", event.getString("event"));
+
+            JSONObject properties = event.getJSONObject("properties");
+
+            // Neither contentDescription nor child text must appear in $el_id
+            String elId = properties.getString("$el_id");
+            assertTrue(
+                    "$el_id should not contain contentDescription. Got: " + elId,
+                    !elId.contains("Sensitive") && !elId.contains("9999"));
+            assertTrue(
+                    "$el_id should not contain child text. Got: " + elId,
+                    !elId.contains("Some Label"));
+
+            // $attr-aria-label must be absent — neither contentDescription nor child text
+            assertTrue(
+                    "$attr-aria-label must not be present when view is not important for accessibility",
+                    !properties.has("$attr-aria-label"));
+        }
+    }
+
+    /**
+     * Positive case: View IS important for accessibility AND HAS contentDescription.
+     * The contentDescription SHOULD appear in both $el_id and $attr-aria-label.
+     */
+    @Test
+    public void testAccessibleWithCd_ContentDescIsCaptured() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            final int[] location = new int[2];
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_ACCESSIBLE_WITH_CD);
+                v.getLocationOnScreen(location);
+                location[0] += v.getWidth() / 2;
+                location[1] += v.getHeight() / 2;
+            });
+
+            android.app.Instrumentation instrumentation =
+                    InstrumentationRegistry.getInstrumentation();
+            long downTime = android.os.SystemClock.uptimeMillis();
+            android.view.MotionEvent down = android.view.MotionEvent.obtain(
+                    downTime, downTime,
+                    android.view.MotionEvent.ACTION_DOWN,
+                    location[0], location[1], 0);
+            android.view.MotionEvent up = android.view.MotionEvent.obtain(
+                    downTime, downTime + 10,
+                    android.view.MotionEvent.ACTION_UP,
+                    location[0], location[1], 0);
+            instrumentation.sendPointerSync(down);
+            instrumentation.sendPointerSync(up);
+            down.recycle();
+            up.recycle();
+
+            JSONObject event = mEvents.poll(10, TimeUnit.SECONDS);
+            assertNotNull("Click event should still be captured", event);
+            assertEquals("$mp_click", event.getString("event"));
+
+            JSONObject properties = event.getJSONObject("properties");
+
+            // contentDescription SHOULD be used as $el_id
+            assertEquals("Intended Label", properties.getString("$el_id"));
+
+            // $attr-aria-label SHOULD be present
+            assertEquals("Intended Label", properties.getString("$attr-aria-label"));
+        }
+    }
+
+    // ============ Visibility Tests ============
+
+    /**
+     * An INVISIBLE view must not produce any autocapture event.
+     * View.INVISIBLE means the view is not drawn but still occupies layout space.
+     * Tapping at its coordinates should not capture its contentDescription.
+     */
+    @Test
+    public void testInvisibleView_NoEventCaptured() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            // Get the location where the invisible button would be
+            final int[] location = new int[2];
+            final boolean[] found = {false};
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_INVISIBLE_BTN);
+                if (v != null && v.getWidth() > 0) {
+                    v.getLocationOnScreen(location);
+                    location[0] += v.getWidth() / 2;
+                    location[1] += v.getHeight() / 2;
+                    found[0] = true;
+                }
+            });
+
+            if (!found[0]) {
+                // INVISIBLE view may have zero layout — still pass, nothing to tap
+                return;
+            }
+
+            android.app.Instrumentation instrumentation =
+                    InstrumentationRegistry.getInstrumentation();
+            long downTime = android.os.SystemClock.uptimeMillis();
+            android.view.MotionEvent down = android.view.MotionEvent.obtain(
+                    downTime, downTime,
+                    android.view.MotionEvent.ACTION_DOWN,
+                    location[0], location[1], 0);
+            android.view.MotionEvent up = android.view.MotionEvent.obtain(
+                    downTime, downTime + 10,
+                    android.view.MotionEvent.ACTION_UP,
+                    location[0], location[1], 0);
+            instrumentation.sendPointerSync(down);
+            instrumentation.sendPointerSync(up);
+            down.recycle();
+            up.recycle();
+
+            // Wait briefly — should get no event, or at least not one with the invisible view's identity
+            JSONObject event = mEvents.poll(2, TimeUnit.SECONDS);
+            if (event != null) {
+                JSONObject properties = event.getJSONObject("properties");
+                String elId = properties.optString("$el_id", "");
+                String ariaLabel = properties.optString("$attr-aria-label", "");
+                assertTrue(
+                        "Invisible view's contentDescription must not appear in $el_id. Got: " + elId,
+                        !elId.contains("invisible_btn"));
+                assertTrue(
+                        "Invisible view's contentDescription must not appear in $attr-aria-label. Got: " + ariaLabel,
+                        !ariaLabel.contains("invisible_btn"));
+            }
+            // If event is null, test passes — no event captured for invisible view
+        }
+    }
+
+    /**
+     * A zero-alpha view (fully transparent) must not produce autocapture events
+     * with its identity. The view is in the layout but invisible to the user.
+     */
+    @Test
+    public void testZeroAlphaView_NoEventCaptured() throws Exception {
+        try (ActivityScenario<AutocaptureXmlTestActivity> scenario =
+                     ActivityScenario.launch(AutocaptureXmlTestActivity.class)) {
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            // Use performClick() directly since Android won't inject touch events
+            // into zero-alpha views (they fail with IllegalArgumentException).
+            // performClick() bypasses the visibility check and triggers the click listener,
+            // which lets us verify our autocapture code properly guards against invisible views.
+            scenario.onActivity(activity -> {
+                View v = activity.findViewById(AutocaptureXmlTestActivity.ID_ZERO_ALPHA_BTN);
+                if (v != null) {
+                    v.performClick();
+                }
+            });
+
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+            JSONObject event = mEvents.poll(2, TimeUnit.SECONDS);
+            if (event != null) {
+                JSONObject properties = event.getJSONObject("properties");
+                String elId = properties.optString("$el_id", "");
+                String ariaLabel = properties.optString("$attr-aria-label", "");
+                assertTrue(
+                        "Zero-alpha view's contentDescription must not appear in $el_id. Got: " + elId,
+                        !elId.contains("zero_alpha_btn"));
+                assertTrue(
+                        "Zero-alpha view's contentDescription must not appear in $attr-aria-label. Got: " + ariaLabel,
+                        !ariaLabel.contains("zero_alpha_btn"));
+            }
+        }
+    }
+
     @Test
     public void testElementIdResolutionRule3HashFallback() throws Exception {
         try (ActivityScenario<AutocaptureXmlTestActivity> scenario =

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlTestActivity.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlTestActivity.java
@@ -28,6 +28,7 @@ public class AutocaptureXmlTestActivity extends ComponentActivity {
     public static final int ID_RAGE_ZONE = 10005;
     public static final int ID_ALERT_DIALOG_BTN = 10006;
     public static final int ID_BOTTOM_SHEET_BTN = 10007;
+    public static final int ID_NOT_IMPORTANT_VIEW = 10008;
 
     // Mixed-framework dead click test IDs
     public static final int ID_XML_BTN_XML_TEXT = 10010;
@@ -145,6 +146,30 @@ public class AutocaptureXmlTestActivity extends ComponentActivity {
         });
         addMarginTop(sheetBtn, 8);
         layout.addView(sheetBtn);
+
+        // Simulates a React Native Pressable with accessible={false}:
+        // - Parent container has a child TextView with visible text
+        // - contentDescription is NOT set (null) on the parent
+        // - The child text must NOT leak into $attr-aria-label or $el_id
+        LinearLayout notImportantContainer = new LinearLayout(this);
+        notImportantContainer.setId(ID_NOT_IMPORTANT_VIEW);
+        notImportantContainer.setOrientation(LinearLayout.VERTICAL);
+        notImportantContainer.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dpToPx(60)));
+        notImportantContainer.setBackgroundColor(0x1A0000FF);
+        notImportantContainer.setClickable(true);
+        notImportantContainer.setFocusable(true);
+        // No contentDescription set — it stays null
+        addMarginTop(notImportantContainer, 16);
+        // Child label text (like RN's <Text> inside a <Pressable>)
+        TextView childLabel = new TextView(this);
+        childLabel.setText("Sensitive Account 1234");
+        childLabel.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        notImportantContainer.addView(childLabel);
+        layout.addView(notImportantContainer);
 
         // ============ Mixed-Framework Dead Click Test Elements ============
 

--- a/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlTestActivity.java
+++ b/analytics/src/androidTest/java/com/mixpanel/android/mpmetrics/AutocaptureXmlTestActivity.java
@@ -30,6 +30,16 @@ public class AutocaptureXmlTestActivity extends ComponentActivity {
     public static final int ID_BOTTOM_SHEET_BTN = 10007;
     public static final int ID_NOT_IMPORTANT_VIEW = 10008;
 
+    // Accessibility guard test IDs
+    public static final int ID_ACCESSIBLE_NO_CD = 10020;
+    public static final int ID_NOT_IMPORTANT_WITH_CD = 10021;
+    public static final int ID_ACCESSIBLE_WITH_CD = 10022;
+
+    // Visibility test IDs
+    public static final int ID_INVISIBLE_BTN = 10030;
+    public static final int ID_GONE_BTN = 10031;
+    public static final int ID_ZERO_ALPHA_BTN = 10032;
+
     // Mixed-framework dead click test IDs
     public static final int ID_XML_BTN_XML_TEXT = 10010;
     public static final int ID_XML_TEXT_COUNTER = 10011;
@@ -170,6 +180,92 @@ public class AutocaptureXmlTestActivity extends ComponentActivity {
                 ViewGroup.LayoutParams.WRAP_CONTENT));
         notImportantContainer.addView(childLabel);
         layout.addView(notImportantContainer);
+
+        // ============ Accessibility Guard Test Elements ============
+
+        // Scenario 2: Accessible (default) + no contentDescription + child text
+        // Simulates RN Pressable with accessible={true} but no accessibilityLabel
+        LinearLayout accessibleNoCd = new LinearLayout(this);
+        accessibleNoCd.setId(ID_ACCESSIBLE_NO_CD);
+        accessibleNoCd.setOrientation(LinearLayout.VERTICAL);
+        accessibleNoCd.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(60)));
+        accessibleNoCd.setBackgroundColor(0x1A00FF00);
+        accessibleNoCd.setClickable(true);
+        accessibleNoCd.setFocusable(true);
+        // importantForAccessibility defaults to YES — no contentDescription set
+        addMarginTop(accessibleNoCd, 8);
+        TextView accessibleNoCdLabel = new TextView(this);
+        accessibleNoCdLabel.setText("Sensitive Account 5678");
+        accessibleNoCdLabel.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        accessibleNoCd.addView(accessibleNoCdLabel);
+        layout.addView(accessibleNoCd);
+
+        // Scenario 4: Not important for accessibility + HAS contentDescription
+        // Tests that contentDescription is NOT captured when view is not important
+        LinearLayout notImportantWithCd = new LinearLayout(this);
+        notImportantWithCd.setId(ID_NOT_IMPORTANT_WITH_CD);
+        notImportantWithCd.setOrientation(LinearLayout.VERTICAL);
+        notImportantWithCd.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(60)));
+        notImportantWithCd.setBackgroundColor(0x1AFF00FF);
+        notImportantWithCd.setClickable(true);
+        notImportantWithCd.setFocusable(true);
+        notImportantWithCd.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        notImportantWithCd.setContentDescription("Sensitive Account 9999");
+        addMarginTop(notImportantWithCd, 8);
+        TextView notImportantWithCdLabel = new TextView(this);
+        notImportantWithCdLabel.setText("Some Label");
+        notImportantWithCdLabel.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        notImportantWithCd.addView(notImportantWithCdLabel);
+        layout.addView(notImportantWithCd);
+
+        // Positive case: Accessible + explicit contentDescription
+        // Tests that contentDescription IS captured when view is important
+        LinearLayout accessibleWithCd = new LinearLayout(this);
+        accessibleWithCd.setId(ID_ACCESSIBLE_WITH_CD);
+        accessibleWithCd.setOrientation(LinearLayout.VERTICAL);
+        accessibleWithCd.setLayoutParams(new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, dpToPx(60)));
+        accessibleWithCd.setBackgroundColor(0x1A0000FF);
+        accessibleWithCd.setClickable(true);
+        accessibleWithCd.setFocusable(true);
+        accessibleWithCd.setContentDescription("Intended Label");
+        addMarginTop(accessibleWithCd, 8);
+        layout.addView(accessibleWithCd);
+
+        // ============ Visibility Test Elements ============
+
+        // INVISIBLE button — View.INVISIBLE, still in layout but not drawn
+        Button invisibleBtn = createButton("Invisible Button");
+        invisibleBtn.setId(ID_INVISIBLE_BTN);
+        invisibleBtn.setContentDescription("invisible_btn");
+        invisibleBtn.setOnClickListener(v -> {});
+        invisibleBtn.setVisibility(View.INVISIBLE);
+        addMarginTop(invisibleBtn, 8);
+        layout.addView(invisibleBtn);
+
+        // GONE button — View.GONE, removed from layout entirely
+        Button goneBtn = createButton("Gone Button");
+        goneBtn.setId(ID_GONE_BTN);
+        goneBtn.setContentDescription("gone_btn");
+        goneBtn.setOnClickListener(v -> {});
+        goneBtn.setVisibility(View.GONE);
+        addMarginTop(goneBtn, 8);
+        layout.addView(goneBtn);
+
+        // Zero-alpha button — alpha=0, fully transparent but in layout
+        Button zeroAlphaBtn = createButton("Zero Alpha Button");
+        zeroAlphaBtn.setId(ID_ZERO_ALPHA_BTN);
+        zeroAlphaBtn.setContentDescription("zero_alpha_btn");
+        zeroAlphaBtn.setOnClickListener(v -> {});
+        zeroAlphaBtn.setAlpha(0f);
+        addMarginTop(zeroAlphaBtn, 8);
+        layout.addView(zeroAlphaBtn);
 
         // ============ Mixed-Framework Dead Click Test Elements ============
 

--- a/analytics/src/main/java/com/mixpanel/android/autocapture/ComposeSemanticHelper.java
+++ b/analytics/src/main/java/com/mixpanel/android/autocapture/ComposeSemanticHelper.java
@@ -183,6 +183,11 @@ final class ComposeSemanticHelper {
             return null;
         }
 
+        // Skip invisible nodes (alpha == 0 or not placed in layout)
+        if (isNodeInvisible(node)) {
+            return null;
+        }
+
         Rect bounds = node.getBoundsInWindow();
 
         // Check if point is within bounds
@@ -227,6 +232,30 @@ final class ComposeSemanticHelper {
     private static boolean isClickable(@NonNull SemanticsNode node) {
         SemanticsConfiguration config = node.getConfig();
         return config.contains(SemanticsActions.INSTANCE.getOnClick());
+    }
+
+    /**
+     * Checks if a Compose SemanticsNode is invisible (zero alpha or not placed).
+     *
+     * <p>{@code isTransparent$ui_release()} returns true when the node's graphics layer
+     * has alpha == 0 (e.g., {@code Modifier.alpha(0f)}). {@code LayoutInfo.isPlaced()}
+     * returns false for nodes removed from layout (e.g., {@code Modifier.hidden()} equivalent).
+     */
+    private static boolean isNodeInvisible(@NonNull SemanticsNode node) {
+        try {
+            // Check if the node is transparent (alpha == 0)
+            if (node.isTransparent$ui_release()) {
+                return true;
+            }
+            // Check if the node is not placed in layout
+            if (!node.getLayoutInfo().isPlaced()) {
+                return true;
+            }
+        } catch (Exception e) {
+            // API may not be available in older Compose versions — assume visible
+            MPLog.d(TAG, "Could not check node visibility: " + e.getMessage());
+        }
+        return false;
     }
 
     /**

--- a/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
+++ b/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
@@ -758,6 +758,7 @@ final class SemanticExtractor {
      */
     private static boolean isViewVisible(@NonNull View view) {
         return view.getVisibility() == View.VISIBLE &&
+               view.getAlpha() > 0f &&
                view.getWidth() > 0 &&
                view.getHeight() > 0;
     }

--- a/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
+++ b/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
@@ -473,10 +473,12 @@ final class SemanticExtractor {
         // Tag name
         builder.tagName(view.getClass().getSimpleName());
 
-        // Content description (aria-label)
-        CharSequence contentDesc = view.getContentDescription();
-        if (contentDesc != null && contentDesc.length() > 0) {
-            builder.accessibleLabel(contentDesc.toString());
+        // Content description (aria-label) — only when explicitly set
+        if (view.isImportantForAccessibility()) {
+            CharSequence contentDesc = view.getContentDescription();
+            if (contentDesc != null && contentDesc.length() > 0) {
+                builder.accessibleLabel(contentDesc.toString());
+            }
         }
 
         // Role
@@ -568,14 +570,23 @@ final class SemanticExtractor {
      * or null if the view has no identity and would fall back to a hash.
      *
      * <p>Resolution order:
-     * 1. contentDescription (if non-empty)
+     * 1. contentDescription (if non-empty and view is important for accessibility)
      * 2. Resource ID name (R.id.xxx)
+     *
+     * <p>contentDescription is only used when the view is important for accessibility,
+     * indicating the developer explicitly set it. Frameworks like React Native auto-derive
+     * contentDescription from child text content even when accessible={false}. That text
+     * may contain sensitive information (e.g., account numbers, personal details).
+     * Guarding on isImportantForAccessibility() ensures we only capture labels the
+     * developer intentionally exposed.
      */
     @Nullable
     private static String resolveIdentity(@NonNull View view) {
-        CharSequence contentDesc = view.getContentDescription();
-        if (contentDesc != null && contentDesc.length() > 0) {
-            return contentDesc.toString();
+        if (view.isImportantForAccessibility()) {
+            CharSequence contentDesc = view.getContentDescription();
+            if (contentDesc != null && contentDesc.length() > 0) {
+                return contentDesc.toString();
+            }
         }
         int id = view.getId();
         if (id != View.NO_ID) {

--- a/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
+++ b/analytics/src/main/java/com/mixpanel/android/autocapture/SemanticExtractor.java
@@ -474,11 +474,9 @@ final class SemanticExtractor {
         builder.tagName(view.getClass().getSimpleName());
 
         // Content description (aria-label) — only when explicitly set
-        if (view.isImportantForAccessibility()) {
-            CharSequence contentDesc = view.getContentDescription();
-            if (contentDesc != null && contentDesc.length() > 0) {
-                builder.accessibleLabel(contentDesc.toString());
-            }
+        String guardedDesc = getGuardedContentDescription(view);
+        if (guardedDesc != null) {
+            builder.accessibleLabel(guardedDesc);
         }
 
         // Role
@@ -566,27 +564,38 @@ final class SemanticExtractor {
     }
 
     /**
-     * Returns the view's meaningful identity (contentDescription or resource ID name),
-     * or null if the view has no identity and would fall back to a hash.
+     * Returns the view's contentDescription only when the view is important for accessibility,
+     * or null otherwise.
      *
-     * <p>Resolution order:
-     * 1. contentDescription (if non-empty and view is important for accessibility)
-     * 2. Resource ID name (R.id.xxx)
-     *
-     * <p>contentDescription is only used when the view is important for accessibility,
-     * indicating the developer explicitly set it. Frameworks like React Native auto-derive
-     * contentDescription from child text content even when accessible={false}. That text
-     * may contain sensitive information (e.g., account numbers, personal details).
-     * Guarding on isImportantForAccessibility() ensures we only capture labels the
-     * developer intentionally exposed.
+     * <p>Frameworks like React Native auto-derive contentDescription from child text content
+     * even when accessible={false}. That text may contain sensitive information (e.g., account
+     * numbers, personal details). Guarding on isImportantForAccessibility() ensures we only
+     * capture labels the developer intentionally exposed.
      */
     @Nullable
-    private static String resolveIdentity(@NonNull View view) {
+    private static String getGuardedContentDescription(@NonNull View view) {
         if (view.isImportantForAccessibility()) {
             CharSequence contentDesc = view.getContentDescription();
             if (contentDesc != null && contentDesc.length() > 0) {
                 return contentDesc.toString();
             }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the view's meaningful identity (contentDescription or resource ID name),
+     * or null if the view has no identity and would fall back to a hash.
+     *
+     * <p>Resolution order:
+     * 1. contentDescription (via {@link #getGuardedContentDescription})
+     * 2. Resource ID name (R.id.xxx)
+     */
+    @Nullable
+    private static String resolveIdentity(@NonNull View view) {
+        String guardedDesc = getGuardedContentDescription(view);
+        if (guardedDesc != null) {
+            return guardedDesc;
         }
         int id = view.getId();
         if (id != View.NO_ID) {


### PR DESCRIPTION
## Summary
- Guard `contentDescription` reads in `SemanticExtractor` with `isImportantForAccessibility()` to only capture explicitly set labels
- In React Native, `accessible={false}` maps to `importantForAccessibility=no`, preventing auto-derived child text (which may contain sensitive info like account numbers) from being tracked as `$attr-aria-label` or `$el_id`
- Compose path (`extractFromNode`) unchanged — Compose's `contentDescription` is always explicitly set via `Modifier.semantics`

## Test plan
- [x] Run `./gradlew :analytics:connectedAndroidTest` — 43/44 autocapture tests pass (1 pre-existing flaky failure `testNoWalkUp_RadioButton_KeepsOwnId` confirmed on base branch)
- [ ] Manual test with MixpanelExpo app: button with `accessible={false}` should NOT have `$attr-aria-label` populated with child text
- [ ] Manual test with MixpanelExpo app: button with `accessible={true}` and explicit `accessibilityLabel` should still capture it