### PR TITLE
release: prepare analytics 8.11.0 and session-replay 1.5.0

### DIFF
--- a/analytics/CHANGELOG.md
+++ b/analytics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v8.11.0](https://github.com/mixpanel/mixpanel-android/tree/v8.11.0) (2026-09-09)
+
+### Features
+- Implement semver and date custom operators for flags runtime events ([#995](https://github.com/mixpanel/mixpanel-android/pull/995))
+
+[Full Changelog](https://github.com/mixpanel/mixpanel-android/compare/v8.10.0...v8.11.0)
+
 ## [v8.10.0](https://github.com/mixpanel/mixpanel-android/tree/v8.10.0) (2026-09-01)
 
 ### Features

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -4,7 +4,7 @@
 
 # Latest Version
 
-##### _September 01, 2026_ - [v8.10.0](https://github.com/mixpanel/mixpanel-android/releases/tag/v8.10.0)
+##### _September 09, 2026_ - [v8.11.0](https://github.com/mixpanel/mixpanel-android/releases/tag/v8.11.0)
 
 # Table of Contents
 

--- a/analytics/gradle.properties
+++ b/analytics/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.10.0
+VERSION_NAME=8.11.0
 
 POM_PACKAGING=aar
 GROUP=com.mixpanel.android

--- a/session-replay/CHANGELOG.md
+++ b/session-replay/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [session-replay-v1.5.0](https://github.com/mixpanel/mixpanel-android/tree/session-replay-v1.5.0) (2026-09-09)
+
+### Features
+- wireframes (beta) ([#1003](https://github.com/mixpanel/mixpanel-android/pull/1003))
+- add getSessionReplayUrl API to return replay link for active session ([#964](https://github.com/mixpanel/mixpanel-android/pull/964))
+
+### Fixes
+- derive the replay meta viewport from the captured frame ([#1002](https://github.com/mixpanel/mixpanel-android/pull/1002))
+- respect remoteSettingsMode for event triggers ([#979](https://github.com/mixpanel/mixpanel-android/pull/979))
+
+[Full Changelog](https://github.com/mixpanel/mixpanel-android/compare/session-replay-v1.4.0...session-replay-v1.5.0)
+
 ## [session-replay-v1.4.0](https://github.com/mixpanel/mixpanel-android/tree/session-replay-v1.4.0) (2026-05-11)
 
 ### Features

--- a/session-replay/gradle.properties
+++ b/session-replay/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.0
+VERSION_NAME=1.5.0
 
 POM_PACKAGING=aar
 GROUP=com.mixpanel.android


### PR DESCRIPTION
## Summary
- Prepares analytics 8.11.0 for release
- Prepares session-replay 1.5.0 for release
- Consolidates the work from #1010 and #1011 into one release PR

## Changes
- Bumps `analytics` to `8.11.0` and updates its changelog and README
- Bumps `session-replay` to `1.5.0` and updates its changelog

## After merging
1. Run the publish workflow for analytics to publish `v8.11.0`
2. Run the publish workflow for session-replay to publish `session-replay-v1.5.0`

## Validation
- Combined both original commits cleanly on current `master`
- Full Gradle validation skipped per request