### PR TITLE
feat(session-replay): send app bundle_id and build_number as settings API query params

### DIFF
--- a/session-replay/sessionreplaydemo/build.gradle.kts
+++ b/session-replay/sessionreplaydemo/build.gradle.kts
@@ -30,7 +30,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.mixpanel.sessionreplaydemo1"
+        applicationId = "com.mixpanel.sessionreplaydemo"
         minSdk = 21
         targetSdk = 34
         versionCode = 22

--- a/session-replay/sessionreplaydemo/build.gradle.kts
+++ b/session-replay/sessionreplaydemo/build.gradle.kts
@@ -30,11 +30,11 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.mixpanel.sessionreplaydemo"
+        applicationId = "com.mixpanel.sessionreplaydemo1"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 22
+        versionName = "1.0.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/session-replay/src/main/java/com/mixpanel/android/sessionreplay/services/RemoteSettingsService.kt
+++ b/session-replay/src/main/java/com/mixpanel/android/sessionreplay/services/RemoteSettingsService.kt
@@ -73,8 +73,8 @@ internal open class RemoteSettingsService(
 
         // Include app bundle ID and build number to enable server-side SDK blocking
         // per app ID and app build version. Either is omitted if unavailable.
-        bundleId?.let { queryItems.add("bundleId" to it) }
-        buildNumber?.let { queryItems.add("buildNumber" to it) }
+        bundleId?.let { queryItems.add("bundle_id" to it) }
+        buildNumber?.let { queryItems.add("build_number" to it) }
         if (bundleId == null || buildNumber == null) {
             Logger.warn("Incomplete app info for settings request: bundleId=$bundleId, buildNumber=$buildNumber")
         }

--- a/session-replay/src/main/java/com/mixpanel/android/sessionreplay/services/RemoteSettingsService.kt
+++ b/session-replay/src/main/java/com/mixpanel/android/sessionreplay/services/RemoteSettingsService.kt
@@ -10,6 +10,7 @@ import com.mixpanel.android.sessionreplay.network.Network
 import com.mixpanel.android.sessionreplay.network.RequestMethod
 import com.mixpanel.android.sessionreplay.network.SdkConfig
 import com.mixpanel.android.sessionreplay.network.SettingsResponse
+import com.mixpanel.android.sessionreplay.utils.DeviceInfo
 import com.mixpanel.android.sessionreplay.utils.EndPoints
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -28,7 +29,9 @@ internal open class RemoteSettingsService(
     private val network: Network = Network(),
     private val version: String,
     private val mpLib: String,
-    private val serverUrl: String = EndPoints.DEFAULT_BASE_URL
+    private val serverUrl: String = EndPoints.DEFAULT_BASE_URL,
+    bundleIdOverride: String? = null,
+    buildNumberOverride: String? = null
 ) {
     companion object {
         private const val SETTINGS_TIMEOUT_MS = 5000L
@@ -39,6 +42,9 @@ internal open class RemoteSettingsService(
     private val prefs: SharedPreferences by lazy {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
+
+    private val bundleId: String? by lazy { bundleIdOverride ?: DeviceInfo.bundleId(context) }
+    private val buildNumber: String? by lazy { buildNumberOverride ?: DeviceInfo.buildNumber(context) }
 
     private fun recordingEnabledKey(token: String) = "mp_sr_recording_${token}_enabled"
     private fun recordingTimestampKey(token: String) = "mp_sr_recording_${token}_timestamp"
@@ -57,17 +63,27 @@ internal open class RemoteSettingsService(
     private suspend fun performRemoteSettingsFetch(token: String): RemoteSettingsResult {
         Logger.info("Checking settings for project")
 
+        val queryItems = mutableListOf(
+            "recording" to "1",
+            "sdk_config" to "1",
+            "\$os" to "Android",
+            "mp_lib" to mpLib,
+            "\$lib_version" to version
+        )
+
+        // Include app bundle ID and build number to enable server-side SDK blocking
+        // per app ID and app build version. Either is omitted if unavailable.
+        bundleId?.let { queryItems.add("bundleId" to it) }
+        buildNumber?.let { queryItems.add("buildNumber" to it) }
+        if (bundleId == null || buildNumber == null) {
+            Logger.warn("Incomplete app info for settings request: bundleId=$bundleId, buildNumber=$buildNumber")
+        }
+
         val apiRequest = APIRequest(
             endPoint = EndPoints.settings(serverUrl),
             method = RequestMethod.GET,
             requestBody = null,
-            queryItems = listOf(
-                "recording" to "1",
-                "sdk_config" to "1",
-                "\$os" to "Android",
-                "mp_lib" to mpLib,
-                "\$lib_version" to version
-            ),
+            queryItems = queryItems,
             headers = mapOf(
                 "Authorization" to "Basic ${Base64.encodeToString("$token:".toByteArray(), Base64.NO_WRAP)}"
             ),

--- a/session-replay/src/main/java/com/mixpanel/android/sessionreplay/utils/DeviceInfo.kt
+++ b/session-replay/src/main/java/com/mixpanel/android/sessionreplay/utils/DeviceInfo.kt
@@ -1,5 +1,6 @@
 package com.mixpanel.android.sessionreplay.utils
 
+import android.content.Context
 import android.content.res.Resources
 import android.os.Build
 
@@ -62,4 +63,29 @@ object DeviceInfo {
             } catch (e: Exception) {
                 "Unknown" // Default value in case of error
             }
+
+    // Host app bundle/package identifier.
+    // Requires a Context — Android has no global equivalent of iOS's Bundle.main.
+    // Returns null rather than a sentinel so callers can omit the value entirely.
+    fun bundleId(context: Context): String? =
+        try {
+            context.packageName
+        } catch (e: Exception) {
+            null // Caller omits the value when unavailable
+        }
+
+    // Host app build number: versionCode, or longVersionCode on API 28+.
+    // This is the Android analog of iOS CFBundleVersion, not versionName.
+    fun buildNumber(context: Context): String? =
+        try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                packageInfo.longVersionCode.toString()
+            } else {
+                @Suppress("DEPRECATION")
+                packageInfo.versionCode.toString()
+            }
+        } catch (e: Exception) {
+            null // Caller omits the value when unavailable
+        }
 }

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/DeviceInfoTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/DeviceInfoTest.kt
@@ -1,0 +1,74 @@
+package com.mixpanel.android.sessionreplay
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.mixpanel.android.sessionreplay.utils.DeviceInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class DeviceInfoTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockPackageManager: PackageManager
+
+    private val testPackageName = "com.mixpanel.test.app"
+    private val testVersionCode = 42
+
+    @Before
+    fun setUp() {
+        mockContext = mockk()
+        mockPackageManager = mockk()
+
+        every { mockContext.packageName } returns testPackageName
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo(testPackageName, 0) } returns PackageInfo().apply {
+            @Suppress("DEPRECATION")
+            versionCode = testVersionCode
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testBundleIdReturnsPackageName() {
+        assertEquals(testPackageName, DeviceInfo.bundleId(mockContext))
+    }
+
+    @Test
+    fun testBuildNumberReturnsVersionCode() {
+        // JVM unit tests report SDK_INT as 0, so this exercises the pre-API-28 branch
+        assertEquals(testVersionCode.toString(), DeviceInfo.buildNumber(mockContext))
+    }
+
+    @Test
+    fun testBundleIdReturnsNullWhenContextThrows() {
+        every { mockContext.packageName } throws IllegalStateException("no package name")
+
+        assertNull(DeviceInfo.bundleId(mockContext))
+    }
+
+    @Test
+    fun testBuildNumberReturnsNullWhenPackageNotFound() {
+        every {
+            mockPackageManager.getPackageInfo(testPackageName, 0)
+        } throws PackageManager.NameNotFoundException()
+
+        assertNull(DeviceInfo.buildNumber(mockContext))
+    }
+
+    @Test
+    fun testBuildNumberReturnsNullWhenPackageManagerUnavailable() {
+        every { mockContext.packageManager } throws IllegalStateException("no package manager")
+
+        assertNull(DeviceInfo.buildNumber(mockContext))
+    }
+}

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsServiceTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsServiceTest.kt
@@ -2,6 +2,8 @@ package com.mixpanel.android.sessionreplay
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.util.Base64
 import com.mixpanel.android.sessionreplay.network.APIRequest
 import com.mixpanel.android.sessionreplay.network.Network
@@ -23,6 +25,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -32,11 +36,14 @@ class RemoteSettingsServiceTest {
     private lateinit var mockNetwork: Network
     private lateinit var mockSharedPreferences: SharedPreferences
     private lateinit var mockEditor: SharedPreferences.Editor
+    private lateinit var mockPackageManager: PackageManager
 
     private lateinit var remoteSettingsService: RemoteSettingsService
     private val testToken = "testToken123"
     private val version = APIConstants.currentLibVersion
     private val mpLib = APIConstants.currentMpLib
+    private val testPackageName = "com.mixpanel.test.app"
+    private val testVersionCode = 42
 
     @Before
     fun setUp() {
@@ -44,6 +51,7 @@ class RemoteSettingsServiceTest {
         mockNetwork = mockk()
         mockSharedPreferences = mockk()
         mockEditor = mockk()
+        mockPackageManager = mockk()
 
         mockkStatic(Base64::class)
         every { Base64.encodeToString(any(), any()) } returns "dGVzdFRva2VuMTIzOg=="
@@ -55,6 +63,13 @@ class RemoteSettingsServiceTest {
         every { mockEditor.putString(any(), any()) } returns mockEditor
         every { mockEditor.remove(any()) } returns mockEditor
         every { mockEditor.apply() } just Runs
+
+        every { mockContext.packageName } returns testPackageName
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo(testPackageName, 0) } returns PackageInfo().apply {
+            @Suppress("DEPRECATION")
+            versionCode = testVersionCode
+        }
 
         remoteSettingsService = RemoteSettingsService(mockContext, mockNetwork, version, mpLib)
     }
@@ -154,7 +169,9 @@ class RemoteSettingsServiceTest {
                 "sdk_config" to "1",
                 "\$os" to "Android",
                 "mp_lib" to mpLib,
-                "\$lib_version" to version
+                "\$lib_version" to version,
+                "bundleId" to testPackageName,
+                "buildNumber" to testVersionCode.toString()
             ),
             headers = mapOf("Authorization" to "Basic dGVzdFRva2VuMTIzOg=="),
             timeout = 5000L
@@ -312,6 +329,70 @@ class RemoteSettingsServiceTest {
                 isFromCache = false
             ),
             result
+        )
+    }
+
+    // --- Bundle ID / Build Number Query Param Tests ---
+
+    @Test
+    fun testSettingsRequestIncludesBundleIdAndBuildNumber() = runTest {
+        val responseJson = """{"recording": {"is_enabled": true}}"""
+        val capturedRequest = slot<APIRequest>()
+        coEvery { mockNetwork.performAPIRequestWithResponse(capture(capturedRequest)) } returns Result.success(responseJson)
+
+        val serviceWithOverrides = RemoteSettingsService(
+            mockContext,
+            mockNetwork,
+            version,
+            mpLib,
+            bundleIdOverride = "com.test.app",
+            buildNumberOverride = "1234"
+        )
+
+        serviceWithOverrides.fetchRemoteSettings(testToken)
+
+        val queryItems = capturedRequest.captured.queryItems
+        assertTrue(queryItems!!.contains("bundleId" to "com.test.app"))
+        assertTrue(queryItems.contains("buildNumber" to "1234"))
+
+        // Pre-existing params must be unaffected
+        assertTrue(queryItems.contains("recording" to "1"))
+        assertTrue(queryItems.contains("sdk_config" to "1"))
+        assertTrue(queryItems.contains("\$os" to "Android"))
+        assertTrue(queryItems.contains("mp_lib" to mpLib))
+        assertTrue(queryItems.contains("\$lib_version" to version))
+    }
+
+    @Test
+    fun testSettingsRequestOmitsBundleIdAndBuildNumberWhenUnavailable() = runTest {
+        val responseJson = """{"recording": {"is_enabled": true}}"""
+        val capturedRequest = slot<APIRequest>()
+        coEvery { mockNetwork.performAPIRequestWithResponse(capture(capturedRequest)) } returns Result.success(responseJson)
+
+        // Context that cannot supply app metadata
+        val brokenContext = mockk<Context>()
+        every { brokenContext.getSharedPreferences(any(), any()) } returns mockSharedPreferences
+        every { brokenContext.packageName } throws IllegalStateException("no package name")
+        every { brokenContext.packageManager } throws IllegalStateException("no package manager")
+
+        val serviceWithBrokenContext = RemoteSettingsService(brokenContext, mockNetwork, version, mpLib)
+
+        serviceWithBrokenContext.fetchRemoteSettings(testToken)
+
+        val queryItems = capturedRequest.captured.queryItems
+        assertFalse(queryItems!!.any { it.first == "bundleId" })
+        assertFalse(queryItems.any { it.first == "buildNumber" })
+
+        // Pre-existing params must still be sent
+        assertEquals(
+            listOf(
+                "recording" to "1",
+                "sdk_config" to "1",
+                "\$os" to "Android",
+                "mp_lib" to mpLib,
+                "\$lib_version" to version
+            ),
+            queryItems
         )
     }
 }

--- a/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsServiceTest.kt
+++ b/session-replay/src/test/java/com/mixpanel/android/sessionreplay/RemoteSettingsServiceTest.kt
@@ -170,8 +170,8 @@ class RemoteSettingsServiceTest {
                 "\$os" to "Android",
                 "mp_lib" to mpLib,
                 "\$lib_version" to version,
-                "bundleId" to testPackageName,
-                "buildNumber" to testVersionCode.toString()
+                "bundle_id" to testPackageName,
+                "build_number" to testVersionCode.toString()
             ),
             headers = mapOf("Authorization" to "Basic dGVzdFRva2VuMTIzOg=="),
             timeout = 5000L
@@ -352,8 +352,8 @@ class RemoteSettingsServiceTest {
         serviceWithOverrides.fetchRemoteSettings(testToken)
 
         val queryItems = capturedRequest.captured.queryItems
-        assertTrue(queryItems!!.contains("bundleId" to "com.test.app"))
-        assertTrue(queryItems.contains("buildNumber" to "1234"))
+        assertTrue(queryItems!!.contains("bundle_id" to "com.test.app"))
+        assertTrue(queryItems.contains("build_number" to "1234"))
 
         // Pre-existing params must be unaffected
         assertTrue(queryItems.contains("recording" to "1"))
@@ -380,8 +380,8 @@ class RemoteSettingsServiceTest {
         serviceWithBrokenContext.fetchRemoteSettings(testToken)
 
         val queryItems = capturedRequest.captured.queryItems
-        assertFalse(queryItems!!.any { it.first == "bundleId" })
-        assertFalse(queryItems.any { it.first == "buildNumber" })
+        assertFalse(queryItems!!.any { it.first == "bundle_id" })
+        assertFalse(queryItems.any { it.first == "build_number" })
 
         // Pre-existing params must still be sent
         assertEquals(


### PR DESCRIPTION
This pull request enhances the Session Replay SDK's remote settings logic by including the host app's bundle ID and build number in settings requests, enabling server-side SDK blocking per app and build version. It also introduces robust handling for missing app metadata and adds comprehensive unit tests for the new logic.

**Remote Settings Request Enhancements:**

* The `RemoteSettingsService` now includes the app's bundle ID and build number as query parameters in settings requests, using new helper methods in `DeviceInfo`. These values are omitted if unavailable, and a warning is logged in that case. [[1]](diffhunk://#diff-80f1346c166996f725a08f803653e79b35acc0567e8a301fd3d23f9243981a44L31-R34) [[2]](diffhunk://#diff-80f1346c166996f725a08f803653e79b35acc0567e8a301fd3d23f9243981a44R46-R48) [[3]](diffhunk://#diff-80f1346c166996f725a08f803653e79b35acc0567e8a301fd3d23f9243981a44L60-R86)

* Optional overrides for bundle ID and build number can be passed to `RemoteSettingsService`, allowing for custom or test values.

**Device Info Utilities:**

* The `DeviceInfo` utility adds `bundleId(context)` and `buildNumber(context)` methods to retrieve the app's package name and build number, with safe error handling to return `null` if unavailable.

**Testing Improvements:**

* New unit tests in `DeviceInfoTest` cover normal and error cases for bundle ID and build number retrieval.

* The `RemoteSettingsServiceTest` is extended to verify that settings requests include or omit bundle ID and build number as appropriate, and that existing parameters remain unaffected. [[1]](diffhunk://#diff-0c33ce2ac5667d61b8c5099672108a57a784c69e71506e6861d0143032228c77L157-R174) [[2]](diffhunk://#diff-0c33ce2ac5667d61b8c5099672108a57a784c69e71506e6861d0143032228c77R334-R397)

**Versioning:**

* The demo app's `versionCode` and `versionName` are updated to reflect a new release.## Summary

Android counterpart to the iOS change. Sends the host app's package name and build
number as query parameters on the `/settings` request, so the backend can extend
server-side SDK blocking to work **per app ID and per app build version**.

## What changed

- `DeviceInfo` gains `bundleId(context)` and `buildNumber(context)`, mirroring where
  iOS puts them. They take a `Context` because `DeviceInfo` is a stateless object and
  Android has no global equivalent of iOS's `Bundle.main`.
  - `bundleId` → `context.packageName`
  - `buildNumber` → `PackageInfo.longVersionCode` on API 28+, `versionCode` below
    (minSdk is 21). This is the analog of iOS `CFBundleVersion` — deliberately
    `versionCode`, not `versionName`.
  - Both return `null` on failure rather than the `0` / `"Unknown"` sentinels its
    siblings use, because omitting the param is better than sending a fake value.
- `RemoteSettingsService` appends each param only when non-nil, and gains optional
  trailing `bundleIdOverride` / `buildNumberOverride` constructor params for testing.
  Being optional and trailing, every existing call site compiles unchanged — including
  the `remoteSettingsServiceFactory` lambda in `MPSessionReplay`.

### API URL
```
2026-09-02 20:05:36.442  4272-4297  MixpanelSessionReplay   com.mixpanel.sessionreplaydemo       D  [Mixpanel Session Replay - Network.kt - func executeAPIRequest-0E7RQCE] (DEBUG) - https://api.mixpanel.com/settings?recording=1&sdk_config=1&%24os=Android&mp_lib=android-sr&%24lib_version=1.4.0&bundle_id=com.mixpanel.sessionreplaydemo&build_number=22

```

### Note on `BuildConfig.VERSION_CODE`

Not usable here. `session-replay` is a `com.android.library` module whose `BuildConfig`
has one hand-declared field (`VERSION_NAME`); AGP does not generate `VERSION_CODE` for
library modules, so it would not compile. Even if declared it would carry the *SDK's*
version — duplicating the existing `$lib_version` param — rather than the host app's
build, so it could not support blocking per app build version.

## Test plan

`./gradlew :session-replay:testDebugUnitTest :session-replay:ktlintCheck`

- **169 tests, 0 failures** (was 164), ktlint clean
- New `DeviceInfoTest` (5 tests): package name returned, versionCode returned, and null
  on each failure mode — `packageName` throwing, `NameNotFoundException`, and
  `packageManager` throwing
- New `RemoteSettingsServiceTest` cases: params present when injected, both absent when
  the context can't supply them
- Updated `testCheckSettingsIncludesSdkConfigQueryParam`, which asserts the whole
  ordered `queryItems` list

**Known gap:** the API-28+ `longVersionCode` branch isn't covered — JVM unit tests
report `Build.VERSION.SDK_INT` as `0`, so tests exercise the deprecated `versionCode`
path only. A Robolectric test with `@Config(sdk = [28])` would close it.

Fixes SDK-153